### PR TITLE
ci: smoke test Linux binary on Ubuntu 20.04

### DIFF
--- a/.github/workflows/package-npm.yml
+++ b/.github/workflows/package-npm.yml
@@ -97,6 +97,9 @@ jobs:
       - name: Verify Linux binary is statically linked
         if: matrix.platform == 'linux'
         run: node scripts/check-static-elf.mjs "${{ matrix.binary }}"
+      - name: Smoke test Linux binary on Ubuntu 20.04
+        if: matrix.platform == 'linux'
+        run: node scripts/smoke-old-linux.mjs "${{ matrix.binary }}"
       - name: Stage native binary
         run: >-
           node scripts/package-native.mjs stage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ All notable changes to this project are documented here. The project follows
 
 - Linux x64 packages now ship a statically linked musl binary instead of a
   binary tied to the Ubuntu 24.04 glibc version. Release CI verifies the ELF
-  artifact has no dynamic program interpreter before packaging it.
+  artifact has no dynamic program interpreter and runs it on Ubuntu 20.04
+  before packaging it.
 
 ### Changed
 

--- a/npm/package.json
+++ b/npm/package.json
@@ -14,7 +14,7 @@
   "type": "module",
   "main": "lib/index.js",
   "scripts": {
-    "test": "node --test ../scripts/package-native.test.mjs ../scripts/check-release-tag.test.mjs ../scripts/check-static-elf.test.mjs ../scripts/cargo-guard.test.mjs ../scripts/build-npm.test.mjs ../scripts/client-profile.test.mjs ../scripts/plugin-runner.test.mjs ../scripts/profile-link-resolution.test.mjs ../scripts/jsonrpc-line-transport.test.mjs ../scripts/tui-theme.test.mjs ../scripts/tui-slots.test.mjs ../scripts/tui-commands.test.mjs ../scripts/tui-overlay.test.mjs ../scripts/mux.test.mjs ../scripts/acp-client.test.mjs ../scripts/acp-session-config.test.mjs ../scripts/runner.test.mjs ../scripts/inspect.test.mjs ../scripts/creator-overlay.test.mjs ../scripts/real-agent-e2e.test.mjs"
+    "test": "node --test ../scripts/package-native.test.mjs ../scripts/check-release-tag.test.mjs ../scripts/check-static-elf.test.mjs ../scripts/smoke-old-linux.test.mjs ../scripts/cargo-guard.test.mjs ../scripts/build-npm.test.mjs ../scripts/client-profile.test.mjs ../scripts/plugin-runner.test.mjs ../scripts/profile-link-resolution.test.mjs ../scripts/jsonrpc-line-transport.test.mjs ../scripts/tui-theme.test.mjs ../scripts/tui-slots.test.mjs ../scripts/tui-commands.test.mjs ../scripts/tui-overlay.test.mjs ../scripts/mux.test.mjs ../scripts/acp-client.test.mjs ../scripts/acp-session-config.test.mjs ../scripts/runner.test.mjs ../scripts/inspect.test.mjs ../scripts/creator-overlay.test.mjs ../scripts/real-agent-e2e.test.mjs"
   },
   "publishConfig": {
     "access": "public",

--- a/scripts/smoke-old-linux.mjs
+++ b/scripts/smoke-old-linux.mjs
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+
+import { spawnSync } from 'node:child_process'
+import path from 'node:path'
+
+const binary = process.argv[2]
+const runtime = process.env.DSH_TUI_CONTAINER_BIN || 'docker'
+
+try {
+  if (!binary) throw new Error('usage: smoke-old-linux.mjs <binary>')
+
+  const mountedBinary = '/usr/local/bin/dsh-tui'
+  const result = spawnSync(runtime, [
+    'run',
+    '--rm',
+    '--platform',
+    'linux/amd64',
+    '--network',
+    'none',
+    '--volume',
+    `${path.resolve(binary)}:${mountedBinary}:ro`,
+    'ubuntu:20.04',
+    mountedBinary,
+    '--help',
+  ], { stdio: 'inherit' })
+
+  if (result.error) throw result.error
+  if (result.status !== 0) throw new Error(`old Linux smoke test exited with status ${result.status}`)
+} catch (error) {
+  process.stderr.write(`${error.message}\n`)
+  process.exitCode = 1
+}

--- a/scripts/smoke-old-linux.test.mjs
+++ b/scripts/smoke-old-linux.test.mjs
@@ -1,0 +1,71 @@
+import assert from 'node:assert/strict'
+import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { spawnSync } from 'node:child_process'
+import test from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+const smoke = path.join(repoRoot, 'scripts', 'smoke-old-linux.mjs')
+
+function fixture() {
+  const root = mkdtempSync(path.join(tmpdir(), 'dsh-tui-old-linux-'))
+  const runtime = path.join(root, 'container-runtime')
+  const binary = path.join(root, 'dsh-tui')
+  const argsLog = path.join(root, 'args.log')
+  writeFileSync(binary, 'fixture')
+  writeFileSync(runtime, `#!/bin/sh
+printf '%s\n' "$@" > "$DSH_TUI_TEST_CONTAINER_ARGS"
+exit "\${DSH_TUI_TEST_CONTAINER_STATUS:-0}"
+`)
+  chmodSync(runtime, 0o755)
+  return { root, runtime, binary, argsLog }
+}
+
+test('runs the packaged binary in an Ubuntu 20.04 amd64 container', (t) => {
+  const item = fixture()
+  t.after(() => rmSync(item.root, { recursive: true, force: true }))
+
+  const result = spawnSync(process.execPath, [smoke, item.binary], {
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      DSH_TUI_CONTAINER_BIN: item.runtime,
+      DSH_TUI_TEST_CONTAINER_ARGS: item.argsLog,
+    },
+  })
+
+  assert.equal(result.status, 0, result.stderr)
+  assert.deepEqual(readFileSync(item.argsLog, 'utf8').trim().split('\n'), [
+    'run',
+    '--rm',
+    '--platform',
+    'linux/amd64',
+    '--network',
+    'none',
+    '--volume',
+    `${path.resolve(item.binary)}:/usr/local/bin/dsh-tui:ro`,
+    'ubuntu:20.04',
+    '/usr/local/bin/dsh-tui',
+    '--help',
+  ])
+})
+
+test('fails when the packaged binary cannot run in old Linux', (t) => {
+  const item = fixture()
+  t.after(() => rmSync(item.root, { recursive: true, force: true }))
+
+  const result = spawnSync(process.execPath, [smoke, item.binary], {
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      DSH_TUI_CONTAINER_BIN: item.runtime,
+      DSH_TUI_TEST_CONTAINER_ARGS: item.argsLog,
+      DSH_TUI_TEST_CONTAINER_STATUS: '126',
+    },
+  })
+
+  assert.equal(result.status, 1)
+  assert.match(result.stderr, /old Linux smoke test exited with status 126/)
+})


### PR DESCRIPTION
## Summary

- run the packaged Linux x64 binary inside an Ubuntu 20.04 amd64 container
- execute `dsh-tui --help` before the artifact is staged for npm packaging
- propagate container execution failures so they block packaging and publishing
- cover the container invocation and failure path with Node tests

## Why

PR #12 switched the Linux artifact to a statically linked musl build and verifies its ELF metadata. This follow-up adds an actual runtime check on an older distribution whose glibc predates the versions reported in issue #10.

The static check and runtime check now both run in the native build job before package assembly.

## Validation

- `npm test --prefix npm` — 120 passed
- workflow YAML parse
- `git diff --check`

The real Ubuntu 20.04 container invocation runs in GitHub Actions because the local Docker daemon is unavailable.
