### PR TITLE
fix: ship Linux binary without glibc dependency

### DIFF
--- a/.github/workflows/package-npm.yml
+++ b/.github/workflows/package-npm.yml
@@ -71,10 +71,10 @@ jobs:
             binary: target/x86_64-apple-darwin/release/dsh-tui
           - name: linux-x64
             runner: ubuntu-24.04
-            rust-target: x86_64-unknown-linux-gnu
+            rust-target: x86_64-unknown-linux-musl
             platform: linux
             arch: x64
-            binary: target/x86_64-unknown-linux-gnu/release/dsh-tui
+            binary: target/x86_64-unknown-linux-musl/release/dsh-tui
           - name: win32-x64
             runner: windows-2025
             rust-target: x86_64-pc-windows-msvc
@@ -89,8 +89,14 @@ jobs:
           package-manager-cache: false
       - run: rustup update stable
       - run: rustup default stable
+      - name: Install musl linker
+        if: matrix.platform == 'linux'
+        run: sudo apt-get update && sudo apt-get install --yes musl-tools
       - run: rustup target add ${{ matrix.rust-target }}
       - run: cargo build --release --locked --target ${{ matrix.rust-target }}
+      - name: Verify Linux binary is statically linked
+        if: matrix.platform == 'linux'
+        run: node scripts/check-static-elf.mjs "${{ matrix.binary }}"
       - name: Stage native binary
         run: >-
           node scripts/package-native.mjs stage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project are documented here. The project follows
 
 ## [Unreleased]
 
+### Fixed
+
+- Linux x64 packages now ship a statically linked musl binary instead of a
+  binary tied to the Ubuntu 24.04 glibc version. Release CI verifies the ELF
+  artifact has no dynamic program interpreter before packaging it.
+
 ### Changed
 
 - Markdown rendering now runs on `tui-markdown` (pulldown-cmark) instead of a

--- a/npm/package.json
+++ b/npm/package.json
@@ -14,7 +14,7 @@
   "type": "module",
   "main": "lib/index.js",
   "scripts": {
-    "test": "node --test ../scripts/package-native.test.mjs ../scripts/check-release-tag.test.mjs ../scripts/cargo-guard.test.mjs ../scripts/build-npm.test.mjs ../scripts/client-profile.test.mjs ../scripts/plugin-runner.test.mjs ../scripts/profile-link-resolution.test.mjs ../scripts/jsonrpc-line-transport.test.mjs ../scripts/tui-theme.test.mjs ../scripts/tui-slots.test.mjs ../scripts/tui-commands.test.mjs ../scripts/tui-overlay.test.mjs ../scripts/mux.test.mjs ../scripts/acp-client.test.mjs ../scripts/acp-session-config.test.mjs ../scripts/runner.test.mjs ../scripts/inspect.test.mjs ../scripts/creator-overlay.test.mjs ../scripts/real-agent-e2e.test.mjs"
+    "test": "node --test ../scripts/package-native.test.mjs ../scripts/check-release-tag.test.mjs ../scripts/check-static-elf.test.mjs ../scripts/cargo-guard.test.mjs ../scripts/build-npm.test.mjs ../scripts/client-profile.test.mjs ../scripts/plugin-runner.test.mjs ../scripts/profile-link-resolution.test.mjs ../scripts/jsonrpc-line-transport.test.mjs ../scripts/tui-theme.test.mjs ../scripts/tui-slots.test.mjs ../scripts/tui-commands.test.mjs ../scripts/tui-overlay.test.mjs ../scripts/mux.test.mjs ../scripts/acp-client.test.mjs ../scripts/acp-session-config.test.mjs ../scripts/runner.test.mjs ../scripts/inspect.test.mjs ../scripts/creator-overlay.test.mjs ../scripts/real-agent-e2e.test.mjs"
   },
   "publishConfig": {
     "access": "public",

--- a/scripts/check-static-elf.mjs
+++ b/scripts/check-static-elf.mjs
@@ -1,0 +1,24 @@
+#!/usr/bin/env node
+
+import { spawnSync } from 'node:child_process'
+import path from 'node:path'
+
+const binary = process.argv[2]
+const readelf = process.env.DSH_TUI_READELF_BIN || 'readelf'
+
+try {
+  if (!binary) throw new Error('usage: check-static-elf.mjs <binary>')
+
+  const result = spawnSync(readelf, ['--program-headers', binary], { encoding: 'utf8' })
+  if (result.error) throw result.error
+  if (result.status !== 0) {
+    throw new Error(result.stderr.trim() || `readelf exited with status ${result.status}`)
+  }
+  if (/\bINTERP\b|Requesting program interpreter/i.test(result.stdout)) {
+    throw new Error(`${path.basename(binary)} is dynamically linked and requires a program interpreter`)
+  }
+  process.stdout.write(`static ELF verified: ${binary}\n`)
+} catch (error) {
+  process.stderr.write(`${error.message}\n`)
+  process.exitCode = 1
+}

--- a/scripts/check-static-elf.test.mjs
+++ b/scripts/check-static-elf.test.mjs
@@ -1,0 +1,48 @@
+import assert from 'node:assert/strict'
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { spawnSync } from 'node:child_process'
+import test from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+const checker = path.join(repoRoot, 'scripts', 'check-static-elf.mjs')
+
+function fixture(programHeaders) {
+  const root = mkdtempSync(path.join(tmpdir(), 'dsh-tui-static-elf-'))
+  const readelf = path.join(root, 'readelf')
+  const binary = path.join(root, 'dsh-tui')
+  writeFileSync(binary, 'fixture')
+  writeFileSync(readelf, `#!/bin/sh
+printf '%s\n' "${programHeaders}"
+`)
+  chmodSync(readelf, 0o755)
+  return { root, readelf, binary }
+}
+
+test('accepts a static ELF binary without a program interpreter', (t) => {
+  const item = fixture('Elf file type is EXEC (Executable file)')
+  t.after(() => rmSync(item.root, { recursive: true, force: true }))
+
+  const result = spawnSync(process.execPath, [checker, item.binary], {
+    encoding: 'utf8',
+    env: { ...process.env, DSH_TUI_READELF_BIN: item.readelf },
+  })
+
+  assert.equal(result.status, 0, result.stderr)
+  assert.match(result.stdout, /static ELF verified/)
+})
+
+test('rejects an ELF binary that needs the glibc program interpreter', (t) => {
+  const item = fixture('INTERP         0x0000000000000350\n      [Requesting program interpreter: /lib64/ld-linux-x86-64.so.2]')
+  t.after(() => rmSync(item.root, { recursive: true, force: true }))
+
+  const result = spawnSync(process.execPath, [checker, item.binary], {
+    encoding: 'utf8',
+    env: { ...process.env, DSH_TUI_READELF_BIN: item.readelf },
+  })
+
+  assert.equal(result.status, 1)
+  assert.match(result.stderr, /dynamically linked/)
+})


### PR DESCRIPTION
## Summary

- build the packaged Linux x64 binary for `x86_64-unknown-linux-musl`
- verify the release ELF has no dynamic program interpreter before staging it
- cover the release guard with acceptance and rejection tests
- document the compatibility fix in the unreleased changelog

## Why

The existing release job builds `x86_64-unknown-linux-gnu` on Ubuntu 24.04. That links the distributed binary to newer glibc symbols, so it cannot start on older Linux distributions.

Shipping a statically linked musl artifact removes the host glibc dependency while retaining the existing `linux-x64` package layout.

Closes #10.

## Validation

- `npm test --prefix npm` — 118 passed
- `./scripts/cargo-guard.sh test --locked` — 335 passed
- workflow YAML parse and `git diff --check`
