### PR TITLE
docs: restructure README quick-start, add AI-agent install guide

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -20,6 +20,11 @@
 
 ---
 
+## Sleek and powerful DSH-TUI
+
+- A high-performance interface written in Rust/ratatui.
+- 100% built on official DeepSeek Harness AI capabilities.
+
 `dsh-tui` is a terminal-native ACP client and an extensible terminal on a
 Cordis **client** tree. It presents streamed reasoning, tool calls, subagents,
 token usage, and durable sessions in a Rust/ratatui interface. The recommended
@@ -36,24 +41,33 @@ and iterate on its own terminal capabilities.
 
 ### Recommended: dsh TUI surface plugin
 
-Needs Node.js 18+. The same command installs or upgrades: it creates a missing
-profile, while an existing profile explicitly re-resolves TUI and its dependency
-graph from npm's `latest` tag:
+Needs Node.js 18+. If your system does not have Node.js, visit the
+[Node.js website](https://nodejs.org/) and follow its instructions to install it.
 
-First install the official [DeepSeek Harness](https://github.com/deepseek-ai/dsh):
+Once Node.js is ready, first install the official
+[DeepSeek Harness](https://github.com/deepseek-ai/dsh):
 ```sh
 npm install -g @deepseek-ai/dsh
+```
+
+Then install pnpm:
+```sh
+npm install -g pnpm
 ```
 
 Then install this project as its TUI surface plugin:
 ```sh
 dsh plugin --profile tui add @openma/deepseek-harness-tui@latest
+```
+This command also upgrades the project to the latest version later on; you may
+run it periodically.
+
+Once installed, start by running:
+```sh
 dsh --profile tui
 ```
 
-The Host process mounts the ACP plugin on its Base Cordis tree. A separate TUI
-Client process speaks ACP to it on standard stdin/stdout and never spawns a
-second ACP agent.
+An install guide for AI agents: [docs/agent-setup.md](docs/agent-setup.md)
 
 TUI declares ACP as its own runtime dependency. If the target profile already
 contains another version through the standard ACP bundle, the package manager
@@ -346,8 +360,8 @@ publishing.
 - `scripts/`: local builds, cross-platform package checks, protocol integration
   tests, and asset generation.
 - `assets/`: screenshots, visual assets, and optional pet sprites.
-- `docs/`: architecture, plugin API, `TuiNode` schema, and the migration plan
-  ([index](docs/README.md)).
+- `docs/`: architecture, plugin API, `TuiNode` schema, the migration plan, and
+  the AI-agent install guide ([index](docs/README.md)).
 
 Agent communication is ACP over stdio; Node and Rust use a separate private
 compositor channel. Start with [`src/acp.rs`](src/acp.rs),

--- a/README.md
+++ b/README.md
@@ -20,6 +20,11 @@
 
 ---
 
+## 简洁且强悍的DSH-TUI
+
+* Rust/ratatui 编写的高性能程序界面.
+* 100% 基于Deepseek Harness官方AI能力.
+
 `dsh-tui` 是终端原生 ACP client，也是一套运行在 Cordis **client 树**上的
 可扩展终端。它在 Rust/ratatui 界面里呈现流式推理、工具调用、subagent、token
 用量和持久化会话。推荐 profile 路径把 ACP plugin 挂在 dsh Base Host 树上，并
@@ -33,22 +38,30 @@
 
 ### 推荐：作为 dsh 的 TUI surface plugin
 
-需要 Node.js 18+。同一条命令用于首次安装和以后升级；缺失的 profile 会自动创建，
-已有 profile 会显式按 npm 的 `latest` 标签重新解析 TUI 及其依赖图：
+需要 Node.js 18+。 如果你的系统没有Node.js,那么请访问: [Node.js 官网](https://nodejs.org/) 按指导安装;
 
-首先安装官方的 [DeepSeek Harness](https://github.com/deepseek-ai/dsh)：
+Node.js就绪后; 首先安装官方的 [DeepSeek Harness](https://github.com/deepseek-ai/dsh)：
 ```sh
 npm install -g @deepseek-ai/dsh
 ```
 
-再安装本项目作为它的 TUI surface plugin：
+然后安装pnpm：
+```sh
+npm install -g pnpm
+```
+
+再安装本项目作为它的TUI界面插件：
 ```sh
 dsh plugin --profile tui add @openma/deepseek-harness-tui@latest
+```
+上面这条命令今后同样可以用于更新项目到最新版; 可以定期运行;
+
+安装完成后, 运行就可以开始了:
+```sh
 dsh --profile tui
 ```
 
-Host 进程的 Base Cordis 树挂 ACP plugin；独立 TUI Client 进程通过标准
-stdin/stdout 与它通信。TUI Client 不 spawn 第二个 ACP agent。
+这是给 AI agent 阅读的安装说明：[docs/agent-setup.md](docs/agent-setup.md)
 
 TUI 把 ACP 声明为自身运行时依赖。若目标 profile 已通过标准 ACP bundle 装过另一
 版本，包管理器可以保留两份依赖，但 TUI bundle 会停用该 surface 的旧
@@ -300,7 +313,7 @@ npm/vendor/win32-x64/dsh-tui.exe
 - `npm/`：Cordis client boot、ACP/compositor mux、CLI shim 与原生二进制。
 - `scripts/`：本地构建、跨平台打包校验、协议集成测试与资源生成。
 - `assets/`：截图、主题资源和可选宠物精灵。
-- `docs/`：分层架构、插件 API、`TuiNode` schema 与迁移计划（[索引](docs/README.md)）。
+- `docs/`：分层架构、插件 API、`TuiNode` schema、迁移计划与 AI agent 安装说明（[索引](docs/README.md)）。
 
 Agent 通信是 stdio 上的 ACP；Node 与 Rust 之间另有私有 compositor 通道。
 实现细节可从 [`src/acp.rs`](src/acp.rs)、[`npm/lib/boot.js`](npm/lib/boot.js) 和

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,6 +5,7 @@
 | [architecture.md](architecture.md) · [EN](architecture.en.md) | 分层、TTY 所有权、控制面与绘制面 |
 | [plugins.md](plugins.md) · [EN](plugins.en.md) | 第三方插件可调用的 API；没有列出的能力宿主不提供 |
 | [migration.md](migration.md) · [EN](migration.en.md) | Client 插件能力的迁移状态 |
+| [agent-setup.md](agent-setup.md) | 面向 AI agent / 自动化脚本的安装、验证与升级步骤 |
 | [tui-palette.v0.schema.json](tui-palette.v0.schema.json) | `tuiTheme.register` protocol `0` |
 | [fixtures/demo-skin.v0.json](fixtures/demo-skin.v0.json) | 阶段 1 gallery 配色 `ember` |
 | [tui-node.v0.schema.json](tui-node.v0.schema.json) | `tuiSlots` 节点协议；`chrome.right` 已开放 |

--- a/docs/agent-setup.md
+++ b/docs/agent-setup.md
@@ -1,0 +1,88 @@
+# AI Agent 安装与运行指南（dsh-tui）
+
+本文档面向需要在本机安装、升级或验证 dsh-tui 的 AI agent / 自动化脚本。
+所有命令都是非交互的；请按顺序执行并检查退出码，任何一步失败都应停止并报告
+错误输出，不要继续后续步骤。
+
+## 1. 前置条件
+
+- **Node.js 18+**：执行 `node -v`，输出应为 `v18` 或更高版本。若命令不存在或
+  版本过低，按 [Node.js 官网](https://nodejs.org/) 的指导安装，然后重新打开
+  shell 再验证。
+- **npm**：随 Node.js 提供，用 `npm -v` 验证。
+
+## 2. 安装（推荐：作为 dsh 的 TUI surface plugin）
+
+按顺序执行：
+
+```sh
+# 1) 官方 DeepSeek Harness（提供 dsh 命令）
+npm install -g @deepseek-ai/dsh
+
+# 2) pnpm（README 要求的安装项）
+npm install -g pnpm
+
+# 3) 把 dsh-tui 作为 TUI surface plugin 装入 profile `tui`
+dsh plugin --profile tui add @openma/deepseek-harness-tui@latest
+```
+
+注意：
+
+- 第 3 步在 profile `tui` 不存在时会自动创建；
+- 第 3 步会把 TUI 及其依赖图按 npm `latest` 标签重新解析，因此同一命令也可
+  用于以后升级（见第 4 节）；
+- 不需要手工整理已有的 ACP profile：TUI bundle 会停用目标 profile 中旧的
+  ACP transport/provider 行，只挂载从 TUI 自身依赖图解析出的 ACP plugin。
+
+## 3. 验证
+
+```sh
+dsh-tui --version      # 应输出 dsh-tui <版本号> 并退出 0
+dsh --version          # 应输出版本号
+```
+
+**交互式启动**（需要 TTY，自动化场景慎用）：
+
+```sh
+dsh --profile tui
+```
+
+**无头验证**（不需要 runtime 或 API key，也不占用长期 TTY）：
+
+```sh
+dsh-tui --demo
+```
+
+`--demo` 能正常渲染即安装成功；空闲状态连按 2 次 `ctrl+c` 退出。
+
+进阶检查：`dsh-tui --check-runtime` 会 spawn 并 `initialize` 一个真实 ACP
+agent、打印协商信息后退出（`--demo` 模式下不可用）。
+
+## 4. 升级
+
+```sh
+dsh plugin --profile tui add @openma/deepseek-harness-tui@latest
+```
+
+与安装是同一命令，可定期运行。
+
+## 5. 卸载（可选）
+
+```sh
+dsh plugin --profile tui remove @openma/deepseek-harness-tui
+npm uninstall -g @deepseek-ai/dsh
+```
+
+## 6. 故障排查
+
+| 症状 | 处理 |
+|---|---|
+| `dsh: command not found` | 第 1 步失败，或 npm 全局 bin 不在 PATH；先 `node -v` / `npm -v` 验证 |
+| `spawn dsh-acp ENOENT` | 未安装 `dsh-acp`；可改用 `dsh-tui --agent <cmd>` 指向其它 ACP server |
+| `no native binary for ...` | 安装包不含当前平台；确认装的是最新版本并查看 README 的支持矩阵 |
+
+## 7. 更多资料
+
+- 完整使用说明：根目录 [README.md](../README.md)
+- 插件 API：[docs/plugins.md](plugins.md)
+- 运行架构：[docs/architecture.md](architecture.md)


### PR DESCRIPTION
- README.md: remove misplaced '架构说明' heading and its duplicate architecture paragraph; add sleek-and-powerful intro; add pnpm step and AI-agent install guide link
- README.en.md: mirror the restructure (drop duplicated paragraph, add install-guide link and intro section), update repo map docs/ description
- docs/agent-setup.md: step-by-step install/verify/upgrade guide for AI agents
- docs/README.md: register the new guide in the index