### PR TITLE
Fix cache usage parsing for Harness cacheReadTokens

### DIFF
--- a/src/events.rs
+++ b/src/events.rs
@@ -183,7 +183,8 @@ fn parse_assistant_chunk(session: String, data: &Value) -> Vec<UiEvent> {
         }],
         Some("usage") => {
             let usage = chunk.get("usage").unwrap_or(&Value::Null);
-            let cached = u64_field(usage, "cachedInputTokens")
+            let cached = u64_field(usage, "cacheReadTokens")
+                .or_else(|| u64_field(usage, "cachedInputTokens"))
                 .or_else(|| u64_field(usage, "cacheReadInputTokens"))
                 .unwrap_or(0);
             vec![UiEvent::Usage {
@@ -427,6 +428,21 @@ mod tests {
         assert_eq!(
             ev,
             vec![UiEvent::Usage { session: "s".into(), input: 1, output: 0, cached: 9, reasoning: 0 }]
+        );
+    }
+
+    #[test]
+    fn usage_with_harness_cache_read_tokens() {
+        let ev = parse_notification(
+            "session.event",
+            &json!({"sessionId": "s", "event": {"type": "assistant/chunk",
+                "data": {"chunk": {"type": "usage", "usage": {
+                    "inputTokens": 1, "outputTokens": 2,
+                    "cacheReadTokens": 9, "reasoningTokens": 3}}}}}),
+        );
+        assert_eq!(
+            ev,
+            vec![UiEvent::Usage { session: "s".into(), input: 1, output: 2, cached: 9, reasoning: 3 }]
         );
     }
 


### PR DESCRIPTION
## Summary

修复将 `@openma/deepseek-harness-tui` 作为 DeepSeek Harness profile 插件使用时，缓存命中 token 无法显示的问题：

- 支持 DeepSeek Harness 当前正式使用的 `cacheReadTokens` 字段，让 TUI 状态栏能正确显示 `(cache …)`。

关于原任务中提到的 ESM 加载竞态（`ERR_REQUIRE_ESM_RACE_CONDITION`）：该问题在当前 upstream `main` 上**已经被提前修复**——runner 已整体转换为 ESM（`npm/package.json` 的 `"type": "module"`，`npm/lib/index.js` 使用顶层静态 `import`，包内已无任何 `require('@deepseek-ai/…')`），并已有对应回归测试（`scripts/plugin-runner.test.mjs` 中的 "the published plugin is ESM so Cordis can import() it in parallel"）。因此本 PR **不重复修复该问题**，只提交仍然缺失的 cache usage 解析部分。

## Root cause

DeepSeek Harness 当前的 token usage 数据通过 `cacheReadTokens` 表示缓存读取 token，而 TUI parser 只检查 `cachedInputTokens` 和 `cacheReadInputTokens`，导致真实缓存命中被解析为 0，状态栏因此不会显示 `(cache …)`。

## Changes

- `src/events.rs`：优先解析 `cacheReadTokens`
- 保留 `cachedInputTokens` 和 `cacheReadInputTokens` 兼容字段（按原优先级降级使用）
- 新增 Rust 回归测试 `usage_with_harness_cache_read_tokens` 覆盖 Harness 正式字段

## User impact

- 恢复当前 DeepSeek Harness 版本下 TUI 的缓存命中 token 显示（例如状态栏出现 `(cache 8.0k)`）

## Validation

已执行：

- `cargo test --locked` — 71 passed; 0 failed（含新增回归测试与两个兼容字段测试）
- `cd npm && npm test` — 7 passed; 0 failed
- `node --check npm/lib/index.js` — 通过

端到端启动验证（Node.js v24.19.0，本机 `dsh 0.1.0-rc.6`）：

- `dsh --profile tui` 在当前 upstream ESM runner 下可正常启动、TUI 正常渲染，无 `ERR_REQUIRE_ESM_RACE_CONDITION` 或插件树加载错误
- 说明：本 PR 未改动 runner；`ERR_REQUIRE_ESM_RACE_CONDITION` 属时序相关竞态，本机多次尝试未复现（旧 CJS 0.1.0 与新版 ESM runner 均未触发），因此无法提供复现前后对比
- 缓存命中显示未用真实 API 会话验证（无可用会话），由单元测试覆盖解析逻辑
