### PR TITLE
feat: publish linux-arm64 native npm package

### DIFF
--- a/.github/workflows/package-npm.yml
+++ b/.github/workflows/package-npm.yml
@@ -100,23 +100,19 @@ jobs:
       - name: Install musl linker
         if: matrix.platform == 'linux'
         run: sudo apt-get update && sudo apt-get install --yes musl-tools
-      - name: Install aarch64 musl cross toolchain
-        # Ubuntu musl-tools only ships the host (x86_64) musl-gcc wrapper, so
-        # the aarch64 linker must come from the musl.cc prebuilt toolchain.
-        if: matrix.platform == 'linux' && matrix.arch == 'arm64'
-        run: |
-          curl -fsSL -o "$RUNNER_TEMP/aarch64-linux-musl-cross.tgz" https://musl.cc/aarch64-linux-musl-cross.tgz
-          tar xzf "$RUNNER_TEMP/aarch64-linux-musl-cross.tgz" -C "$RUNNER_TEMP"
-          echo "$RUNNER_TEMP/aarch64-linux-musl-cross/bin" >> "$GITHUB_PATH"
       - run: rustup target add ${{ matrix.rust-target }}
       - name: Build
-        # -fno-use-linker-plugin: the musl.cc ld cannot dlopen the LTO plugin
-        # that gcc passes for the project's fat-LTO (lto = true) objects. The
-        # flag only affects this musl target; other matrix entries ignore it.
-        env:
-          CC_aarch64_unknown_linux_musl: aarch64-linux-musl-gcc
-          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_RUSTFLAGS: -C link-arg=-fno-use-linker-plugin
-        run: cargo build --release --locked --target ${{ matrix.rust-target }}
+        # The aarch64 musl target links fully self-contained from the rust
+        # sysroot (bundled crt objects + musl libc.a), and the only cc
+        # dependency (iana-time-zone-haiku) is Haiku-only, so no external
+        # C toolchain is needed: point the arm64 link at the toolchain's
+        # bundled rust-lld. Other matrix entries build their own targets.
+        run: |
+          if [ "${{ matrix.platform }}" = "linux" ] && [ "${{ matrix.arch }}" = "arm64" ]; then
+            HOST="$(rustc -vV | sed -n 's/^host: //p')"
+            export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER="$(rustc --print sysroot)/lib/rustlib/$HOST/bin/rust-lld"
+          fi
+          cargo build --release --locked --target "${{ matrix.rust-target }}"
       - name: Verify Linux binary is statically linked
         if: matrix.platform == 'linux'
         run: node scripts/check-static-elf.mjs "${{ matrix.binary }}"

--- a/.github/workflows/package-npm.yml
+++ b/.github/workflows/package-npm.yml
@@ -74,7 +74,15 @@ jobs:
             rust-target: x86_64-unknown-linux-musl
             platform: linux
             arch: x64
+            smoke-platform: linux/amd64
             binary: target/x86_64-unknown-linux-musl/release/dsh-tui
+          - name: linux-arm64
+            runner: ubuntu-24.04
+            rust-target: aarch64-unknown-linux-musl
+            platform: linux
+            arch: arm64
+            smoke-platform: linux/arm64
+            binary: target/aarch64-unknown-linux-musl/release/dsh-tui
           - name: win32-x64
             runner: windows-2025
             rust-target: x86_64-pc-windows-msvc
@@ -99,6 +107,8 @@ jobs:
         run: node scripts/check-static-elf.mjs "${{ matrix.binary }}"
       - name: Smoke test Linux binary on Ubuntu 20.04
         if: matrix.platform == 'linux'
+        env:
+          DSH_TUI_SMOKE_PLATFORM: ${{ matrix.smoke-platform }}
         run: node scripts/smoke-old-linux.mjs "${{ matrix.binary }}"
       - name: Stage native binary
         run: >-
@@ -129,7 +139,7 @@ jobs:
           path: npm/vendor
           merge-multiple: true
       - name: Restore executable permissions
-        run: chmod +x npm/vendor/darwin-arm64/dsh-tui npm/vendor/darwin-x64/dsh-tui npm/vendor/linux-x64/dsh-tui
+        run: chmod +x npm/vendor/darwin-arm64/dsh-tui npm/vendor/darwin-x64/dsh-tui npm/vendor/linux-x64/dsh-tui npm/vendor/linux-arm64/dsh-tui
       - run: node scripts/package-native.mjs verify --vendor-root npm/vendor
       - name: Pack npm packages
         run: |

--- a/.github/workflows/package-npm.yml
+++ b/.github/workflows/package-npm.yml
@@ -107,6 +107,8 @@ jobs:
         # dependency (iana-time-zone-haiku) is Haiku-only, so no external
         # C toolchain is needed: point the arm64 link at the toolchain's
         # bundled rust-lld. Other matrix entries build their own targets.
+        # shell: bash keeps the POSIX script valid on the Windows runner.
+        shell: bash
         run: |
           if [ "${{ matrix.platform }}" = "linux" ] && [ "${{ matrix.arch }}" = "arm64" ]; then
             HOST="$(rustc -vV | sed -n 's/^host: //p')"
@@ -116,6 +118,10 @@ jobs:
       - name: Verify Linux binary is statically linked
         if: matrix.platform == 'linux'
         run: node scripts/check-static-elf.mjs "${{ matrix.binary }}"
+      - uses: docker/setup-qemu-action@v3
+        # GitHub-hosted runners have no arm64 binfmt by default; QEMU
+        # emulation is required to run the linux/arm64 smoke container.
+        if: matrix.platform == 'linux' && matrix.arch == 'arm64'
       - name: Smoke test Linux binary on Ubuntu 20.04
         if: matrix.platform == 'linux'
         env:

--- a/.github/workflows/package-npm.yml
+++ b/.github/workflows/package-npm.yml
@@ -100,8 +100,23 @@ jobs:
       - name: Install musl linker
         if: matrix.platform == 'linux'
         run: sudo apt-get update && sudo apt-get install --yes musl-tools
+      - name: Install aarch64 musl cross toolchain
+        # Ubuntu musl-tools only ships the host (x86_64) musl-gcc wrapper, so
+        # the aarch64 linker must come from the musl.cc prebuilt toolchain.
+        if: matrix.platform == 'linux' && matrix.arch == 'arm64'
+        run: |
+          curl -fsSL -o "$RUNNER_TEMP/aarch64-linux-musl-cross.tgz" https://musl.cc/aarch64-linux-musl-cross.tgz
+          tar xzf "$RUNNER_TEMP/aarch64-linux-musl-cross.tgz" -C "$RUNNER_TEMP"
+          echo "$RUNNER_TEMP/aarch64-linux-musl-cross/bin" >> "$GITHUB_PATH"
       - run: rustup target add ${{ matrix.rust-target }}
-      - run: cargo build --release --locked --target ${{ matrix.rust-target }}
+      - name: Build
+        # -fno-use-linker-plugin: the musl.cc ld cannot dlopen the LTO plugin
+        # that gcc passes for the project's fat-LTO (lto = true) objects. The
+        # flag only affects this musl target; other matrix entries ignore it.
+        env:
+          CC_aarch64_unknown_linux_musl: aarch64-linux-musl-gcc
+          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_RUSTFLAGS: -C link-arg=-fno-use-linker-plugin
+        run: cargo build --release --locked --target ${{ matrix.rust-target }}
       - name: Verify Linux binary is statically linked
         if: matrix.platform == 'linux'
         run: node scripts/check-static-elf.mjs "${{ matrix.binary }}"

--- a/npm/README.md
+++ b/npm/README.md
@@ -97,6 +97,7 @@ credential, session, theme, and demo options.
 | `darwin-arm64` | `vendor/darwin-arm64/dsh-tui` |
 | `darwin-x64` | `vendor/darwin-x64/dsh-tui` |
 | `linux-x64` | `vendor/linux-x64/dsh-tui` |
+| `linux-arm64` | `vendor/linux-arm64/dsh-tui` |
 | `win32-x64` | `vendor/win32-x64/dsh-tui.exe` |
 
 If installation succeeds but launch reports `no native binary for ...`, confirm

--- a/scripts/package-native.mjs
+++ b/scripts/package-native.mjs
@@ -7,6 +7,7 @@ const supported = [
   { platform: 'darwin', arch: 'arm64', file: 'dsh-tui' },
   { platform: 'darwin', arch: 'x64', file: 'dsh-tui' },
   { platform: 'linux', arch: 'x64', file: 'dsh-tui' },
+  { platform: 'linux', arch: 'arm64', file: 'dsh-tui' },
   { platform: 'win32', arch: 'x64', file: 'dsh-tui.exe' },
 ]
 

--- a/scripts/package-native.test.mjs
+++ b/scripts/package-native.test.mjs
@@ -25,6 +25,7 @@ test('stages native binaries under npm platform keys', () => {
     ['darwin', 'arm64', 'darwin-arm64/dsh-tui'],
     ['darwin', 'x64', 'darwin-x64/dsh-tui'],
     ['linux', 'x64', 'linux-x64/dsh-tui'],
+    ['linux', 'arm64', 'linux-arm64/dsh-tui'],
     ['win32', 'x64', 'win32-x64/dsh-tui.exe'],
   ]
 
@@ -54,6 +55,7 @@ test('verifies that a release contains every supported platform', () => {
     ['darwin', 'arm64'],
     ['darwin', 'x64'],
     ['linux', 'x64'],
+    ['linux', 'arm64'],
     ['win32', 'x64'],
   ]) {
     const staged = run([

--- a/scripts/smoke-old-linux.mjs
+++ b/scripts/smoke-old-linux.mjs
@@ -5,6 +5,7 @@ import path from 'node:path'
 
 const binary = process.argv[2]
 const runtime = process.env.DSH_TUI_CONTAINER_BIN || 'docker'
+const platform = process.env.DSH_TUI_SMOKE_PLATFORM || 'linux/amd64'
 
 try {
   if (!binary) throw new Error('usage: smoke-old-linux.mjs <binary>')
@@ -14,7 +15,7 @@ try {
     'run',
     '--rm',
     '--platform',
-    'linux/amd64',
+    platform,
     '--network',
     'none',
     '--volume',

--- a/scripts/smoke-old-linux.test.mjs
+++ b/scripts/smoke-old-linux.test.mjs
@@ -52,6 +52,36 @@ test('runs the packaged binary in an Ubuntu 20.04 amd64 container', (t) => {
   ])
 })
 
+test('runs the packaged binary in an Ubuntu 20.04 arm64 container', (t) => {
+  const item = fixture()
+  t.after(() => rmSync(item.root, { recursive: true, force: true }))
+
+  const result = spawnSync(process.execPath, [smoke, item.binary], {
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      DSH_TUI_CONTAINER_BIN: item.runtime,
+      DSH_TUI_TEST_CONTAINER_ARGS: item.argsLog,
+      DSH_TUI_SMOKE_PLATFORM: 'linux/arm64',
+    },
+  })
+
+  assert.equal(result.status, 0, result.stderr)
+  assert.deepEqual(readFileSync(item.argsLog, 'utf8').trim().split('\n'), [
+    'run',
+    '--rm',
+    '--platform',
+    'linux/arm64',
+    '--network',
+    'none',
+    '--volume',
+    `${path.resolve(item.binary)}:/usr/local/bin/dsh-tui:ro`,
+    'ubuntu:20.04',
+    '/usr/local/bin/dsh-tui',
+    '--help',
+  ])
+})
+
 test('fails when the packaged binary cannot run in old Linux', (t) => {
   const item = fixture()
   t.after(() => rmSync(item.root, { recursive: true, force: true }))


### PR DESCRIPTION
Adds `linux-arm64` to the supported native targets so the npm package bundles a static aarch64 musl binary alongside the existing five platforms.

## Changes

- **scripts/package-native.mjs**: register `linux-arm64` in the supported target table (runtime lookup in `bin/dsh-tui.js` is already generic over `platform-arch`); `verify` now requires all six platforms.
- **.github/workflows/package-npm.yml**:
  - new `linux-arm64` matrix entry cross-compiles `aarch64-unknown-linux-musl` on `ubuntu-24.04`;
  - links with the toolchain's bundled `rust-lld` — the musl target is effectively pure Rust (the only `cc` dependency, `iana-time-zone-haiku`, is Haiku-only), so it links fully self-contained from the rust sysroot (crt objects + musl `libc.a`). No external C toolchain, no musl.cc download (unreachable from GitHub runners), no LTO-plugin workarounds;
  - smoke-tests the arm64 binary in an Ubuntu 20.04 arm64 container using `docker/setup-qemu-action` (GitHub runners have no arm64 binfmt by default), parameterized via `DSH_TUI_SMOKE_PLATFORM`;
  - `Build` step uses `shell: bash` so the POSIX script stays valid on the Windows runner.
- **scripts/smoke-old-linux.mjs**: container platform overridable via `DSH_TUI_SMOKE_PLATFORM` (default `linux/amd64`, unchanged behavior).
- **scripts/package-native.test.mjs / scripts/smoke-old-linux.test.mjs**: cover the arm64 staging and smoke-test paths.
- **npm/README.md**: add `linux-arm64` to the supported platforms table.

## Verification

- Full workflow green on the fork (all six native matrix entries, including the new arm64 build + QEMU smoke test).
- Locally reproduced the exact CI build commands on an aarch64 host: build, `check-static-elf` (statically linked, no INTERP), and run (`dsh-tui 0.2.5`).