### PR TITLE
Rewrite README and add cross-platform npm packaging

### DIFF
--- a/.github/workflows/package-npm.yml
+++ b/.github/workflows/package-npm.yml
@@ -1,0 +1,134 @@
+name: Package and publish npm
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      publish:
+        description: Publish npm/package.json version to npm with the beta tag
+        required: true
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          package-manager-cache: false
+      - run: rustup update stable
+      - run: rustup default stable
+      - run: cargo test --locked
+      - run: node --test scripts/package-native.test.mjs
+
+  native:
+    name: Build ${{ matrix.name }}
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: darwin-arm64
+            runner: macos-15
+            rust-target: aarch64-apple-darwin
+            platform: darwin
+            arch: arm64
+            binary: target/aarch64-apple-darwin/release/dsh-tui
+          - name: darwin-x64
+            runner: macos-15-intel
+            rust-target: x86_64-apple-darwin
+            platform: darwin
+            arch: x64
+            binary: target/x86_64-apple-darwin/release/dsh-tui
+          - name: linux-x64
+            runner: ubuntu-24.04
+            rust-target: x86_64-unknown-linux-gnu
+            platform: linux
+            arch: x64
+            binary: target/x86_64-unknown-linux-gnu/release/dsh-tui
+          - name: win32-x64
+            runner: windows-2025
+            rust-target: x86_64-pc-windows-msvc
+            platform: win32
+            arch: x64
+            binary: target/x86_64-pc-windows-msvc/release/dsh-tui.exe
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          package-manager-cache: false
+      - run: rustup update stable
+      - run: rustup default stable
+      - run: rustup target add ${{ matrix.rust-target }}
+      - run: cargo build --release --locked --target ${{ matrix.rust-target }}
+      - name: Stage native binary
+        run: >-
+          node scripts/package-native.mjs stage
+          --source "${{ matrix.binary }}"
+          --platform "${{ matrix.platform }}"
+          --arch "${{ matrix.arch }}"
+          --vendor-root staged
+      - uses: actions/upload-artifact@v4
+        with:
+          name: native-${{ matrix.name }}
+          path: staged
+          if-no-files-found: error
+
+  package:
+    name: Assemble npm package
+    needs: [test, native]
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          package-manager-cache: false
+      - uses: actions/download-artifact@v5
+        with:
+          pattern: native-*
+          path: npm/vendor
+          merge-multiple: true
+      - name: Restore executable permissions
+        run: chmod +x npm/vendor/darwin-arm64/dsh-tui npm/vendor/darwin-x64/dsh-tui npm/vendor/linux-x64/dsh-tui
+      - run: node scripts/package-native.mjs verify --vendor-root npm/vendor
+      - run: mkdir -p dist && npm pack ./npm --pack-destination dist
+      - uses: actions/upload-artifact@v4
+        with:
+          name: openma-deepseek-harness-tui-npm
+          path: dist/*.tgz
+          if-no-files-found: error
+          retention-days: 14
+
+  publish:
+    name: Publish npm
+    if: github.event_name == 'workflow_dispatch' && inputs.publish
+    needs: package
+    runs-on: ubuntu-24.04
+    environment: npm
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          registry-url: https://registry.npmjs.org
+          package-manager-cache: false
+      - run: npm install --global npm@^11.15.0
+      - uses: actions/download-artifact@v5
+        with:
+          name: openma-deepseek-harness-tui-npm
+          path: dist
+      - run: npm publish dist/*.tgz

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "deepseek-harness-tui"
 version = "0.1.0"
 edition = "2021"
-description = "DeepSeek Build (dsh-tui) — a grok-build style TUI speaking the deepseek-harness JSON-RPC stdio protocol"
+description = "Terminal-native agent UI for DeepSeek Harness over the SDK JSON-RPC stdio protocol"
 license = "MIT"
 
 [[bin]]

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 OpenMA contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.en.md
+++ b/README.en.md
@@ -1,149 +1,184 @@
-# dsh-tui — DEEPSEEK HARNESS, in the terminal
+# dsh-tui
 
-[中文](README.md) | English
+[中文](README.md) | [English](README.en.md)
 
-A [grok-build](https://github.com/xai-org/grok-build)-style terminal agent UI
-for [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness),
-written in Rust (ratatui). It speaks the harness **SDK JSON-RPC stdio
-protocol directly** — no Python SDK in the loop — and skins the whole thing
-in the exact DeepSeek Web UI palette, whale included.
+[![npm beta](https://img.shields.io/npm/v/%40openma%2Fdeepseek-harness-tui?tag=beta&label=npm%20beta)](https://www.npmjs.com/package/@openma/deepseek-harness-tui)
+[![Package and publish npm](https://github.com/openma-ai/deepseek-harness-tui/actions/workflows/package-npm.yml/badge.svg)](https://github.com/openma-ai/deepseek-harness-tui/actions/workflows/package-npm.yml)
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
-深度求索 · 探索未至之境 — *everything is a plugin.*
+A terminal-native agent UI for DeepSeek Harness. Follow streamed reasoning,
+tool calls, subagents, token usage, and durable sessions in one Rust/ratatui
+interface. Run it as an official `dsh` profile plugin or connect it directly to
+the SDK JSON-RPC runtime.
 
-![dsh-tui — the whale banner, DEEPSEEK HARNESS wordmark, Into the Unknown](assets/screenshots/banner.jpg)
+> **Beta** · The `0.0.4-beta` CI package targets macOS on Apple Silicon and
+> Intel, Linux x64, and Windows x64. The current integration baseline is
+> `dsh 0.1.0-rc.6`.
 
-The whale is rasterized by `scripts/gen_logo.py` from the actual favicon SVG
-shipped by the harness Web UI; the wordmark is figlet `ansi_shadow` tinted
-like the whale's belly, with a white-edged hollow `HARNESS` when the terminal
-is wide enough. Theme tokens in `src/theme.rs` are a 1:1 mapping of `--dsw-*`
-variables from the Web UI's `design-platform.css` (dark and light, `/theme`
-toggles).
+![A DeepSeek Harness session in dsh-tui](assets/screenshots/banner.jpg)
 
-## What it shows
+## Quick start
 
-Everything the Web UI surfaces for a session, live from the event stream:
-streamed reasoning (collapsible `✻ thought · 3.2s · 14 lines`), streamed
-assistant text, every tool call with arguments and results (`bash`,
-`str_replace_editor`, `read`, …), injected plugin context, subagent
-lifecycles, token usage incl. cache hits, turn end reasons, and runtime
-state.
+### Recommended: run as a dsh profile plugin
 
-## Interactions (grok-build homage)
-
-| Key | Behavior |
-|---|---|
-| `enter` | send · **queues a follow-up while a turn runs** (protocol-native inbox) |
-| `alt+enter` | send-now: interrupt the turn, run this next |
-| `esc` | interrupt (draft survives) · idle: `esc esc` clears the draft |
-| `ctrl+c` | clear draft first · interrupt · `ctrl+c ctrl+c` quits |
-| `↑` | prompt history (on an empty prompt) |
-| `!cmd` | run a local shell command (client-side, not the agent) |
-| `/` | slash menu with prefix filtering (`/help /new /model /mode /effort /permission /plan /theme /liang …`) |
-| `ctrl+m` | model picker (host catalog) → reasoning-effort picker |
-| `shift+tab` | cycle permission presets · `/permission` opens the picker |
-| `ctrl+e` | expand all thoughts/tool output · `ctrl+t` theme · `ctrl+l` clear |
-| `pgup/pgdn` `ctrl+u/d` | scroll · mouse wheel works · `end` follows the tail |
-| mouse drag | select in the chat pane — **release copies** (选中即复制) · double-click copies a word |
-
-Agent seams are real, not cosmetic: `/mode` picks the agent preset —
-standard · code · minimal · creator (the host `agentPresets` roster in
-plugin mode; composed on a session's first prompt), `/model` switches live
-in plugin mode, `/effort off|high|max` sets reasoning effort for the
-session, and `/plan` passes plan mode through to the host.
-
-<p align="center">
-  <img src="assets/screenshots/commands.jpg" width="536"
-       alt="slash menu on a narrow terminal — /liang highlighted, the pet listening" />
-</p>
-
-Clipboard delivery is grok-pager-style routed legs that never hard-fail the
-UI (`src/clipboard.rs`): native tool (`pbcopy` / `wl-copy` / `xclip` /
-`xsel`) → tmux paste buffer → OSC 52 to the controlling terminal, wrapped in
-a tmux passthrough envelope when needed — so copy works locally, in tmux,
-and over SSH.
-
-## The composer pet · `/liang` 🤫
-
-A pixel-art **梁文锋** — affectionately, **小难梁** — perches on the
-composer's right edge; `/liang` summons him. Two states, driven by the run
-state:
-
-| State | Sprite | Vibe |
-|---|---|---|
-| idle | 🤫 finger on lips | *quiet — he's thinking about AGI* |
-| working | ⌨︎ hammering a tiny terminal | *a turn is streaming — 亲自上手* |
-
-The meme, for the record: DeepSeek's famously low-profile founder — the
-legend goes he still reads every paper and writes code between GPU runs —
-so naturally he moonlights in your status corner, shushing the room while
-the model thinks and typing furiously the moment a turn starts. 小难梁:
-because 难 (hard problems) is the family business — AGI 很难，但他在加班.
-
-Mechanics: the frames are real pixels (`assets/pet/liang-*.png`, RGBA,
-transparent), placed with the **kitty graphics protocol** where the terminal
-speaks it (ghostty · kitty · WezTerm, sniffed from `$TERM` /
-`$TERM_PROGRAM`; one-shot transmit-and-display, re-sent on layout/state
-changes — `src/pet.rs`). Terminals without pixel graphics get the XS
-half-block whale from `logo_data.rs` instead, so the corner never goes
-empty. `/liang` toggles him (also `/liang on|off`); he steps out on his own
-below 60 columns.
-
-## Install & run
-
-The npm package is a Cordis bundle for the official `dsh` CLI — `dsh plugin`
-forwards to pnpm inside the profile directory. The profile is a
-single-package pnpm workspace (its root is the only member), so root-mutating
-commands take `-w`:
+Requires a configured `dsh` installation, Node.js 18+, and pnpm 10+.
 
 ```sh
-dsh plugin --profile tui add -w @openma/deepseek-harness-tui
+dsh plugin --profile tui add @openma/deepseek-harness-tui@beta
 dsh --profile tui
 ```
 
-`dsh --profile tui --dump-config` should now show the bundle mounted under
-the stable plugin id `tui-runner`. Building from source instead:
-`bash scripts/build-npm.sh` writes `dist/openma-deepseek-harness-tui-*.tgz`,
-which the same `add -w` command accepts as a local path.
+The install command does not need `-w`. Confirm that the bundle is mounted as
+`tui-runner` with:
 
-![a real plugin-mode turn — injected context, read calls, a queued follow-up](assets/screenshots/plugin-turn.jpg)
-
-`npm/lib/index.js` spawns the native binary on the host TTY and mounts the
-official `@deepseek-ai/dsh-sdk-jsonrpc-server` with its transport redirected
-over pipe fds 3/4 (`dsh-tui --attach-fds`), so the TUI speaks the identical
-protocol in both modes while agent, tools, providers, and persistence come
-from the dsh profile — the status line says `connected · dsh-tui-shim`, and
-credentials truthfully read `host dsh (credential seam)`. Wire-tested by
-`scripts/test-attach.mjs`. In plugin mode, mid-turn interrupt is not
-available (the host owns the turn).
-
-## Protocol
-
-NDJSON JSON-RPC 2.0 over stdio (`src/proto.rs`):
-requests `initialize` / `session/prompt` / `shutdown`; notifications
-`session.event` (persistence-catalog events: `assistant/chunk`, `tool/call`,
-`tool/result`, `turn/*`, `user/message`, …), `session.status`,
-`subagent.started/finished`. Esc-interrupt in standalone mode kills the
-runtime process — the durable JSONL session survives and the next prompt
-respawns it with the same session id.
-
-## Layout
-
-```
-src/proto.rs       NDJSON JSON-RPC client (spawn + attach transports)
-src/runtime.rs     runtime binary / cordis config discovery
-src/controller.rs  lifecycle thread: spawn, initialize, prompt, interrupt
-src/events.rs      notifications → UiEvents (unit-tested)
-src/transcript.rs  scrollback cells + wrapping + styling
-src/app.rs         state machine & keys        src/ui.rs  drawing
-src/theme.rs       Web UI design tokens        src/logo.rs + logo_data.rs
-src/pet.rs         /liang — kitty-graphics pet (idle/working sprites)
-src/clipboard.rs   routed copy: native tool → tmux buffer → OSC 52
-src/demo.rs        scripted wire-identical turns for --demo
-assets/pet/        Liang sprite frames         assets/screenshots/
-assets/promo/      social card + build.py (composed from real pixels)
-npm/               dual-mode package (CLI shim + dsh bundle plugin)
-scripts/           gen_logo.py · build-npm.sh · test-attach.mjs
+```sh
+dsh --profile tui --dump-config
 ```
 
-MIT. Not affiliated with DeepSeek or xAI; grok-build is the interaction
-reference, deepseek-harness is the substrate.
+### Try the demo first
+
+The demo needs neither a runtime nor an API key:
+
+```sh
+npm install --global @openma/deepseek-harness-tui@beta
+dsh-tui --demo
+```
+
+`dsh-tui` is the primary command; `dsb` remains as a compatibility alias.
+
+## Highlights
+
+- Streams reasoning, assistant text, tool arguments and results, plugin context,
+  and subagent lifecycles.
+- Queues follow-ups during a turn; standalone mode can also interrupt and send
+  the next message immediately.
+- Keeps durable JSONL sessions managed through `/new`, `/resume`, and
+  `--session-id`.
+- Uses the host dsh model catalog, agent presets, permission presets, providers,
+  and credentials.
+- Includes dark and light DeepSeek Web UI-inspired themes, narrow-terminal
+  layouts, and mouse interaction.
+- Copies through native clipboard tools, the tmux buffer, or OSC 52 for local,
+  tmux, and SSH sessions.
+
+![Plugin context, tool calls, and a queued follow-up](assets/screenshots/plugin-turn.jpg)
+
+## Two runtime modes
+
+| | dsh plugin (recommended) | Standalone |
+|---|---|---|
+| Agent, tools, providers | Supplied by the dsh profile | Supplied by a separate SDK runtime |
+| Models and agent presets | Uses the live host catalog and switches from the TUI | Uses launch flags or runtime configuration |
+| Session storage | `~/.dsh/sessions` | `~/.dsh-tui/sessions`, configurable with `--session-root` |
+| Mid-turn interrupt | The host owns the turn; no hard interrupt | `esc` stops the runtime while preserving the session log |
+| Runtime installation | The bundle includes its compatibility layer | Requires `dsh-jsonrpc-agent` |
+
+The plugin runner launches the native binary on the host TTY and serves an SDK
+server-compatible JSON-RPC interface over fds 3/4. It does not mount
+`@deepseek-ai/dsh-sdk-jsonrpc-server` directly; the surrounding dsh profile
+still supplies agents, tools, providers, and persistence.
+
+### Standalone runtime
+
+The global npm install provides the TUI binary. Standalone mode also needs the
+DeepSeek Harness SDK in a nearby `.venv`, or an explicitly configured runtime:
+
+```sh
+python -m venv .venv
+.venv/bin/pip install deepseek-harness-sdk
+dsh-tui --workspace .
+```
+
+Alternatively, set `DSH_RUNTIME_BIN` or pass `--runtime-bin <path>`. Credentials
+come from `--api-key`, `DEEPSEEK_API_KEY`, or the local `~/.dsh` configuration,
+in that order.
+
+## Essential interactions
+
+| Key / command | Behavior |
+|---|---|
+| `enter` | Send; queue a follow-up while a turn is running |
+| `alt+enter` | Standalone: interrupt and send next; plugin: queue |
+| `esc` | Standalone: interrupt and preserve the draft; press twice while idle to clear |
+| `ctrl+c` | Clear the draft, then interrupt; press twice to quit |
+| `/` | Open the command menu and filter by prefix |
+| `/model` · `/mode` | Pick a model or agent preset; the full host catalog needs plugin mode |
+| `/permission` · `shift+tab` | Pick or cycle permission presets; plugin mode only |
+| `/effort` · `/plan` | Set reasoning effort or pass plan mode to the host |
+| `ctrl+e` · `ctrl+t` | Expand output · toggle the theme |
+| `pgup/pgdn` · `ctrl+u/d` | Scroll; `end` follows the live tail |
+| Mouse drag | Copy on release; double-click a word; `shift+drag` uses native selection |
+| `!cmd` | Run a local shell command on the client, outside the agent |
+
+Use `/help` for commands and `/keys` for the complete shortcut list.
+
+<p align="center">
+  <img src="assets/screenshots/commands.jpg" width="536"
+       alt="The dsh-tui slash command menu" />
+</p>
+
+<details>
+<summary><strong>Composer pet: /liang 🤫</strong></summary>
+
+`/liang` places a small pixel-art companion beside the composer: quiet while
+idle, typing at a tiny terminal during a turn. Terminals with kitty graphics
+protocol support, including Ghostty, Kitty, and WezTerm, get RGBA sprites;
+others fall back to a half-block whale. The pet hides below 60 columns.
+
+Use `/liang on` or `/liang off` to control it explicitly.
+
+</details>
+
+## Build from source
+
+Requires Rust stable and Node.js 18+:
+
+```sh
+cargo test --locked
+node --test scripts/package-native.test.mjs
+bash scripts/build-npm.sh
+```
+
+The local script builds only the current platform and writes a tarball to
+`dist/`. The `Package and publish npm` GitHub Actions workflow builds and then
+assembles these paths into one npm package:
+
+```text
+npm/vendor/darwin-arm64/dsh-tui
+npm/vendor/darwin-x64/dsh-tui
+npm/vendor/linux-x64/dsh-tui
+npm/vendor/win32-x64/dsh-tui.exe
+```
+
+Running the workflow manually with `publish=true` publishes the version in
+`npm/package.json` under the `beta` tag through npm Trusted Publishing (OIDC).
+
+## Troubleshooting
+
+- **`no native binary for ...`**: the installed package does not contain your
+  platform. Confirm that you installed `@beta` and check the support matrix.
+- **`cannot find ... dsh-jsonrpc-agent`**: the standalone runtime is missing.
+  Install the SDK, set `DSH_RUNTIME_BIN`, or use dsh plugin mode.
+- **pnpm workspace root error**: upgrade to pnpm 10+ and rerun the install
+  command without `-w`.
+- **No pixel pet**: the terminal may not support kitty graphics protocol; the
+  rest of the UI is unaffected.
+
+## Repository map
+
+- `src/`: TUI state, rendering, protocol, runtime lifecycle, and session catalog.
+- `npm/`: dsh bundle runner, CLI shim, manifest, and native binaries.
+- `scripts/`: local builds, cross-platform package checks, protocol integration
+  tests, and asset generation.
+- `assets/`: screenshots, visual assets, and optional pet sprites.
+
+The wire protocol is NDJSON JSON-RPC 2.0 over stdio. Start with
+[`src/proto.rs`](src/proto.rs), [`src/controller.rs`](src/controller.rs), and
+[`npm/lib/index.js`](npm/lib/index.js) for implementation details.
+
+## License
+
+[MIT](LICENSE). Not affiliated with DeepSeek or xAI;
+[grok-build](https://github.com/xai-org/grok-build) is an interaction design
+reference, and [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness)
+is the runtime substrate.

--- a/README.md
+++ b/README.md
@@ -1,141 +1,170 @@
-# dsh-tui — 终端里的 DEEPSEEK HARNESS
+# dsh-tui
 
-中文 | [English](README.en.md)
+[中文](README.md) | [English](README.en.md)
 
-一个 [grok-build](https://github.com/xai-org/grok-build) 风格的
-[DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) 终端
-agent UI，Rust（ratatui）实现。它**直接说 harness 的 SDK JSON-RPC stdio
-协议** —— 链路里没有 Python SDK —— 整套界面按 DeepSeek Web UI 的调色板
-1:1 上色，鲸鱼也在。
+[![npm beta](https://img.shields.io/npm/v/%40openma%2Fdeepseek-harness-tui?tag=beta&label=npm%20beta)](https://www.npmjs.com/package/@openma/deepseek-harness-tui)
+[![Package and publish npm](https://github.com/openma-ai/deepseek-harness-tui/actions/workflows/package-npm.yml/badge.svg)](https://github.com/openma-ai/deepseek-harness-tui/actions/workflows/package-npm.yml)
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
-深度求索 · 探索未至之境 — *everything is a plugin.*
+DeepSeek Harness 的终端原生 agent UI：在一个 Rust/ratatui 界面里查看流式推理、
+工具调用、subagent、token 用量和持久化会话。既可以作为官方 `dsh` profile
+插件运行，也可以直接连接 SDK JSON-RPC runtime。
 
-![dsh-tui — 鲸鱼 banner、DEEPSEEK HARNESS 字标、Into the Unknown](assets/screenshots/banner.jpg)
+> **Beta** · `0.0.4-beta` 的 CI 包覆盖 macOS Apple Silicon、macOS Intel、
+> Linux x64 和 Windows x64。当前集成以 `dsh 0.1.0-rc.6` 为基线。
 
-鲸鱼由 `scripts/gen_logo.py` 从 harness Web UI 实际下发的 favicon SVG
-栅格化而来；字标是 figlet `ansi_shadow`，染成鲸腹灰，终端够宽时右侧跟一个
-白边镂空的 `HARNESS`。`src/theme.rs` 的主题 token 与 Web UI
-`design-platform.css` 的 `--dsw-*` 变量 1:1 对应（深浅两套，`/theme`
-切换）。
+![dsh-tui 的 DeepSeek Harness 会话界面](assets/screenshots/banner.jpg)
 
-## 它展示什么
+## 快速开始
 
-Web UI 为一个会话呈现的一切，这里从事件流实时呈现：流式推理（可折叠的
-`✻ thought · 3.2s · 14 lines`）、流式回复文本、每一次工具调用及其参数与
-结果（`bash`、`str_replace_editor`、`read`…）、注入的 plugin 上下文、
-subagent 生命周期、token 用量（含 cache 命中）、回合结束原因、运行时状态。
+### 推荐：作为 dsh profile 插件运行
 
-## 交互（致敬 grok-build）
-
-| 按键 | 行为 |
-|---|---|
-| `enter` | 发送 · **回合进行中排队 follow-up**（协议原生 inbox） |
-| `alt+enter` | 立即发送：打断当前回合，下一个跑它 |
-| `esc` | 打断（草稿保留）· 空闲时 `esc esc` 清空草稿 |
-| `ctrl+c` | 先清草稿 · 再打断 · `ctrl+c ctrl+c` 退出 |
-| `↑` | 提示词历史（输入框为空时） |
-| `!cmd` | 跑一条本地 shell 命令（客户端执行，不经过 agent） |
-| `/` | 斜杠菜单，前缀过滤（`/help /new /model /mode /effort /permission /plan /theme /liang …`） |
-| `ctrl+m` | 模型选择器（宿主目录）→ 推理力度选择器 |
-| `shift+tab` | 轮换权限预设 · `/permission` 打开选择器 |
-| `ctrl+e` | 展开全部思考/工具输出 · `ctrl+t` 主题 · `ctrl+l` 清屏 |
-| `pgup/pgdn` `ctrl+u/d` | 滚动 · 支持鼠标滚轮 · `end` 跟住尾部 |
-| 鼠标拖选 | 聊天区划选 —— **松手即复制** · 双击复制单词 |
-
-agent 的接缝都是真的，不是装饰：`/mode` 选 agent 预设 —— standard ·
-code · minimal · creator（plugin 模式下换成宿主真实的 `agentPresets`
-名册；在会话第一个 prompt 时组装），`/model` 在 plugin 模式下即时切换，
-`/effort off|high|max` 设定本会话的推理力度，`/plan` 把 plan 模式透传给
-宿主。
-
-<p align="center">
-  <img src="assets/screenshots/commands.jpg" width="536"
-       alt="窄终端上的斜杠菜单 — /liang 高亮，小人在旁听" />
-</p>
-
-剪贴板投递是 grok-pager 式的多级路由，绝不硬失败（`src/clipboard.rs`）：
-原生工具（`pbcopy` / `wl-copy` / `xclip` / `xsel`）→ tmux paste buffer →
-控制终端的 OSC 52（必要时套 tmux passthrough 信封）—— 本机、tmux、SSH
-里复制都好使。
-
-## 输入框宠物 · `/liang` 🤫
-
-一个像素画 **梁文锋** —— 爱称 **小难梁** —— 蹲在输入框右缘；`/liang`
-召唤。两个状态，跟随运行状态切换：
-
-| 状态 | 精灵 | 气场 |
-|---|---|---|
-| idle | 🤫 手指抵唇 | 安静 —— 他在想 AGI |
-| working | ⌨︎ 敲一台小终端 | 回合流式进行中 —— 亲自上手 |
-
-这个梗，立此存照：DeepSeek 出了名低调的创始人 —— 传说他至今每篇论文都读、
-GPU 排队的间隙还在写代码 —— 所以他自然也来你的状态角落兼职：模型思考时
-嘘声示意全场安静，回合一开始就疯狂敲键盘。为什么叫小难梁：因为"难"是
-家族事业 —— AGI 很难，但他在加班。
-
-机制：帧是真像素（`assets/pet/liang-*.png`，RGBA 透明底），在会说 **kitty
-graphics protocol** 的终端上直贴（ghostty · kitty · WezTerm，凭 `$TERM` /
-`$TERM_PROGRAM` 嗅探；一次性 transmit-and-display，布局/状态变化时重发 ——
-`src/pet.rs`）。不支持像素图的终端退回 `logo_data.rs` 的 XS 半块鲸鱼，
-角落永不落空。`/liang` 开关（也支持 `/liang on|off`）；宽度低于 60 列时
-他自己退场。
-
-## 安装与运行
-
-npm 包本身就是官方 `dsh` CLI 的 Cordis bundle —— `dsh plugin` 把剩余参数
-转发给 PATH 上的 pnpm（在 profile 目录里执行）：
+需要已安装并配置好的 `dsh`、Node.js 18+ 和 pnpm 10+。
 
 ```sh
-dsh plugin --profile tui add @openma/deepseek-harness-tui
+dsh plugin --profile tui add @openma/deepseek-harness-tui@beta
 dsh --profile tui
 ```
 
-dsh 的 profile 布局按 **pnpm ≥ 10** 设计。pnpm 9 会对这种“根即唯一成员”
-的单包 workspace 触发 root 护栏（`ERR_PNPM_ADDING_TO_ROOT`），需给
-`add` 补上 `-w`。
+安装命令不需要 `-w`。可用下面的命令确认 bundle 已挂载为 `tui-runner`：
 
-`dsh --profile tui --dump-config` 应能看到 bundle 以稳定插件 id
-`tui-runner` 挂载。想从源码构建：`bash scripts/build-npm.sh` 产出
-`dist/openma-deepseek-harness-tui-*.tgz`，同一条 `add -w` 命令接受这个
-本地路径。
-
-![一个真实的 plugin 模式回合 — 注入的上下文、read 调用、排队中的 follow-up](assets/screenshots/plugin-turn.jpg)
-
-`npm/lib/index.js` 在宿主 TTY 上拉起原生二进制，并挂载官方
-`@deepseek-ai/dsh-sdk-jsonrpc-server`，其传输经管道 fd 3/4 重定向
-（`dsh-tui --attach-fds`）—— 两种模式下 TUI 说的是同一套协议，而 agent、
-工具、providers、持久化全部来自 dsh profile —— 状态行会写
-`connected · dsh-tui-shim`，凭据一栏如实显示 `host dsh (credential
-seam)`。线级行为由 `scripts/test-attach.mjs` 验证。plugin 模式下没有
-回合中打断（回合归宿主所有）。
-
-## 协议
-
-stdio 上的 NDJSON JSON-RPC 2.0（`src/proto.rs`）：请求 `initialize` /
-`session/prompt` / `shutdown`；通知 `session.event`（持久化目录事件：
-`assistant/chunk`、`tool/call`、`tool/result`、`turn/*`、`user/message`
-…）、`session.status`、`subagent.started/finished`。standalone 模式下
-esc 打断会杀掉 runtime 进程 —— 持久化的 JSONL 会话仍在，下一个 prompt
-用同一个 session id 重新拉起。
-
-## 布局
-
-```
-src/proto.rs       NDJSON JSON-RPC 客户端（spawn + attach 两种传输）
-src/runtime.rs     runtime 二进制 / cordis 配置发现
-src/controller.rs  生命周期线程：spawn、initialize、prompt、interrupt
-src/events.rs      通知 → UiEvents（有单测）
-src/transcript.rs  回滚区 cell + 折行 + 样式
-src/app.rs         状态机与按键              src/ui.rs  绘制
-src/theme.rs       Web UI 设计 token         src/logo.rs + logo_data.rs
-src/pet.rs         /liang — kitty 图形宠物（idle/working 精灵）
-src/clipboard.rs   路由式复制：原生工具 → tmux buffer → OSC 52
-src/demo.rs        --demo 的脚本化线缆级回合
-assets/pet/        小难梁精灵帧              assets/screenshots/
-assets/promo/      社交卡片 + build.py（用产品自身像素合成）
-npm/               双模式包（CLI shim + dsh bundle 插件）
-scripts/           gen_logo.py · build-npm.sh · test-attach.mjs
+```sh
+dsh --profile tui --dump-config
 ```
 
-MIT。与 DeepSeek、xAI 均无关联；grok-build 是交互参照，deepseek-harness
-是底座。
+### 先看 Demo
+
+Demo 不需要 runtime 或 API key：
+
+```sh
+npm install --global @openma/deepseek-harness-tui@beta
+dsh-tui --demo
+```
+
+`dsh-tui` 是主命令；`dsb` 保留为兼容别名。
+
+## 核心能力
+
+- 实时呈现推理、回复、工具参数与结果、plugin 上下文和 subagent 生命周期。
+- 回合进行中排队 follow-up；standalone 模式还支持立即打断并发送下一条。
+- 持久化 JSONL 会话，可通过 `/new`、`/resume` 和 `--session-id` 管理。
+- 从 dsh 宿主读取模型、agent preset、权限 preset、provider 和凭据。
+- 深浅两套 DeepSeek Web UI 风格主题，支持窄终端与鼠标交互。
+- 本机、tmux 和 SSH 下通过原生剪贴板、tmux buffer 或 OSC 52 复制文本。
+
+![plugin 模式中的上下文、工具调用和排队 follow-up](assets/screenshots/plugin-turn.jpg)
+
+## 两种运行模式
+
+| | dsh plugin（推荐） | Standalone |
+|---|---|---|
+| Agent、工具与 provider | 来自 dsh profile | 来自独立 SDK runtime |
+| 模型与 agent preset | 使用宿主真实目录，可在 TUI 中切换 | 使用启动参数或 runtime 配置 |
+| 会话存储 | `~/.dsh/sessions` | `~/.dsh-tui/sessions`，可用 `--session-root` 修改 |
+| 回合中断 | 宿主持有回合，不做硬中断 | `esc` 停止 runtime；会话日志保留 |
+| Runtime 安装 | bundle 自带兼容层 | 需要 `dsh-jsonrpc-agent` |
+
+Plugin runner 在宿主 TTY 上启动原生二进制，并通过 fd 3/4 提供一套与官方 SDK
+server 兼容的 JSON-RPC 接口。它不是对
+`@deepseek-ai/dsh-sdk-jsonrpc-server` 的直接挂载；agent、工具、provider 和持久化
+仍由外围 dsh profile 提供。
+
+### Standalone runtime
+
+全局安装只提供 TUI 二进制。Standalone 模式还需要在工作区附近的 `.venv` 中
+安装 DeepSeek Harness SDK，或显式指定 runtime：
+
+```sh
+python -m venv .venv
+.venv/bin/pip install deepseek-harness-sdk
+dsh-tui --workspace .
+```
+
+也可以设置 `DSH_RUNTIME_BIN`，或传入 `--runtime-bin <path>`。凭据优先使用
+`--api-key`、`DEEPSEEK_API_KEY`，随后尝试读取本机 `~/.dsh` 配置。
+
+## 常用交互
+
+| 按键 / 命令 | 行为 |
+|---|---|
+| `enter` | 发送；回合运行时排队 follow-up |
+| `alt+enter` | Standalone：打断当前回合并优先发送；plugin：排队 |
+| `esc` | Standalone：打断且保留草稿；空闲时连按两次清草稿 |
+| `ctrl+c` | 先清草稿，再中断；连按两次退出 |
+| `/` | 打开命令菜单并按前缀过滤 |
+| `/model` · `/mode` | 选择模型和 agent preset；完整目录需要 plugin 模式 |
+| `/permission` · `shift+tab` | 选择或轮换权限 preset；需要 plugin 模式 |
+| `/effort` · `/plan` | 设置推理力度或把 plan 模式传给宿主 |
+| `ctrl+e` · `ctrl+t` | 展开输出 · 切换主题 |
+| `pgup/pgdn` · `ctrl+u/d` | 滚动；`end` 回到实时尾部 |
+| 鼠标拖选 | 松手复制；双击复制单词；`shift+拖选` 使用终端原生选择 |
+| `!cmd` | 在客户端本地执行 shell 命令，不经过 agent |
+
+界面内使用 `/help` 查看命令，使用 `/keys` 查看完整快捷键。
+
+<p align="center">
+  <img src="assets/screenshots/commands.jpg" width="536"
+       alt="dsh-tui 的斜杠菜单" />
+</p>
+
+<details>
+<summary><strong>输入框宠物：/liang 🤫</strong></summary>
+
+`/liang` 会在输入框右侧显示小难梁：空闲时安静思考，回合运行时敲小终端。
+Ghostty、Kitty 和 WezTerm 等支持 kitty graphics protocol 的终端会显示 RGBA
+像素精灵；其他终端退回半块字符鲸鱼。宽度低于 60 列时自动隐藏。
+
+可用 `/liang on`、`/liang off` 显式控制。
+
+</details>
+
+## 从源码构建
+
+需要 Rust stable 和 Node.js 18+：
+
+```sh
+cargo test --locked
+node --test scripts/package-native.test.mjs
+bash scripts/build-npm.sh
+```
+
+本地脚本只编译当前平台，并将 tarball 写入 `dist/`。GitHub Actions 工作流
+`Package and publish npm` 会分别构建以下目录，再汇总为一个 npm 包：
+
+```text
+npm/vendor/darwin-arm64/dsh-tui
+npm/vendor/darwin-x64/dsh-tui
+npm/vendor/linux-x64/dsh-tui
+npm/vendor/win32-x64/dsh-tui.exe
+```
+
+手动运行该工作流并设置 `publish=true` 时，会通过 npm Trusted Publishing
+（OIDC）将 `npm/package.json` 中的版本发布到 `beta` tag。
+
+## 故障排查
+
+- **`no native binary for ...`**：当前安装包不包含你的平台。确认安装的是
+  `@beta`，并查看上方支持矩阵。
+- **`cannot find ... dsh-jsonrpc-agent`**：这是 standalone runtime 缺失；安装
+  SDK、设置 `DSH_RUNTIME_BIN`，或改用 dsh plugin 模式。
+- **pnpm workspace root 错误**：升级到 pnpm 10+，然后重新运行不带 `-w` 的
+  安装命令。
+- **像素宠物不显示**：终端可能不支持 kitty graphics protocol；主界面功能
+  不受影响。
+
+## 项目结构
+
+- `src/`：TUI 状态机、绘制、协议、runtime 生命周期和会话目录。
+- `npm/`：dsh bundle runner、CLI shim、manifest 与原生二进制。
+- `scripts/`：本地构建、跨平台打包校验、协议集成测试与资源生成。
+- `assets/`：截图、主题资源和可选宠物精灵。
+
+协议是 stdio 上的 NDJSON JSON-RPC 2.0。实现细节可从
+[`src/proto.rs`](src/proto.rs)、[`src/controller.rs`](src/controller.rs) 和
+[`npm/lib/index.js`](npm/lib/index.js) 开始阅读。
+
+## License
+
+[MIT](LICENSE)。本项目与 DeepSeek、xAI 无关联；
+[grok-build](https://github.com/xai-org/grok-build) 是交互设计参考，
+[DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) 是运行底座。

--- a/npm/LICENSE
+++ b/npm/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 OpenMA contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/npm/README.md
+++ b/npm/README.md
@@ -1,59 +1,64 @@
 # @openma/deepseek-harness-tui
 
-DeepSeek Build (`dsh-tui`) — grok-build style terminal UI for the deepseek-harness agent runtime.
+Terminal-native UI for DeepSeek Harness, distributed as both a `dsh` profile
+bundle and a standalone `dsh-tui` command.
 
-This package bundles a platform-native binary and installs two commands:
+> **Beta** · Native binaries are packaged for macOS arm64, macOS x64, Linux
+> x64, and Windows x64. Requires Node.js 18+; plugin installation requires
+> pnpm 10+ and is tested with `dsh 0.1.0-rc.6`.
 
-- `dsh-tui` (primary)
-- `dsb` (alias)
-
-## Install
-
-As a dsh plugin (needs **pnpm ≥ 10** on PATH; on pnpm 9 add `-w` to the `add`):
+## Recommended: dsh profile plugin
 
 ```sh
-dsh plugin --profile tui add @openma/deepseek-harness-tui
+dsh plugin --profile tui add @openma/deepseek-harness-tui@beta
 dsh --profile tui
 ```
 
-As a standalone CLI:
+The install command does not need `-w`. The profile supplies agents, tools,
+providers, credentials, and durable sessions; the package supplies the native
+TUI and its dsh-compatible JSON-RPC bridge.
+
+## Demo and standalone CLI
 
 ```sh
-npm i -g @openma/deepseek-harness-tui@beta
+npm install --global @openma/deepseek-harness-tui@beta
+dsh-tui --demo
 ```
 
-Or from a local tarball built from source:
+`dsh-tui` is the primary command. `dsb` is a compatibility alias.
+
+The demo needs no API key or runtime. Normal standalone sessions additionally
+need `dsh-jsonrpc-agent`, discovered from a nearby SDK virtual environment,
+`DSH_RUNTIME_BIN`, `--runtime-bin`, or `PATH`:
 
 ```sh
-# From the repo root, after building the tarball:
-npm i -g ./dist/<tgz>
+python -m venv .venv
+.venv/bin/pip install deepseek-harness-sdk
+dsh-tui --workspace .
 ```
 
-## Runtime discovery
+Run `dsh-tui --help` for runtime, model, credential, session, theme, and demo
+options.
 
-The deepseek-harness runtime is discovered separately from this package. Either:
+## Supported platforms
 
-- install the SDK into a `.venv` next to your workspace:
+| Node platform key | Binary |
+|---|---|
+| `darwin-arm64` | `vendor/darwin-arm64/dsh-tui` |
+| `darwin-x64` | `vendor/darwin-x64/dsh-tui` |
+| `linux-x64` | `vendor/linux-x64/dsh-tui` |
+| `win32-x64` | `vendor/win32-x64/dsh-tui.exe` |
 
-  ```sh
-  python -m venv .venv
-  .venv/bin/pip install deepseek-harness-sdk
-  ```
-
-- or point directly at a runtime binary with the `DSH_RUNTIME_BIN` environment variable.
+If installation succeeds but launch reports `no native binary for ...`, confirm
+that you installed the `beta` tag and that your platform appears above.
 
 ## Uninstall
 
 ```sh
-npm uninstall -g @openma/deepseek-harness-tui
+npm uninstall --global @openma/deepseek-harness-tui
 ```
 
-## Rebuild
+Source, screenshots, development commands, and architecture notes live in the
+[GitHub repository](https://github.com/openma-ai/deepseek-harness-tui).
 
-The bundled binary is platform-specific. To (re)build the binary and the tarball on your machine:
-
-```sh
-bash scripts/build-npm.sh
-```
-
-This runs `cargo build --release`, copies the binary into `npm/vendor/<platform>-<arch>/`, and writes a fresh `.tgz` into `dist/`.
+[MIT](https://github.com/openma-ai/deepseek-harness-tui/blob/main/LICENSE).

--- a/npm/cordis.patch.yml
+++ b/npm/cordis.patch.yml
@@ -1,7 +1,7 @@
 # @openma/deepseek-harness-tui bundle patch: mounts the native dsh-tui runner over
 # the profile's base bundle under the stable plugin id `tui-runner`. The runner
-# spawns the platform-native TUI binary on the host TTY and bridges the agent
-# through @deepseek-ai/dsh-sdk-jsonrpc-server over inherited pipe fds.
+# spawns the platform-native TUI binary on the host TTY and serves the compatible
+# SDK JSON-RPC surface over inherited pipe fds.
 
 - insert:
     - id: tui-runner

--- a/npm/lib/index.js
+++ b/npm/lib/index.js
@@ -4,7 +4,7 @@
  *
  * Install into a profile and launch:
  *
- *     dsh plugin --profile tui add @openma/deepseek-harness-tui
+ *     dsh plugin --profile tui add @openma/deepseek-harness-tui@beta
  *     dsh --profile tui
  *
  * The runner spawns the platform-native `dsh-tui` binary with the host TTY

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openma/deepseek-harness-tui",
-  "version": "0.0.3-beta",
-  "description": "DeepSeek Build (dsh-tui) \u2014 grok-build style terminal UI for the deepseek-harness agent runtime; standalone CLI or dsh profile bundle",
+  "version": "0.0.4-beta",
+  "description": "Terminal-native agent UI for DeepSeek Harness; standalone CLI or dsh profile bundle",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -12,6 +12,13 @@
     "url": "https://github.com/openma-ai/deepseek-harness-tui/issues"
   },
   "main": "lib/index.js",
+  "scripts": {
+    "test": "node --test ../scripts/package-native.test.mjs"
+  },
+  "publishConfig": {
+    "access": "public",
+    "tag": "beta"
+  },
   "exports": {
     ".": "./lib/index.js",
     "./cordis.patch.yml": "./cordis.patch.yml",
@@ -26,7 +33,8 @@
     "lib",
     "vendor",
     "cordis.patch.yml",
-    "README.md"
+    "README.md",
+    "LICENSE"
   ],
   "dsh": {
     "bundle": {

--- a/scripts/build-npm.sh
+++ b/scripts/build-npm.sh
@@ -6,11 +6,18 @@ cd "$(dirname "${BASH_SOURCE[0]}")/.."
 
 cargo build --release
 
-PLAT="$(node -p 'process.platform + "-" + process.arch')"
+PLATFORM="$(node -p 'process.platform')"
+ARCH="$(node -p 'process.arch')"
+BINARY="target/release/dsh-tui"
+if [[ "$PLATFORM" == "win32" ]]; then
+  BINARY="${BINARY}.exe"
+fi
 
-mkdir -p "npm/vendor/$PLAT"
-cp target/release/dsh-tui "npm/vendor/$PLAT/"
-chmod +x "npm/vendor/$PLAT/dsh-tui"
+node scripts/package-native.mjs stage \
+  --source "$BINARY" \
+  --platform "$PLATFORM" \
+  --arch "$ARCH" \
+  --vendor-root npm/vendor
 
 mkdir -p dist
 (cd npm && npm pack --pack-destination ../dist)

--- a/scripts/package-native.mjs
+++ b/scripts/package-native.mjs
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+
+import { chmodSync, copyFileSync, existsSync, mkdirSync, statSync } from 'node:fs'
+import path from 'node:path'
+
+const supported = [
+  { platform: 'darwin', arch: 'arm64', file: 'dsh-tui' },
+  { platform: 'darwin', arch: 'x64', file: 'dsh-tui' },
+  { platform: 'linux', arch: 'x64', file: 'dsh-tui' },
+  { platform: 'win32', arch: 'x64', file: 'dsh-tui.exe' },
+]
+
+function options(args) {
+  const out = new Map()
+  for (let i = 0; i < args.length; i += 2) {
+    const key = args[i]
+    const value = args[i + 1]
+    if (!key?.startsWith('--') || value === undefined) {
+      throw new Error(`invalid option list near ${key ?? '<end>'}`)
+    }
+    out.set(key.slice(2), value)
+  }
+  return out
+}
+
+function required(values, name) {
+  const value = values.get(name)
+  if (!value) throw new Error(`--${name} is required`)
+  return value
+}
+
+function platformSpec(platform, arch) {
+  const spec = supported.find((item) => item.platform === platform && item.arch === arch)
+  if (!spec) throw new Error(`unsupported native target: ${platform}-${arch}`)
+  return spec
+}
+
+function stage(values) {
+  const source = path.resolve(required(values, 'source'))
+  const platform = required(values, 'platform')
+  const arch = required(values, 'arch')
+  const vendorRoot = path.resolve(required(values, 'vendor-root'))
+  const spec = platformSpec(platform, arch)
+  if (!existsSync(source) || !statSync(source).isFile()) {
+    throw new Error(`native binary not found: ${source}`)
+  }
+
+  const destinationDir = path.join(vendorRoot, `${platform}-${arch}`)
+  const destination = path.join(destinationDir, spec.file)
+  mkdirSync(destinationDir, { recursive: true })
+  copyFileSync(source, destination)
+  if (platform !== 'win32') chmodSync(destination, 0o755)
+  process.stdout.write(`${destination}\n`)
+}
+
+function verify(values) {
+  const vendorRoot = path.resolve(required(values, 'vendor-root'))
+  const missing = supported
+    .map((spec) => path.join(vendorRoot, `${spec.platform}-${spec.arch}`, spec.file))
+    .filter((file) => !existsSync(file) || !statSync(file).isFile() || statSync(file).size === 0)
+  if (missing.length > 0) {
+    throw new Error(`release package is missing native binaries:\n${missing.join('\n')}`)
+  }
+  process.stdout.write('native package set complete\n')
+}
+
+const [command, ...args] = process.argv.slice(2)
+const values = options(args)
+
+try {
+  if (command === 'stage') stage(values)
+  else if (command === 'verify') verify(values)
+  else throw new Error('usage: package-native.mjs <stage|verify> [options]')
+} catch (error) {
+  process.stderr.write(`${error.message}\n`)
+  process.exitCode = 1
+}

--- a/scripts/package-native.test.mjs
+++ b/scripts/package-native.test.mjs
@@ -1,0 +1,71 @@
+import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
+import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import test from 'node:test'
+
+const repoRoot = path.resolve(import.meta.dirname, '..')
+const script = path.join(repoRoot, 'scripts', 'package-native.mjs')
+
+function run(args) {
+  return spawnSync(process.execPath, [script, ...args], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+  })
+}
+
+test('stages native binaries under npm platform keys', () => {
+  const root = mkdtempSync(path.join(tmpdir(), 'dsh-tui-package-'))
+  const source = path.join(root, 'compiled-binary')
+  const vendorRoot = path.join(root, 'vendor')
+  writeFileSync(source, 'native-binary-fixture')
+
+  const cases = [
+    ['darwin', 'arm64', 'darwin-arm64/dsh-tui'],
+    ['darwin', 'x64', 'darwin-x64/dsh-tui'],
+    ['linux', 'x64', 'linux-x64/dsh-tui'],
+    ['win32', 'x64', 'win32-x64/dsh-tui.exe'],
+  ]
+
+  for (const [platform, arch, expectedPath] of cases) {
+    const result = run([
+      'stage',
+      '--source', source,
+      '--platform', platform,
+      '--arch', arch,
+      '--vendor-root', vendorRoot,
+    ])
+    assert.equal(result.status, 0, result.stderr)
+    assert.equal(
+      readFileSync(path.join(vendorRoot, expectedPath), 'utf8'),
+      'native-binary-fixture',
+    )
+  }
+})
+
+test('verifies that a release contains every supported platform', () => {
+  const root = mkdtempSync(path.join(tmpdir(), 'dsh-tui-verify-'))
+  const source = path.join(root, 'compiled-binary')
+  const vendorRoot = path.join(root, 'vendor')
+  writeFileSync(source, 'native-binary-fixture')
+
+  for (const [platform, arch] of [
+    ['darwin', 'arm64'],
+    ['darwin', 'x64'],
+    ['linux', 'x64'],
+    ['win32', 'x64'],
+  ]) {
+    const staged = run([
+      'stage',
+      '--source', source,
+      '--platform', platform,
+      '--arch', arch,
+      '--vendor-root', vendorRoot,
+    ])
+    assert.equal(staged.status, 0, staged.stderr)
+  }
+
+  const verified = run(['verify', '--vendor-root', vendorRoot])
+  assert.equal(verified.status, 0, verified.stderr)
+})

--- a/scripts/test-attach.mjs
+++ b/scripts/test-attach.mjs
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 /**
- * Attach-mode wire test: emulates the dsh plugin host (the role of
- * npm/lib/index.js + @deepseek-ai/dsh-sdk-jsonrpc-server) and drives the
- * native `dsh-tui --attach-fds` binary end to end over fds 3/4.
+ * Attach-mode wire test: emulates the dsh plugin host role implemented by
+ * npm/lib/index.js and drives the native `dsh-tui --attach-fds` binary end to
+ * end over fds 3/4.
  *
  * Needs a TTY on stdio (run under `script -q /dev/null …` in CI-ish shells).
  * DSH_TUI_AUTOPROMPT makes the TUI submit one prompt on startup, so the full

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
-//! dsh-tui — DeepSeek Build: a grok-build style TUI for the deepseek-harness
-//! JSON-RPC stdio runtime.
+//! dsh-tui — a terminal-native agent UI for the DeepSeek Harness JSON-RPC
+//! stdio runtime.
 
 mod app;
 mod bus;
@@ -32,7 +32,7 @@ use crate::controller::Controller;
 use crate::runtime::RuntimeConfig;
 
 const HELP: &str = "\
-dsh-tui — DeepSeek Build · deepseek-harness terminal UI
+dsh-tui — terminal-native UI for DeepSeek Harness
 
 USAGE:
   dsh-tui [OPTIONS]
@@ -51,7 +51,7 @@ OPTIONS:
       --theme <dark|light>  DeepSeek Web UI palette (default: dark)
       --demo                scripted turns, no runtime / API key needed
       --attach-fds          plugin mode: speak JSON-RPC over inherited fds 3/4
-                            (used by `dsh plugin --profile tui add -w @openma/deepseek-harness-tui`)
+                            (used by `dsh plugin --profile tui add @openma/deepseek-harness-tui`)
       --check-runtime       spawn + initialize the runtime, print info, exit
       --dump-frame [WxH]    render one demo frame as text (default 100x34)
   -V, --version             print version


### PR DESCRIPTION
## What changed

- rewrites the Chinese, English, and npm READMEs around a clear quick start, runtime-mode comparison, supported platforms, troubleshooting, and contributor guidance
- standardizes installation on `@beta` without `-w`
- adds MIT license files and corrects the SDK server compatibility-layer description
- adds tested native-binary staging for macOS arm64, macOS x64, Linux x64, and Windows x64
- adds the `Package and publish npm` workflow, which assembles one multi-platform npm tarball and can publish manually through npm Trusted Publishing/OIDC
- bumps the npm package to `0.0.4-beta`

## Why

The previous docs had conflicting install commands, sent untagged installs to an older npm release, did not disclose that the package only contained an Apple Silicon binary, and foregrounded implementation details before onboarding.

## Validation

- `cargo test --locked` — 70 passed
- `node --test scripts/package-native.test.mjs` — 2 passed
- `npm --prefix npm test` — 2 passed
- `cargo build --release --locked`
- `npm pack ./npm --dry-run --json`
- `git diff --check`

`cargo fmt --check` still reports the repository pre-existing broad formatting drift; this PR deliberately does not reformat unrelated Rust files.

## npm setup

Trusted Publisher fields:

- organization: `openma-ai`
- repository: `deepseek-harness-tui`
- workflow filename: `package-npm.yml`
- environment: `npm`
- allowed action: `npm publish`

The publish job only runs for a manual workflow dispatch with `publish=true`.