### PR TITLE
docs: sync README quick-start install step and shortcut updates to En…

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -40,6 +40,12 @@ Needs Node.js 18+. The same command installs or upgrades: it creates a missing
 profile, while an existing profile explicitly re-resolves TUI and its dependency
 graph from npm's `latest` tag:
 
+First install the official [DeepSeek Harness](https://github.com/deepseek-ai/dsh):
+```sh
+npm install -g @deepseek-ai/dsh
+```
+
+Then install this project as its TUI surface plugin:
 ```sh
 dsh plugin --profile tui add @openma/deepseek-harness-tui@latest
 dsh --profile tui
@@ -239,9 +245,9 @@ Requests/Notifications and never enter prompts or conversation history.
 | `enter` | Send; queue a follow-up while a turn is running |
 | `ctrl+x` | Steer the active turn immediately without cancelling it |
 | `esc` | Interrupt the current turn (draft survives); clears the draft when idle |
-| `ctrl+c` | Clear the draft, then interrupt; press twice to quit |
+| `ctrl+c` | Clear the draft first; press twice when idle, five times while a turn runs, to quit; never interrupts the current turn |
 | `/` | Open the command menu and filter by prefix; agent-advertised skills join it and still ship as `/name ` prompts |
-| `/model` · `/agent` | Pick an agent-advertised model or agent preset; `ctrl+a` cycles agents directly without a picker |
+| `/model` · `/agent` | Pick an agent-advertised model or agent preset; `option+a` cycles agents directly without a picker |
 | `/auth` | ACP sign-in (method picker when several methods; otherwise Terminal Auth or `authenticate` `_meta`); mid-session `auth_required` opens the same surface; the agent's `/login` stays a prompt |
 | `/permission` · `shift+tab` | Pick or cycle agent-advertised permission modes |
 | `/effort` · `/plan` | Set reasoning effort or pass plan mode to the host |

--- a/README.md
+++ b/README.md
@@ -36,6 +36,12 @@
 需要 Node.js 18+。同一条命令用于首次安装和以后升级；缺失的 profile 会自动创建，
 已有 profile 会显式按 npm 的 `latest` 标签重新解析 TUI 及其依赖图：
 
+首先安装官方的 [DeepSeek Harness](https://github.com/deepseek-ai/dsh)：
+```sh
+npm install -g @deepseek-ai/dsh
+```
+
+再安装本项目作为它的 TUI surface plugin：
 ```sh
 dsh plugin --profile tui add @openma/deepseek-harness-tui@latest
 dsh --profile tui


### PR DESCRIPTION
…glish

- README.md: add official DeepSeek Harness install step (npm install -g @deepseek-ai/dsh)
- README.en.md: mirror the install step; fix ctrl+c quit behavior (2x idle / 5x running, no turn interrupt) and agent cycle key (option+a, not ctrl+a)