### PR TITLE
feat: clearer /resume picker — session titles, fixed CJK-aware columns, ACP enrichment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ All notable changes to this project are documented here. The project follows
 
 ### Changed
 
+- `/resume` picker rows now lead with the session's human handle — the
+  harness-generated `session/title` (falling back to the first real prompt)
+  — instead of the full UUID; the meta column carries the 8-char id prefix,
+  relative age and turn count, and the picker title shows how many sessions
+  are listed. Label and id columns use fixed display widths (CJK-aware) so
+  rows align vertically. ACP `session/list` rows are enriched with the same
+  local summaries (turns, age, prompt) when the session log is on disk.
 - Markdown rendering now runs on `tui-markdown` (pulldown-cmark) instead of a
   hand-rolled line scanner: proper CommonMark + GFM parsing (nested lists,
   reference links, footnotes, task lists, definition lists, math delimiters)

--- a/src/app.rs
+++ b/src/app.rs
@@ -25,7 +25,7 @@ use crate::input::Action;
 use crate::locale::{Locale, LocaleSettings};
 use crate::runtime::RuntimeConfig;
 use crate::theme::Theme;
-use crate::transcript::{NoticeLevel, Transcript};
+use crate::transcript::{clamp_str, NoticeLevel, Transcript};
 
 pub const SPINNER: [char; 10] = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
 
@@ -501,6 +501,11 @@ pub struct PickerItem {
     pub provider: Option<String>,
 }
 
+/// Fixed display width of the picker label column — rows pad/truncate to
+/// this so the meta column lines up (char-based padding would misalign
+/// CJK labels).
+pub(crate) const PICKER_LABEL_COL: usize = 30;
+
 /// One `/` menu entry: a builtin [`SlashCommand`] or a host skill (plugin
 /// mode). Builtins win a name collision — the command namespace is closed
 /// and resolved client-side before a line ever becomes a prompt; skill
@@ -797,6 +802,54 @@ fn token_spans_in(
     }
     spans.sort_unstable();
     spans
+}
+
+/// 8-char id prefix — unique enough in the picker while staying readable;
+/// `/resume <prefix>` still matches against the full id.
+fn short_id(id: &str) -> String {
+    id.chars().take(8).collect()
+}
+
+/// One `/resume` row. The label is the session's human handle — the
+/// harness title, else the first real prompt; the meta line carries the id
+/// prefix plus age · turns (local logs) or the updated date (ACP rows with
+/// no local log).
+fn session_picker_row(
+    id: &str,
+    title: Option<&str>,
+    local: Option<&crate::sessions::SessionSummary>,
+    updated_at: Option<&str>,
+) -> PickerItem {
+    let short = short_id(id);
+    let label = title
+        .map(str::trim)
+        .filter(|t| !t.is_empty())
+        .map(str::to_string)
+        .or_else(|| local.map(|s| s.preview.clone()))
+        .filter(|s| !s.is_empty())
+        .map(|s| clamp_str(&s, PICKER_LABEL_COL))
+        .unwrap_or_else(|| short.clone());
+    let meta = match local {
+        Some(s) => format!(
+            "{short:<8} · {} · {} turn{}",
+            crate::sessions::age_label(s.modified),
+            s.turns,
+            if s.turns == 1 { "" } else { "s" },
+        ),
+        None => format!(
+            "{short:<8} · {}",
+            updated_at
+                .and_then(|u| u.get(..10))
+                .filter(|d| !d.is_empty())
+                .unwrap_or("?"),
+        ),
+    };
+    PickerItem {
+        id: id.to_string(),
+        label,
+        meta,
+        provider: None,
+    }
 }
 
 fn unique_session_list_match(sessions: &[SessionListItem], prefix: &str) -> Result<String, String> {
@@ -2778,20 +2831,9 @@ impl App {
             );
             return;
         }
-        let items = sessions
+        let items: Vec<PickerItem> = sessions
             .iter()
-            .map(|s| PickerItem {
-                id: s.id.clone(),
-                label: s.id.clone(),
-                meta: format!(
-                    "{} · {} turn{} · {}",
-                    crate::sessions::age_label(s.modified),
-                    s.turns,
-                    if s.turns == 1 { "" } else { "s" },
-                    s.preview
-                ),
-                provider: None,
-            })
+            .map(|s| session_picker_row(&s.id, s.title.as_deref(), Some(s), None))
             .collect();
         self.resume_candidates = sessions;
         self.picker = Some(Picker {
@@ -2799,9 +2841,10 @@ impl App {
             title: self
                 .locale
                 .tr(
-                    " resume session · enter select · esc close ",
-                    " 恢复会话 · enter 选择 · esc 关闭 ",
+                    " resume session · {n} sessions · enter select · esc close ",
+                    " 恢复会话 · {n} 个会话 · enter 选择 · esc 关闭 ",
                 )
+                .replace("{n}", &items.len().to_string())
                 .into(),
             sel: 0,
             items,
@@ -2982,17 +3025,27 @@ impl App {
             );
             return;
         }
-        let items = sessions
+        // Local JSONL summaries (turns, age, prompt preview) for the same
+        // workspace; the local log is the only source for those fields.
+        let local_by_id: std::collections::HashMap<String, crate::sessions::SessionSummary> =
+            crate::sessions::list_sessions(
+                &self.cfg.session_root,
+                &self.cfg.workspace,
+                &self.session_id,
+            )
+            .into_iter()
+            .map(|s| (s.id.clone(), s))
+            .collect();
+        let items: Vec<PickerItem> = sessions
             .iter()
-            .map(|s| PickerItem {
-                id: s.id.clone(),
-                label: s
+            .map(|s| {
+                let local = local_by_id.get(&s.id);
+                let title = s
                     .title
                     .clone()
                     .filter(|t| !t.is_empty())
-                    .unwrap_or_else(|| s.id.clone()),
-                meta: s.updated_at.clone().unwrap_or_default(),
-                provider: None,
+                    .or_else(|| local.and_then(|l| l.title.clone()));
+                session_picker_row(&s.id, title.as_deref(), local, s.updated_at.as_deref())
             })
             .collect();
         self.resume_via_acp = true;
@@ -3001,9 +3054,10 @@ impl App {
             title: self
                 .locale
                 .tr(
-                    " resume session · enter select · esc close ",
-                    " 恢复会话 · enter 选择 · esc 关闭 ",
+                    " resume session · {n} sessions · enter select · esc close ",
+                    " 恢复会话 · {n} 个会话 · enter 选择 · esc 关闭 ",
                 )
+                .replace("{n}", &items.len().to_string())
                 .into(),
             sel: 0,
             items,
@@ -4474,9 +4528,10 @@ mod resume_tests {
             r#"{"type":"permission/preset","seq":0,"data":{"preset":"workspace-write"}}"#.into(),
             r#"{"type":"turn/start","seq":1,"data":{"turn":1}}"#.into(),
             r#"{"type":"user/message","seq":2,"data":{"content":[{"text":"修复失败的测试","type":"text"}],"source":{"kind":"user"},"role":"user","id":"m1"}}"#.into(),
-            r#"{"type":"assistant/chunk","seq":3,"data":{"chunk":{"type":"usage","usage":{"inputTokens":10,"outputTokens":5}}}}"#.into(),
-            r#"{"type":"assistant/message","seq":4,"data":{"message":{"content":[{"type":"text","text":"tests are green now"}],"source":{"model":"deepseek-v4-flash"}}}}"#.into(),
-            r#"{"type":"turn/end","seq":5,"data":{"reason":"completed"}}"#.into(),
+            r#"{"type":"session/title","seq":3,"data":{"title":"fix failing tests","source":{"kind":"provider","provider":"session-title-first-prompt-llm"}}}"#.into(),
+            r#"{"type":"assistant/chunk","seq":4,"data":{"chunk":{"type":"usage","usage":{"inputTokens":10,"outputTokens":5}}}}"#.into(),
+            r#"{"type":"assistant/message","seq":5,"data":{"message":{"content":[{"type":"text","text":"tests are green now"}],"source":{"model":"deepseek-v4-flash"}}}}"#.into(),
+            r#"{"type":"turn/end","seq":6,"data":{"reason":"completed"}}"#.into(),
         ];
         std::fs::write(dir.join("session.jsonl"), lines.join("\n")).unwrap();
     }
@@ -4569,12 +4624,28 @@ mod resume_tests {
         let picker = app.picker.as_ref().expect("picker opens");
         assert!(matches!(picker.kind, PickerKind::Session));
         assert_eq!(picker.items[0].id, "dsh-alpha");
+        // The human handle is the label; the meta carries short id, age, turns.
+        assert_eq!(picker.items[0].label, "fix failing tests", "title as label");
         assert!(
             picker.items[0].meta.contains("1 turn"),
             "{}",
             picker.items[0].meta
         );
-        assert!(picker.items[0].meta.contains("修复失败的测试"));
+        assert!(
+            picker.items[0].meta.contains("dsh-alp"),
+            "short id in meta: {}",
+            picker.items[0].meta
+        );
+        assert!(
+            !picker.items[0].meta.contains("修复失败的测试"),
+            "preview moved out of meta: {}",
+            picker.items[0].meta
+        );
+        assert!(
+            picker.title.contains('1'),
+            "picker title counts sessions: {}",
+            picker.title
+        );
         app.picker = None;
 
         // unique prefix resolves; unknown id warns and keeps the session
@@ -5485,6 +5556,57 @@ mod mode_tests {
         );
         assert_eq!(app.session_id, "s-old");
         assert!(app.picker.is_none());
+    }
+
+    #[test]
+    fn acp_session_list_enriches_rows_with_local_summaries() {
+        let (mut app, ctl, _rx) = test_app();
+        app.demo = false;
+        app.load_session = true;
+        // A local JSONL log for the same workspace (slug of "/tmp").
+        let slug = crate::sessions::workspace_slug("/tmp");
+        let dir = std::path::Path::new(&app.cfg.session_root)
+            .join(&slug)
+            .join("s-local");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(
+            dir.join("session.jsonl"),
+            [
+                r#"{"type":"session","version":0,"id":"s-local","createdAt":1,"cwd":"/tmp"}"#,
+                r#"{"type":"turn/start","seq":1,"data":{"turn":1}}"#,
+                r#"{"type":"user/message","seq":2,"data":{"content":[{"text":"local prompt","type":"text"}],"source":{"kind":"user"},"role":"user","id":"m1"}}"#,
+                r#"{"type":"turn/start","seq":3,"data":{"turn":2}}"#,
+            ]
+            .join("\n"),
+        )
+        .unwrap();
+
+        app.handle(
+            AppEvent::Ctl(CtlEvent::SessionList {
+                sessions: vec![SessionListItem {
+                    id: "s-local".into(),
+                    title: None,
+                    updated_at: None,
+                }],
+                prefix: None,
+            }),
+            &ctl,
+        );
+        let picker = app.picker.as_ref().expect("picker");
+        assert_eq!(
+            picker.items[0].label, "local prompt",
+            "local preview becomes the label"
+        );
+        assert!(
+            picker.items[0].meta.contains("2 turns"),
+            "{}",
+            picker.items[0].meta
+        );
+        assert!(
+            picker.items[0].meta.contains("s-local"),
+            "short id in meta: {}",
+            picker.items[0].meta
+        );
     }
 
     #[test]

--- a/src/sessions.rs
+++ b/src/sessions.rs
@@ -27,6 +27,10 @@ pub struct SessionSummary {
     pub turns: usize,
     /// First real user prompt (truncated) — the session's human handle.
     pub preview: String,
+    /// Harness-generated title from `session/title` events, when present.
+    /// The LLM ("provider" source) title wins over the truncated-prompt
+    /// "fallback" stub.
+    pub title: Option<String>,
 }
 
 /// `/Users/x/proj` → `--Users-x-proj--` (the harness's directory slug).
@@ -173,6 +177,29 @@ fn summarize(file: &Path) -> Option<SessionSummary> {
             p
         })
         .unwrap_or_default();
+    // The harness titles sessions asynchronously: a "fallback" stub derived
+    // from the first prompt arrives first, the LLM-generated "provider"
+    // title later. Keep the provider title when it exists.
+    let mut title: Option<String> = None;
+    let mut provider_title: Option<String> = None;
+    for ev in &events {
+        if ev.get("type").and_then(Value::as_str) != Some("session/title") {
+            continue;
+        }
+        let Some(t) = ev.pointer("/data/title").and_then(Value::as_str) else {
+            continue;
+        };
+        let t = t.trim().to_string();
+        if t.is_empty() {
+            continue;
+        }
+        if ev.pointer("/data/source/kind").and_then(Value::as_str) == Some("provider") {
+            provider_title = Some(t);
+        } else {
+            title = Some(t);
+        }
+    }
+    let title = provider_title.or(title);
     let modified = std::fs::metadata(file)
         .and_then(|m| m.modified())
         .unwrap_or(SystemTime::UNIX_EPOCH);
@@ -182,6 +209,7 @@ fn summarize(file: &Path) -> Option<SessionSummary> {
         modified,
         turns,
         preview,
+        title,
     })
 }
 
@@ -221,6 +249,12 @@ mod tests {
         )
     }
 
+    fn title_event(kind: &str, text: &str) -> String {
+        format!(
+            r#"{{"type":"session/title","seq":8,"data":{{"title":"{text}","source":{{"kind":"{kind}"}}}}}}"#
+        )
+    }
+
     #[test]
     fn slug_matches_observed_host_layout() {
         assert_eq!(
@@ -250,6 +284,8 @@ mod tests {
                 header("dsh-new"),
                 r#"{"type":"turn/start","seq":1,"data":{"turn":1}}"#.into(),
                 user_msg("修复失败的测试 with a long tail that should be truncated away entirely"),
+                title_event("fallback", "修复失败的测试"),
+                title_event("provider", "fix failing tests"),
                 r#"{"type":"turn/start","seq":9,"data":{"turn":2}}"#.into(),
             ],
         );
@@ -261,6 +297,12 @@ mod tests {
         assert_eq!(sessions[0].turns, 2);
         assert!(sessions[0].preview.starts_with("修复失败的测试"));
         assert!(sessions[0].preview.ends_with('…'), "long preview truncated");
+        assert_eq!(
+            sessions[0].title.as_deref(),
+            Some("fix failing tests"),
+            "provider title beats the fallback stub"
+        );
+        assert_eq!(sessions[1].title, None);
         let _ = std::fs::remove_dir_all(&tmp);
     }
 
@@ -273,6 +315,50 @@ mod tests {
         assert_eq!(user_text(&injected), None);
         let real: Value = serde_json::from_str(&user_msg("hi")).unwrap();
         assert_eq!(user_text(&real).as_deref(), Some("hi"));
+    }
+
+    #[test]
+    fn title_falls_back_to_non_provider_and_skips_blanks() {
+        let tmp = std::env::temp_dir().join(format!("dsh-title-test-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&tmp);
+        let slug = workspace_slug("/w");
+        write_session(
+            &tmp,
+            &slug,
+            "dsh-fb",
+            &[
+                header("dsh-fb"),
+                user_msg("hello"),
+                title_event("fallback", "hello world"),
+            ],
+        );
+        write_session(
+            &tmp,
+            &slug,
+            "dsh-blank",
+            &[
+                header("dsh-blank"),
+                user_msg("hi"),
+                title_event("fallback", "  "),
+            ],
+        );
+        let sessions = list_sessions(tmp.to_str().unwrap(), "/w", "other");
+        assert_eq!(
+            sessions
+                .iter()
+                .find(|s| s.id == "dsh-fb")
+                .unwrap()
+                .title
+                .as_deref(),
+            Some("hello world"),
+            "fallback title used when no provider title exists"
+        );
+        assert_eq!(
+            sessions.iter().find(|s| s.id == "dsh-blank").unwrap().title,
+            None,
+            "blank titles are dropped"
+        );
+        let _ = std::fs::remove_dir_all(&tmp);
     }
 
     /// Appended session logs are concatenated zstd frames — every frame

--- a/src/transcript.rs
+++ b/src/transcript.rs
@@ -1266,7 +1266,7 @@ fn one_line(s: &str) -> String {
     clamp_str(&s.replace('\n', " ⏎ "), 120)
 }
 
-fn clamp_str(s: &str, max: usize) -> String {
+pub(crate) fn clamp_str(s: &str, max: usize) -> String {
     if max == 0 {
         return String::new();
     }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1495,6 +1495,17 @@ fn pad_or_ellipsize(s: &str, w: usize) -> String {
     format!("{out}{}", " ".repeat(w.saturating_sub(ow)))
 }
 
+/// Left-pad to a fixed display width so picker columns line up
+/// (`{:<n}` pads by chars, which misaligns CJK labels).
+fn pad_to_width(s: &str, width: usize) -> String {
+    let w = UnicodeWidthStr::width(s);
+    if w >= width {
+        s.to_string()
+    } else {
+        format!("{s}{}", " ".repeat(width - w))
+    }
+}
+
 fn draw_model_picker(f: &mut Frame, app: &App, screen: Rect) {
     let Some(picker) = &app.picker else {
         return;
@@ -1527,7 +1538,7 @@ fn draw_model_picker(f: &mut Frame, app: &App, screen: Rect) {
         .iter()
         .map(|item| {
             let label_w = item.label.width() + if is_current(item) { 2 } else { 0 };
-            2 + label_w.max(24) + item.meta.width()
+            2 + label_w.max(crate::app::PICKER_LABEL_COL) + item.meta.width()
         })
         .max()
         .unwrap_or(0) as u16;
@@ -1557,7 +1568,7 @@ fn draw_model_picker(f: &mut Frame, app: &App, screen: Rect) {
         };
         let mut spans = vec![
             Span::styled(marker.to_string(), Style::default().fg(theme.brand)),
-            Span::styled(format!("{label:<24}"), style),
+            Span::styled(pad_to_width(&label, crate::app::PICKER_LABEL_COL), style),
         ];
         if !item.meta.is_empty() {
             spans.push(Span::styled(
@@ -2513,6 +2524,58 @@ mod tests {
         assert!(
             frame.contains("bash + str_replace_editor"),
             "descriptions visible\n{frame}"
+        );
+    }
+
+    #[test]
+    fn session_picker_rows_align_label_and_meta_columns() {
+        use crate::app::{Picker, PickerItem, PickerKind, PICKER_LABEL_COL};
+        let mut app = test_app();
+        app.show_banner = false;
+        app.picker = Some(Picker {
+            kind: PickerKind::Session,
+            title: " resume session · 2 sessions · enter select · esc close ".into(),
+            sel: 0,
+            items: vec![
+                PickerItem {
+                    id: "276b7574-b12c-488e-958b-f9673b67fba9".into(),
+                    label: "查看session历史命令的可行性".into(),
+                    meta: "276b7574 · 2h · 3 turns".into(),
+                    provider: None,
+                },
+                PickerItem {
+                    id: "dsh-alp".into(),
+                    label: "fix failing tests".into(),
+                    meta: "dsh-alp  · just now · 1 turn".into(),
+                    provider: None,
+                },
+            ],
+        });
+        let frame = dump_frame(&mut app, 100, 30);
+        let ascii_row = frame
+            .lines()
+            .find(|l| l.contains("fix failing tests"))
+            .expect("ascii row");
+        // Wide chars dump as char + continuation cell, so locate the CJK
+        // row by its meta instead of the raw label.
+        let cjk_row = frame
+            .lines()
+            .find(|l| l.contains("276b7574 · 2h"))
+            .unwrap_or_else(|| panic!("cjk row missing:\n{frame}"));
+        // Dump cells contribute exactly one char each, so the column of a
+        // marker is the char count before its byte offset (`find` alone
+        // returns byte indices, which differ for multi-byte CJK labels).
+        let meta_col = |row: &str| row.find('·').map(|i| row[..i].chars().count()).unwrap_or(0);
+        assert_eq!(
+            meta_col(ascii_row),
+            meta_col(cjk_row),
+            "meta column lines up:\n{ascii_row}\n{cjk_row}\ncols: {} vs {}",
+            meta_col(ascii_row),
+            meta_col(cjk_row),
+        );
+        assert!(
+            ascii_row.chars().count() >= 2 + PICKER_LABEL_COL + 8,
+            "label column padded to {PICKER_LABEL_COL}"
         );
     }
 


### PR DESCRIPTION
## What

Makes the `/resume` session picker much easier to scan:

- **Rows lead with a human handle** instead of the full UUID: the harness-generated `session/title` (LLM "provider" title preferred over the "fallback" stub), falling back to the first real user prompt, then the short id.
- **Fixed-width, CJK-aware columns**: label column is padded/truncated to 30 display columns (char-based padding previously misaligned Chinese labels), and the id prefix is padded to 8, so the `id · age · turns` meta column lines up vertically across all rows.
- **Picker title shows the session count** (`resume session · 27 sessions · …`).
- **ACP `session/list` rows enriched from local JSONL**: the ACP path only returns `id/title/updated_at`, so rows now merge in turns, relative age and prompt preview from the local session log when available (fallback: id prefix + updated date).

## Why

The old rows showed a 36-char UUID as the label with the preview buried at the end of the meta line, and CJK labels pushed the meta column out of alignment. Users could not tell sessions apart at a glance.

## Before / After

```
▸ 276b7574-b12c-488e-958b-f9673b67fba9   just now · 4 turns · 研究一下是否可以做一个 查看
▸ 5ba1eeaf-d015-4edb-9c9e-c05a2e0ca6f5   52m · 2 turns · Shell命令输出为什么没有颜色
```

```
▸ 查看session历史命令的可行性    276b7574 · just now · 4 turns
▸ Shell命令输出为什么没有颜色     5ba1eeaf · 52m · 2 turns
```

## Tests

- `sessions.rs`: title extraction (provider > fallback, blank titles dropped) — 7 tests pass
- `app.rs`: picker rows (title as label, short id + turns in meta), ACP enrichment — resume tests pass
- `ui.rs`: new render test asserting the meta column lines up for ASCII and CJK labels
- Full suite: 343 passed

## Notes

- `/resume <prefix>` still matches against the full id, so the 8-char prefix shown in the picker is directly usable.
- No ACP protocol changes; the local JSONL remains the only source for turns/preview.
