### PR TITLE
feat: publish linux-arm64 native npm package

### DIFF
--- a/.github/workflows/package-npm.yml
+++ b/.github/workflows/package-npm.yml
@@ -74,7 +74,15 @@ jobs:
             rust-target: x86_64-unknown-linux-musl
             platform: linux
             arch: x64
+            smoke-platform: linux/amd64
             binary: target/x86_64-unknown-linux-musl/release/dsh-tui
+          - name: linux-arm64
+            runner: ubuntu-24.04
+            rust-target: aarch64-unknown-linux-musl
+            platform: linux
+            arch: arm64
+            smoke-platform: linux/arm64
+            binary: target/aarch64-unknown-linux-musl/release/dsh-tui
           - name: win32-x64
             runner: windows-2025
             rust-target: x86_64-pc-windows-msvc
@@ -99,6 +107,8 @@ jobs:
         run: node scripts/check-static-elf.mjs "${{ matrix.binary }}"
       - name: Smoke test Linux binary on Ubuntu 20.04
         if: matrix.platform == 'linux'
+        env:
+          DSH_TUI_SMOKE_PLATFORM: ${{ matrix.smoke-platform }}
         run: node scripts/smoke-old-linux.mjs "${{ matrix.binary }}"
       - name: Stage native binary
         run: >-
@@ -129,7 +139,7 @@ jobs:
           path: npm/vendor
           merge-multiple: true
       - name: Restore executable permissions
-        run: chmod +x npm/vendor/darwin-arm64/dsh-tui npm/vendor/darwin-x64/dsh-tui npm/vendor/linux-x64/dsh-tui
+        run: chmod +x npm/vendor/darwin-arm64/dsh-tui npm/vendor/darwin-x64/dsh-tui npm/vendor/linux-x64/dsh-tui npm/vendor/linux-arm64/dsh-tui
       - run: node scripts/package-native.mjs verify --vendor-root npm/vendor
       - name: Pack npm packages
         run: |

--- a/npm/README.md
+++ b/npm/README.md
@@ -97,6 +97,7 @@ credential, session, theme, and demo options.
 | `darwin-arm64` | `vendor/darwin-arm64/dsh-tui` |
 | `darwin-x64` | `vendor/darwin-x64/dsh-tui` |
 | `linux-x64` | `vendor/linux-x64/dsh-tui` |
+| `linux-arm64` | `vendor/linux-arm64/dsh-tui` |
 | `win32-x64` | `vendor/win32-x64/dsh-tui.exe` |
 
 If installation succeeds but launch reports `no native binary for ...`, confirm

--- a/scripts/package-native.mjs
+++ b/scripts/package-native.mjs
@@ -7,6 +7,7 @@ const supported = [
   { platform: 'darwin', arch: 'arm64', file: 'dsh-tui' },
   { platform: 'darwin', arch: 'x64', file: 'dsh-tui' },
   { platform: 'linux', arch: 'x64', file: 'dsh-tui' },
+  { platform: 'linux', arch: 'arm64', file: 'dsh-tui' },
   { platform: 'win32', arch: 'x64', file: 'dsh-tui.exe' },
 ]
 

--- a/scripts/package-native.test.mjs
+++ b/scripts/package-native.test.mjs
@@ -25,6 +25,7 @@ test('stages native binaries under npm platform keys', () => {
     ['darwin', 'arm64', 'darwin-arm64/dsh-tui'],
     ['darwin', 'x64', 'darwin-x64/dsh-tui'],
     ['linux', 'x64', 'linux-x64/dsh-tui'],
+    ['linux', 'arm64', 'linux-arm64/dsh-tui'],
     ['win32', 'x64', 'win32-x64/dsh-tui.exe'],
   ]
 
@@ -54,6 +55,7 @@ test('verifies that a release contains every supported platform', () => {
     ['darwin', 'arm64'],
     ['darwin', 'x64'],
     ['linux', 'x64'],
+    ['linux', 'arm64'],
     ['win32', 'x64'],
   ]) {
     const staged = run([

--- a/scripts/smoke-old-linux.mjs
+++ b/scripts/smoke-old-linux.mjs
@@ -5,6 +5,7 @@ import path from 'node:path'
 
 const binary = process.argv[2]
 const runtime = process.env.DSH_TUI_CONTAINER_BIN || 'docker'
+const platform = process.env.DSH_TUI_SMOKE_PLATFORM || 'linux/amd64'
 
 try {
   if (!binary) throw new Error('usage: smoke-old-linux.mjs <binary>')
@@ -14,7 +15,7 @@ try {
     'run',
     '--rm',
     '--platform',
-    'linux/amd64',
+    platform,
     '--network',
     'none',
     '--volume',

--- a/scripts/smoke-old-linux.test.mjs
+++ b/scripts/smoke-old-linux.test.mjs
@@ -52,6 +52,36 @@ test('runs the packaged binary in an Ubuntu 20.04 amd64 container', (t) => {
   ])
 })
 
+test('runs the packaged binary in an Ubuntu 20.04 arm64 container', (t) => {
+  const item = fixture()
+  t.after(() => rmSync(item.root, { recursive: true, force: true }))
+
+  const result = spawnSync(process.execPath, [smoke, item.binary], {
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      DSH_TUI_CONTAINER_BIN: item.runtime,
+      DSH_TUI_TEST_CONTAINER_ARGS: item.argsLog,
+      DSH_TUI_SMOKE_PLATFORM: 'linux/arm64',
+    },
+  })
+
+  assert.equal(result.status, 0, result.stderr)
+  assert.deepEqual(readFileSync(item.argsLog, 'utf8').trim().split('\n'), [
+    'run',
+    '--rm',
+    '--platform',
+    'linux/arm64',
+    '--network',
+    'none',
+    '--volume',
+    `${path.resolve(item.binary)}:/usr/local/bin/dsh-tui:ro`,
+    'ubuntu:20.04',
+    '/usr/local/bin/dsh-tui',
+    '--help',
+  ])
+})
+
 test('fails when the packaged binary cannot run in old Linux', (t) => {
   const item = fixture()
   t.after(() => rmSync(item.root, { recursive: true, force: true }))


### PR DESCRIPTION
Add linux-arm64 to the supported native targets so build-npm.sh and the package workflow cross-compile aarch64-unknown-linux-musl on ubuntu-24.04 (using musl-tools' aarch64-linux-musl-gcc), stage it under vendor/linux-arm64, and smoke-test it in an Ubuntu 20.04 arm64 container via DSH_TUI_SMOKE_PLATFORM. The package verify step now requires all five platforms.