### PR TITLE
feat: /keys derives from the keymap table, rendered as markdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ All notable changes to this project are documented here. The project follows
 - Every picker (`/resume`, model, mode, theme, permission, subagent, auth,
   plugin) now scrolls when the rows overflow the terminal: the visible
   window follows the selection instead of clipping the tail out of reach,
-  and a scrollbar appears on the popup's right edge. `page up`/`page down`
+  and an inline scrollbar appears in a gutter column inside the popup's
+  right edge, leaving the rounded border intact. `page up`/`page down`
   jump a screenful and `home`/`end` pin to the first/last row; `↑`/`↓`
   keep wrapping. The selected row is now highlighted across its full width
   (soft chip background behind marker, label, meta and the row tail — the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,18 @@ All notable changes to this project are documented here. The project follows
   binary tied to the Ubuntu 24.04 glibc version. Release CI verifies the ELF
   artifact has no dynamic program interpreter and runs it on Ubuntu 20.04
   before packaging it.
+- Every picker (`/resume`, model, mode, theme, permission, subagent, auth,
+  plugin) now scrolls when the rows overflow the terminal: the visible
+  window follows the selection instead of clipping the tail out of reach,
+  and a scrollbar appears on the popup's right edge. `page up`/`page down`
+  jump a screenful and `home`/`end` pin to the first/last row; `↑`/`↓`
+  keep wrapping. The selected row is now highlighted across its full width
+  (soft chip background behind marker, label, meta and the row tail — the
+  meta text steps up from caption gray on the highlighted row) instead of
+  only the label column. The scrolling viewport now comes from
+  `tui-widget-list` (the one new crate; it shares ratatui's
+  `ratatui-core`/`ratatui-widgets` crates, so there is no duplicate widget
+  tree).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,19 @@ All notable changes to this project are documented here. The project follows
 
 ### Changed
 
+- `/keys` is no longer a hand-written text wall: the shortcut map is now
+  derived from the keymap table (`src/input/keymap.rs`) and rendered as
+  markdown through the transcript's markdown pipeline — one GFM
+  box-drawing table per group (`send · interrupt`, `scroll · navigate`,
+  `edit · readline`, `app shortcuts`, `mouse`) with `[empty]`/`[typing]`
+  context tags for dual-use keys and platform-appropriate chord spellings
+  (⌘/⌥ vs ctrl). Notices gained a markdown render path (`/keys` is the
+  first consumer); tables truncate with an ellipsis on narrow terminals
+  instead of breaking mid-line. Anti-drift tests assert every `Action` is
+  documented and that every displayed chord resolves back to its action
+  through `classify()`; previously undocumented bindings (`ctrl+q`,
+  `shift+enter`, `shift+tab`, `ctrl+v`, …) are now listed. `/help` stays
+  the command overview; `/keys` is the complete key map.
 - `/resume` picker rows now lead with the session's human handle — the
   harness-generated `session/title` (falling back to the first real prompt)
   — instead of the full UUID; the meta column carries the 8-char id prefix,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -539,6 +539,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tui-markdown",
+ "tui-widget-list",
  "unicode-width",
 ]
 
@@ -2527,6 +2528,16 @@ dependencies = [
  "ratatui-core",
  "rstest",
  "tracing",
+]
+
+[[package]]
+name = "tui-widget-list"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39fc4e2d4f0673ad55213e1db3203b2f5962d8e99acbc54faa59318c435b010a"
+dependencies = [
+ "ratatui-core",
+ "ratatui-widgets",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ serde_json = "1"
 ruzstd = "0.8"
 unicode-width = "0.2"
 tui-markdown = { version = "0.3.9", default-features = false }
+tui-widget-list = "0.15"
 agent-client-protocol = { version = "2.0.0", features = ["unstable_auth_methods", "unstable_elicitation", "unstable_end_turn_token_usage"] }
 tokio = { version = "1.53.1", features = ["rt-multi-thread", "macros", "io-util", "fs", "net", "time", "sync"] }
 tokio-util = { version = "0.7.19", features = ["compat"] }

--- a/scripts/devlocalinstall.sh
+++ b/scripts/devlocalinstall.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+# 1. Build the npm tarball (cargo release build + npm pack -> dist/)
+./scripts/build-npm.sh
+
+# 2. Pick the newest tarball in dist/
+LATEST="$(ls -1t dist/openma-deepseek-harness-tui-*.tgz | head -n 1)"
+echo "using tarball: $LATEST"
+
+# 3. Install the freshly built plugin into the tui profile.
+#    pnpm re-installs the tarball when its content changes (integrity check);
+#    clearing node_modules + lockfile below is a belt-and-braces force step.
+#    Deliberately NOT wiping the whole profile dir, so the user's
+#    cordis.patch.yml layer and any other installed plugins survive.
+rm -rf ~/.dsh/profiles/tui/node_modules ~/.dsh/profiles/tui/pnpm-lock.yaml
+dsh plugin --profile tui add "$PWD/$LATEST"
+
+echo "installed $LATEST into profile tui"

--- a/src/app.rs
+++ b/src/app.rs
@@ -3904,54 +3904,11 @@ usage (incl. cache hits), and the turn end reason.";
     }
 
     fn push_keys(&mut self) {
-        if self.locale == Locale::Zh {
-            let os = if cfg!(target_os = "macos") {
-                "\
-  macOS：⌘←/⌘→ 行首/行尾 · ⌥←/⌥→ 按词移动 · ⌘⌫ 删除到行首 · ⌥⌫ 删除前一词
-         ⌘↑/⌘↓ 到对话顶部/底部；所有终端均读取物理 ⌘/⌥ 状态"
-            } else {
-                "\
-  Linux/Windows：ctrl+←/→ 按词移动 · ctrl+⌫ 或 alt+⌫ 删除前一词"
-            };
-            let text = format!(
-                "\
-快捷键
-  enter 发送 · ctrl+x 立即发送 · esc 取消 · ctrl+c 清草稿/连按退出
-  空输入时 ↑ 调历史 · tab 补全 / 命令
-  option+a 切 Agent · ctrl+p 模型 · ctrl+t 主题 · ctrl+o 展开 · ctrl+l 清屏 · ctrl+. 快捷键
-  pgup/pgdn 翻页 · home/end 顶部/底部 · 空输入时 ctrl+u/ctrl+d 半页
-  readline：home/ctrl+a 行首 · end/ctrl+e 行尾 · ctrl+b/ctrl+f 移动 · ctrl+k/ctrl+u 删除
-            ctrl+w 删除前一词 · 输入时 ctrl+d 向前删除
-{os}
-  点击工具展开/折叠 · 滚轮滚动对话
-  拖动选择并复制 · 双击复制单词 · shift+拖动使用终端原生选择"
-            );
-            self.transcript.push_notice(NoticeLevel::Info, text);
-            return;
-        }
-        let os = if cfg!(target_os = "macos") {
-            "\
-  macOS: ⌘←/⌘→ line ends · ⌥←/⌥→ word hops · ⌘⌫ kill to start · ⌥⌫ word back
-         ⌘↑/⌘↓ transcript top/tail — physical ⌘/⌥ are read natively (CG probe),
-         so these work in every terminal; kitty-keyboard · esc-b/f also mapped"
-        } else {
-            "\
-  linux/windows: ctrl+←/→ word hops · ctrl+⌫ or alt+⌫ deletes a word back"
-        };
-        let text = format!(
-            "\
-keys — grok-build homage set
-  enter send · ctrl+x send-now · esc interrupts · ctrl+c clears / 2× quits
-  ↑ history (empty prompt) · tab completes /commands
-  option+a cycle agent · ctrl+p model picker · ctrl+t theme · ctrl+o expand · ctrl+l clear · ctrl+. keys
-  pgup/pgdn page · home/end top/tail · ctrl+u/ctrl+d half-page (empty prompt)
-  readline: home/ctrl+a line start · end/ctrl+e line end · ctrl+b/ctrl+f move · ctrl+k/ctrl+u kill
-            ctrl+w word back · ctrl+d delete forward (while typing)
-{os}
-  click tool expands/collapses · wheel scrolls the conversation
-  drag select-copies · 2×click word-copies · shift+drag native select"
+        let text = crate::input::keymap::keys_markdown(
+            self.locale == Locale::Zh,
+            cfg!(target_os = "macos"),
         );
-        self.transcript.push_notice(NoticeLevel::Info, text);
+        self.transcript.push_markdown(text);
     }
 
     fn push_session_info(&mut self) {
@@ -4573,6 +4530,34 @@ mod resume_tests {
         assert!(
             text.contains("resumed dsh-past"),
             "resume notice shown:\n{text}"
+        );
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn keys_slash_pushes_the_markdown_shortcut_table() {
+        let root = tmp_root("keys");
+        let (mut app, ctl) = test_app_with_root(root.to_str().unwrap(), "/w");
+
+        app.run_slash("keys", "", &ctl);
+
+        let text = app
+            .transcript
+            .lines(&Theme::dark(), 80, ' ')
+            .iter()
+            .flat_map(|l| l.spans.iter().map(|s| s.content.to_string()))
+            .collect::<String>();
+        assert!(text.contains("keys — shortcut map"), "/keys title:\n{text}");
+        assert!(text.contains("ctrl+q"), "quit binding missing:\n{text}");
+        assert!(
+            text.contains("shift+tab") && text.contains("permission"),
+            "permission binding missing:\n{text}"
+        );
+        // Markdown tables paint box-drawing frames through the transcript.
+        assert!(text.contains('┌') && text.contains('│'), "no table frame:\n{text}");
+        assert!(
+            !text.contains("· keys —"),
+            "keys must not render as a plain notice:\n{text}"
         );
         let _ = std::fs::remove_dir_all(&root);
     }

--- a/src/app.rs
+++ b/src/app.rs
@@ -561,7 +561,11 @@ pub struct SliderOverlay {
 #[derive(Clone, serde::Deserialize)]
 pub struct SliderMark {
     pub value: f64,
+    /// Optional host-side mark identity. Parsed for protocol compatibility;
+    /// the client renders by value/label and reports the numeric value back,
+    /// so the id is not consumed client-side yet.
     #[serde(default)]
+    #[allow(dead_code)]
     pub id: Option<String>,
     pub label: String,
 }
@@ -678,6 +682,9 @@ pub struct App {
     session_title: Option<String>,
     pub slash_sel: usize,
     pub picker: Option<Picker>,
+    /// Rows the open picker actually shows (`h - border`), recorded by
+    /// `ui::draw_model_picker` — the page size for picker PageUp/PageDown.
+    pub picker_page_rows: usize,
     /// ACP tool permission ask (separate from `/permission` session modes).
     pub permission_ask: Option<PermissionAskOverlay>,
     /// Standard ACP form elicitation, above permission and picker overlays.
@@ -996,6 +1003,7 @@ impl App {
             session_title: None,
             slash_sel: 0,
             picker: None,
+            picker_page_rows: 0,
             permission_ask: None,
             elicitation_ask: None,
             slider_overlay: None,
@@ -2608,10 +2616,17 @@ impl App {
             return;
         };
         let n = picker.items.len().max(1);
+        // Page keys jump a screenful of the open popup (rows recorded by the
+        // draw pass); they never wrap, unlike ↑/↓.
+        let page = self.picker_page_rows.max(1);
         match key.code {
             KeyCode::Esc => self.picker = None,
             KeyCode::Up => picker.sel = picker.sel.checked_sub(1).unwrap_or(n - 1),
             KeyCode::Down => picker.sel = (picker.sel + 1) % n,
+            KeyCode::PageUp => picker.sel = picker.sel.saturating_sub(page),
+            KeyCode::PageDown => picker.sel = picker.sel.saturating_add(page).min(n - 1),
+            KeyCode::Home => picker.sel = 0,
+            KeyCode::End => picker.sel = n - 1,
             KeyCode::Enter => {
                 let Some(item) = picker.items.get(picker.sel).cloned() else {
                     self.picker = None;
@@ -4647,6 +4662,48 @@ mod resume_tests {
         let (mut app, ctl) = test_app_with_root(root.to_str().unwrap(), "/w");
         app.run_slash("resume", "", &ctl);
         assert!(app.picker.is_none(), "no picker without sessions");
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn picker_page_keys_jump_a_screenful_and_home_end_pin_the_ends() {
+        let root = tmp_root("page");
+        let (mut app, ctl) = test_app_with_root(root.to_str().unwrap(), "/w");
+        app.picker = Some(Picker {
+            kind: PickerKind::Session,
+            title: " resume session · 40 sessions · enter select · esc close ".into(),
+            sel: 0,
+            items: (0..40)
+                .map(|i| PickerItem {
+                    id: format!("s{i:02}"),
+                    label: format!("session {i:02}"),
+                    meta: String::new(),
+                    provider: None,
+                })
+                .collect(),
+        });
+        // The draw pass records how many rows the popup shows; page keys
+        // move exactly that far (a 10-row popup in this test).
+        app.picker_page_rows = 10;
+
+        let key = |app: &mut App, code: KeyCode| {
+            app.handle_key(KeyEvent::new(code, KeyModifiers::NONE), &ctl);
+        };
+
+        key(&mut app, KeyCode::PageDown);
+        assert_eq!(app.picker.as_ref().unwrap().sel, 10, "page down");
+        key(&mut app, KeyCode::PageDown);
+        assert_eq!(app.picker.as_ref().unwrap().sel, 20, "page down again");
+        key(&mut app, KeyCode::End);
+        assert_eq!(app.picker.as_ref().unwrap().sel, 39, "end pins the tail");
+        key(&mut app, KeyCode::PageUp);
+        assert_eq!(app.picker.as_ref().unwrap().sel, 29, "page up");
+        key(&mut app, KeyCode::Home);
+        assert_eq!(app.picker.as_ref().unwrap().sel, 0, "home pins the head");
+        key(&mut app, KeyCode::PageUp);
+        assert_eq!(app.picker.as_ref().unwrap().sel, 0, "page up sticks at head");
+        key(&mut app, KeyCode::Up);
+        assert_eq!(app.picker.as_ref().unwrap().sel, 39, "↑ still wraps");
         let _ = std::fs::remove_dir_all(&root);
     }
 }

--- a/src/input/keymap.rs
+++ b/src/input/keymap.rs
@@ -160,6 +160,580 @@ pub fn classify(key: &KeyEvent, ctx: KeyCtx) -> Option<Action> {
     Some(action)
 }
 
+// ---------------------------------------------------------------------------
+// `/keys` documentation table — the single source of truth for `push_keys`.
+//
+// Every row is backed by probes: concrete `(KeyCode, KeyModifiers, ctx)` that
+// `classify` must resolve back to the row's Action, so the printed shortcuts
+// cannot drift from the real keymap (the tests below enforce that).
+// ---------------------------------------------------------------------------
+
+use Action::*;
+
+/// When a binding applies. Context rows are dual-use keys whose meaning
+/// changes when the draft is empty (scrolling vs. editing).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CtxNote {
+    Always,
+    EmptyPrompt,
+    Typing,
+}
+
+impl CtxNote {
+    pub fn tag(self, zh: bool) -> &'static str {
+        match (self, zh) {
+            (CtxNote::Always, _) => "",
+            (CtxNote::EmptyPrompt, false) => "[empty]",
+            (CtxNote::EmptyPrompt, true) => "[空输入时]",
+            (CtxNote::Typing, false) => "[typing]",
+            (CtxNote::Typing, true) => "[输入时]",
+        }
+    }
+}
+
+/// The `/keys` groups, in display order.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum KeyGroup {
+    Send,
+    Navigate,
+    Edit,
+    App,
+    Mouse,
+}
+
+impl KeyGroup {
+    fn title(self, zh: bool) -> &'static str {
+        match (self, zh) {
+            (KeyGroup::Send, false) => "send · interrupt",
+            (KeyGroup::Send, true) => "发送 · 中断",
+            (KeyGroup::Navigate, false) => "scroll · navigate",
+            (KeyGroup::Navigate, true) => "滚动 · 导航",
+            (KeyGroup::Edit, false) => "edit · readline",
+            (KeyGroup::Edit, true) => "编辑 · readline",
+            (KeyGroup::App, false) => "app shortcuts",
+            (KeyGroup::App, true) => "应用快捷键",
+            (KeyGroup::Mouse, false) => "mouse",
+            (KeyGroup::Mouse, true) => "鼠标",
+        }
+    }
+}
+
+/// One documented keybinding.
+pub struct KeyRow {
+    /// Documentation anchor; consumed by the anti-drift tests (the renderer
+    /// only needs the display fields, so non-test builds see this unused).
+    #[allow(dead_code)]
+    pub action: Action,
+    pub group: KeyGroup,
+    /// Display spellings; the platform set is picked at render time.
+    pub chords_mac: &'static [&'static str],
+    pub chords_other: &'static [&'static str],
+    pub ctx: CtxNote,
+    pub desc_en: &'static str,
+    pub desc_zh: &'static str,
+    /// One concrete event per displayed chord that `classify` must map back
+    /// to `action` (anti-drift probes: `(code, modifiers, input_empty)`).
+    #[allow(dead_code)]
+    pub probes: &'static [(KeyCode, KeyModifiers, bool)],
+}
+
+impl KeyRow {
+    fn chords(&self, mac: bool) -> &'static [&'static str] {
+        if mac {
+            self.chords_mac
+        } else {
+            self.chords_other
+        }
+    }
+}
+
+/// Mouse affordances live in the app event path, not `classify`, so they
+/// carry no probes — they are documented here only.
+pub struct MouseRow {
+    pub chords: &'static [&'static str],
+    pub desc_en: &'static str,
+    pub desc_zh: &'static str,
+}
+
+const NONE: KeyModifiers = KeyModifiers::NONE;
+const CTRL: KeyModifiers = KeyModifiers::CONTROL;
+const ALT: KeyModifiers = KeyModifiers::ALT;
+const SHIFT: KeyModifiers = KeyModifiers::SHIFT;
+const SUPER: KeyModifiers = KeyModifiers::SUPER;
+/// `CONTROL | SHIFT` — bitflags has no const `BitOr`, so spell the bits.
+const CTRL_SHIFT: KeyModifiers = KeyModifiers::from_bits_retain(0b0000_0011);
+
+const fn p(code: KeyCode, m: KeyModifiers, empty: bool) -> (KeyCode, KeyModifiers, bool) {
+    (code, m, empty)
+}
+
+pub const KEY_ROWS: &[KeyRow] = &[
+    // --- send · interrupt -------------------------------------------------
+    KeyRow {
+        action: Enter,
+        group: KeyGroup::Send,
+        chords_mac: &["enter"],
+        chords_other: &["enter"],
+        ctx: CtxNote::Always,
+        desc_en: "send · follow-ups queue while a turn runs",
+        desc_zh: "发送；轮次运行时后续输入排队",
+        probes: &[p(KeyCode::Enter, NONE, false)],
+    },
+    KeyRow {
+        action: Newline,
+        group: KeyGroup::Send,
+        chords_mac: &["shift+enter"],
+        chords_other: &["shift+enter"],
+        ctx: CtxNote::Always,
+        desc_en: "newline in the draft",
+        desc_zh: "草稿内换行",
+        probes: &[p(KeyCode::Enter, SHIFT, false)],
+    },
+    KeyRow {
+        action: SendNow,
+        group: KeyGroup::Send,
+        chords_mac: &["ctrl+x"],
+        chords_other: &["ctrl+x"],
+        ctx: CtxNote::Always,
+        desc_en: "send now — steers the active turn",
+        desc_zh: "立即发送（steer 当前轮次）",
+        probes: &[p(KeyCode::Char('x'), CTRL, false)],
+    },
+    KeyRow {
+        action: Esc,
+        group: KeyGroup::Send,
+        chords_mac: &["esc"],
+        chords_other: &["esc"],
+        ctx: CtxNote::Always,
+        desc_en: "interrupt · draft survives; clears when idle",
+        desc_zh: "中断（草稿保留）；空闲时清除草稿",
+        probes: &[p(KeyCode::Esc, NONE, false)],
+    },
+    KeyRow {
+        action: CtrlC,
+        group: KeyGroup::Send,
+        chords_mac: &["ctrl+c"],
+        chords_other: &["ctrl+c"],
+        ctx: CtxNote::Always,
+        desc_en: "clear draft · 2× quits with no draft",
+        desc_zh: "清草稿；无草稿时连按 2 次退出",
+        probes: &[p(KeyCode::Char('c'), CTRL, false)],
+    },
+    KeyRow {
+        action: Quit,
+        group: KeyGroup::Send,
+        chords_mac: &["ctrl+q"],
+        chords_other: &["ctrl+q"],
+        ctx: CtxNote::Always,
+        desc_en: "quit dsh-tui",
+        desc_zh: "退出 dsh-tui",
+        probes: &[p(KeyCode::Char('q'), CTRL, false)],
+    },
+    // --- scroll · navigate ------------------------------------------------
+    KeyRow {
+        action: HistoryPrev,
+        group: KeyGroup::Navigate,
+        chords_mac: &["↑"],
+        chords_other: &["↑"],
+        ctx: CtxNote::EmptyPrompt,
+        desc_en: "previous prompt",
+        desc_zh: "上一条历史",
+        probes: &[p(KeyCode::Up, NONE, true)],
+    },
+    KeyRow {
+        action: HistoryNext,
+        group: KeyGroup::Navigate,
+        chords_mac: &["↓"],
+        chords_other: &["↓"],
+        ctx: CtxNote::EmptyPrompt,
+        desc_en: "next prompt",
+        desc_zh: "下一条历史",
+        probes: &[p(KeyCode::Down, NONE, true)],
+    },
+    KeyRow {
+        action: JumpTop,
+        group: KeyGroup::Navigate,
+        chords_mac: &["home", "⌘↑"],
+        chords_other: &["home"],
+        ctx: CtxNote::EmptyPrompt,
+        desc_en: "transcript top",
+        desc_zh: "对话顶部",
+        probes: &[p(KeyCode::Home, NONE, true), p(KeyCode::Up, SUPER, false)],
+    },
+    KeyRow {
+        action: JumpTail,
+        group: KeyGroup::Navigate,
+        chords_mac: &["end", "⌘↓"],
+        chords_other: &["end"],
+        ctx: CtxNote::EmptyPrompt,
+        desc_en: "transcript tail",
+        desc_zh: "对话底部",
+        probes: &[p(KeyCode::End, NONE, true), p(KeyCode::Down, SUPER, false)],
+    },
+    KeyRow {
+        action: ScrollHalfUp,
+        group: KeyGroup::Navigate,
+        chords_mac: &["ctrl+u"],
+        chords_other: &["ctrl+u"],
+        ctx: CtxNote::EmptyPrompt,
+        desc_en: "scroll up half a page",
+        desc_zh: "上翻半页",
+        probes: &[p(KeyCode::Char('u'), CTRL, true)],
+    },
+    KeyRow {
+        action: ScrollHalfDown,
+        group: KeyGroup::Navigate,
+        chords_mac: &["ctrl+d"],
+        chords_other: &["ctrl+d"],
+        ctx: CtxNote::EmptyPrompt,
+        desc_en: "scroll down half a page",
+        desc_zh: "下翻半页",
+        probes: &[p(KeyCode::Char('d'), CTRL, true)],
+    },
+    KeyRow {
+        action: PageUp,
+        group: KeyGroup::Navigate,
+        chords_mac: &["pgup"],
+        chords_other: &["pgup"],
+        ctx: CtxNote::Always,
+        desc_en: "page up",
+        desc_zh: "上一页",
+        probes: &[p(KeyCode::PageUp, NONE, false)],
+    },
+    KeyRow {
+        action: PageDown,
+        group: KeyGroup::Navigate,
+        chords_mac: &["pgdn"],
+        chords_other: &["pgdn"],
+        ctx: CtxNote::Always,
+        desc_en: "page down",
+        desc_zh: "下一页",
+        probes: &[p(KeyCode::PageDown, NONE, false)],
+    },
+    // --- edit · readline --------------------------------------------------
+    KeyRow {
+        action: LineStart,
+        group: KeyGroup::Edit,
+        chords_mac: &["home", "⌘←", "ctrl+a"],
+        chords_other: &["home", "ctrl+a"],
+        ctx: CtxNote::Typing,
+        desc_en: "line start",
+        desc_zh: "行首",
+        probes: &[
+            p(KeyCode::Home, NONE, false),
+            p(KeyCode::Left, SUPER, false),
+            p(KeyCode::Char('a'), CTRL, false),
+        ],
+    },
+    KeyRow {
+        action: LineEnd,
+        group: KeyGroup::Edit,
+        chords_mac: &["end", "⌘→", "ctrl+e"],
+        chords_other: &["end", "ctrl+e"],
+        ctx: CtxNote::Typing,
+        desc_en: "line end",
+        desc_zh: "行尾",
+        probes: &[
+            p(KeyCode::End, NONE, false),
+            p(KeyCode::Right, SUPER, false),
+            p(KeyCode::Char('e'), CTRL, false),
+        ],
+    },
+    KeyRow {
+        action: CursorLeft,
+        group: KeyGroup::Edit,
+        chords_mac: &["ctrl+b"],
+        chords_other: &["ctrl+b"],
+        ctx: CtxNote::Typing,
+        desc_en: "cursor left",
+        desc_zh: "光标左移",
+        probes: &[p(KeyCode::Char('b'), CTRL, false)],
+    },
+    KeyRow {
+        action: CursorRight,
+        group: KeyGroup::Edit,
+        chords_mac: &["ctrl+f"],
+        chords_other: &["ctrl+f"],
+        ctx: CtxNote::Typing,
+        desc_en: "cursor right",
+        desc_zh: "光标右移",
+        probes: &[p(KeyCode::Char('f'), CTRL, false)],
+    },
+    KeyRow {
+        action: CursorUp,
+        group: KeyGroup::Edit,
+        chords_mac: &["↑"],
+        chords_other: &["↑"],
+        ctx: CtxNote::Typing,
+        desc_en: "cursor up",
+        desc_zh: "光标上移",
+        probes: &[p(KeyCode::Up, NONE, false)],
+    },
+    KeyRow {
+        action: CursorDown,
+        group: KeyGroup::Edit,
+        chords_mac: &["↓"],
+        chords_other: &["↓"],
+        ctx: CtxNote::Typing,
+        desc_en: "cursor down",
+        desc_zh: "光标下移",
+        probes: &[p(KeyCode::Down, NONE, false)],
+    },
+    KeyRow {
+        action: WordLeft,
+        group: KeyGroup::Edit,
+        chords_mac: &["⌥←", "esc-b"],
+        chords_other: &["ctrl+←"],
+        ctx: CtxNote::Typing,
+        desc_en: "word back",
+        desc_zh: "按词左移",
+        probes: &[
+            p(KeyCode::Left, ALT, false),
+            p(KeyCode::Char('b'), ALT, false),
+            p(KeyCode::Left, CTRL, false),
+        ],
+    },
+    KeyRow {
+        action: WordRight,
+        group: KeyGroup::Edit,
+        chords_mac: &["⌥→", "esc-f"],
+        chords_other: &["ctrl+→"],
+        ctx: CtxNote::Typing,
+        desc_en: "word forward",
+        desc_zh: "按词右移",
+        probes: &[
+            p(KeyCode::Right, ALT, false),
+            p(KeyCode::Char('f'), ALT, false),
+            p(KeyCode::Right, CTRL, false),
+        ],
+    },
+    KeyRow {
+        action: KillToStart,
+        group: KeyGroup::Edit,
+        chords_mac: &["ctrl+u", "⌘⌫"],
+        chords_other: &["ctrl+u"],
+        ctx: CtxNote::Typing,
+        desc_en: "kill to line start",
+        desc_zh: "删除到行首",
+        probes: &[
+            p(KeyCode::Char('u'), CTRL, false),
+            p(KeyCode::Backspace, SUPER, false),
+        ],
+    },
+    KeyRow {
+        action: KillToEnd,
+        group: KeyGroup::Edit,
+        chords_mac: &["ctrl+k"],
+        chords_other: &["ctrl+k"],
+        ctx: CtxNote::Typing,
+        desc_en: "kill to line end",
+        desc_zh: "删除到行尾",
+        probes: &[p(KeyCode::Char('k'), CTRL, false)],
+    },
+    KeyRow {
+        action: DeleteWordBack,
+        group: KeyGroup::Edit,
+        chords_mac: &["ctrl+w", "⌥⌫"],
+        chords_other: &["ctrl+w", "ctrl+⌫"],
+        ctx: CtxNote::Typing,
+        desc_en: "delete word back",
+        desc_zh: "删除前一词",
+        probes: &[
+            p(KeyCode::Char('w'), CTRL, false),
+            p(KeyCode::Backspace, ALT, false),
+            p(KeyCode::Backspace, CTRL, false),
+        ],
+    },
+    KeyRow {
+        action: DeleteForward,
+        group: KeyGroup::Edit,
+        chords_mac: &["delete", "ctrl+d"],
+        chords_other: &["delete", "ctrl+d"],
+        ctx: CtxNote::Typing,
+        desc_en: "delete forward",
+        desc_zh: "删除光标后字符",
+        probes: &[
+            p(KeyCode::Delete, NONE, false),
+            p(KeyCode::Char('d'), CTRL, false),
+        ],
+    },
+    KeyRow {
+        action: Backspace,
+        group: KeyGroup::Edit,
+        chords_mac: &["⌫"],
+        chords_other: &["⌫"],
+        ctx: CtxNote::Typing,
+        desc_en: "backspace",
+        desc_zh: "退格",
+        probes: &[p(KeyCode::Backspace, NONE, false)],
+    },
+    // --- app shortcuts ----------------------------------------------------
+    KeyRow {
+        action: CycleAgent,
+        group: KeyGroup::App,
+        chords_mac: &["option+a"],
+        chords_other: &["ctrl+shift+a"],
+        ctx: CtxNote::Always,
+        desc_en: "cycle agent preset",
+        desc_zh: "切换 Agent 预设",
+        probes: &[
+            p(KeyCode::Char('a'), ALT, false),
+            p(KeyCode::Char('a'), CTRL_SHIFT, false),
+        ],
+    },
+    KeyRow {
+        action: CyclePermission,
+        group: KeyGroup::App,
+        chords_mac: &["shift+tab"],
+        chords_other: &["shift+tab"],
+        ctx: CtxNote::Always,
+        desc_en: "cycle permission preset (/permission)",
+        desc_zh: "轮换权限预设（/permission）",
+        probes: &[p(KeyCode::BackTab, NONE, false)],
+    },
+    KeyRow {
+        action: ModelPicker,
+        group: KeyGroup::App,
+        chords_mac: &["ctrl+p"],
+        chords_other: &["ctrl+p"],
+        ctx: CtxNote::Always,
+        desc_en: "model picker → effort picker",
+        desc_zh: "模型选择器 → 推理强度",
+        probes: &[p(KeyCode::Char('p'), CTRL, false)],
+    },
+    KeyRow {
+        action: ToggleTheme,
+        group: KeyGroup::App,
+        chords_mac: &["ctrl+t"],
+        chords_other: &["ctrl+t"],
+        ctx: CtxNote::Always,
+        desc_en: "toggle dark/light",
+        desc_zh: "切换明暗主题",
+        probes: &[p(KeyCode::Char('t'), CTRL, false)],
+    },
+    KeyRow {
+        action: ToggleExpandAll,
+        group: KeyGroup::App,
+        chords_mac: &["ctrl+o"],
+        chords_other: &["ctrl+o"],
+        ctx: CtxNote::Always,
+        desc_en: "expand/collapse thoughts + tool output",
+        desc_zh: "展开/折叠思考与工具输出",
+        probes: &[p(KeyCode::Char('o'), CTRL, false)],
+    },
+    KeyRow {
+        action: ClearScrollback,
+        group: KeyGroup::App,
+        chords_mac: &["ctrl+l"],
+        chords_other: &["ctrl+l"],
+        ctx: CtxNote::Always,
+        desc_en: "clear scrollback",
+        desc_zh: "清屏",
+        probes: &[p(KeyCode::Char('l'), CTRL, false)],
+    },
+    KeyRow {
+        action: ShowKeys,
+        group: KeyGroup::App,
+        chords_mac: &["ctrl+."],
+        chords_other: &["ctrl+."],
+        ctx: CtxNote::Always,
+        desc_en: "this shortcut list (/keys)",
+        desc_zh: "本快捷键列表（/keys）",
+        probes: &[p(KeyCode::Char('.'), CTRL, false)],
+    },
+    KeyRow {
+        action: TabComplete,
+        group: KeyGroup::App,
+        chords_mac: &["tab"],
+        chords_other: &["tab"],
+        ctx: CtxNote::Always,
+        desc_en: "complete /commands",
+        desc_zh: "补全 / 命令",
+        probes: &[p(KeyCode::Tab, NONE, false)],
+    },
+    KeyRow {
+        action: AttachClipboard,
+        group: KeyGroup::App,
+        chords_mac: &["ctrl+v"],
+        chords_other: &["ctrl+v"],
+        ctx: CtxNote::Always,
+        desc_en: "attach the clipboard image",
+        desc_zh: "粘贴剪贴板图片",
+        probes: &[p(KeyCode::Char('v'), CTRL, false)],
+    },
+];
+
+pub const MOUSE_ROWS: &[MouseRow] = &[
+    MouseRow {
+        chords: &["click"],
+        desc_en: "expand/collapse a tool · wheel scrolls",
+        desc_zh: "点击展开/折叠工具 · 滚轮滚动",
+    },
+    MouseRow {
+        chords: &["drag"],
+        desc_en: "select text · copies on release",
+        desc_zh: "拖动选择文本，松开即复制",
+    },
+    MouseRow {
+        chords: &["2×click"],
+        desc_en: "copy a word",
+        desc_zh: "双击复制单词",
+    },
+    MouseRow {
+        chords: &["shift+drag"],
+        desc_en: "terminal-native selection",
+        desc_zh: "终端原生选择",
+    },
+];
+
+/// Render the `/keys` map as markdown: one GFM table per group. The
+/// transcript renders it through the markdown pipeline, so tables get
+/// box-drawing frames and truncate (with an ellipsis) instead of wrapping
+/// when the terminal is narrow.
+pub fn keys_markdown(zh: bool, mac: bool) -> String {
+    let mut out = String::new();
+    out.push_str(if zh {
+        "## 快捷键\n\n双用途键：`[空输入时]` 滚动，`[输入时]` 编辑。\n\n"
+    } else {
+        "## keys — shortcut map\n\nDual-use keys: `[empty]` scrolls, `[typing]` edits.\n\n"
+    });
+    let mut last_group: Option<KeyGroup> = None;
+    for row in KEY_ROWS {
+        if last_group != Some(row.group) {
+            if last_group.is_some() {
+                out.push('\n');
+            }
+            out.push_str(&format!("### {}\n\n", row.group.title(zh)));
+            out.push_str(&table_head(zh));
+            last_group = Some(row.group);
+        }
+        let ctx = row.ctx.tag(zh);
+        let desc = if zh { row.desc_zh } else { row.desc_en };
+        let chords = row.chords(mac).join(" · ");
+        // Cells are plain text: no `|` anywhere in chords/descriptions.
+        out.push_str(&format!("| `{chords}` | {ctx} | {desc} |\n"));
+    }
+    out.push('\n');
+    out.push_str(&format!("### {}\n\n", KeyGroup::Mouse.title(zh)));
+    out.push_str(&table_head(zh));
+    for row in MOUSE_ROWS {
+        out.push_str(&format!(
+            "| `{}` |  | {} |\n",
+            row.chords.join(" · "),
+            if zh { row.desc_zh } else { row.desc_en }
+        ));
+    }
+    out
+}
+
+fn table_head(zh: bool) -> String {
+    if zh {
+        "| 键 | 上下文 | 说明 |\n| --- | --- | --- |\n".to_string()
+    } else {
+        "| key | ctx | description |\n| --- | --- | --- |\n".to_string()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -366,4 +940,150 @@ mod tests {
             Some(Action::CyclePermission)
         );
     }
+
+    #[test]
+    fn every_action_has_exactly_one_documented_row_except_typing_insert() {
+        let all = [
+            Action::Insert('x'),
+            Action::Newline,
+            Action::Enter,
+            Action::Esc,
+            Action::CtrlC,
+            Action::Quit,
+            Action::ClearScrollback,
+            Action::ToggleTheme,
+            Action::ToggleExpandAll,
+            Action::SendNow,
+            Action::AttachClipboard,
+            Action::ModelPicker,
+            Action::CycleAgent,
+            Action::ShowKeys,
+            Action::CyclePermission,
+            Action::TabComplete,
+            Action::HistoryPrev,
+            Action::HistoryNext,
+            Action::ScrollHalfUp,
+            Action::ScrollHalfDown,
+            Action::PageUp,
+            Action::PageDown,
+            Action::JumpTop,
+            Action::JumpTail,
+            Action::CursorLeft,
+            Action::CursorRight,
+            Action::CursorUp,
+            Action::CursorDown,
+            Action::WordLeft,
+            Action::WordRight,
+            Action::LineStart,
+            Action::LineEnd,
+            Action::Backspace,
+            Action::DeleteForward,
+            Action::DeleteWordBack,
+            Action::KillToEnd,
+            Action::KillToStart,
+        ];
+        let documented: Vec<Action> = KEY_ROWS.iter().map(|row| row.action).collect();
+        assert_eq!(
+            documented.len(),
+            all.len() - 1,
+            "exactly one row per action (Insert is plain typing and stays out)"
+        );
+        for action in all {
+            if matches!(action, Action::Insert(_)) {
+                continue;
+            }
+            assert!(
+                documented.contains(&action),
+                "{action:?} is missing from KEY_ROWS — /keys would not show it"
+            );
+        }
+    }
+
+    #[test]
+    fn displayed_chords_resolve_to_their_action() {
+        for row in KEY_ROWS {
+            for (code, mods, empty) in row.probes {
+                let got = classify(
+                    &KeyEvent::new(*code, *mods),
+                    KeyCtx {
+                        input_empty: *empty,
+                    },
+                );
+                assert_eq!(
+                    got,
+                    Some(row.action),
+                    "KEY_ROWS drift: {:?} + {mods:?} must be {:?}, got {got:?}",
+                    code,
+                    row.action
+                );
+            }
+        }
+    }
+    #[test]
+    fn keys_markdown_is_well_formed() {
+        for zh in [false, true] {
+            for mac in [false, true] {
+                let md = keys_markdown(zh, mac);
+                assert!(!md.is_empty());
+                let mut saw_table = false;
+                for line in md.lines() {
+                    let trimmed = line.trim();
+                    if !trimmed.starts_with('|') {
+                        continue;
+                    }
+                    saw_table = true;
+                    let cells = trimmed.split('|').count();
+                    assert_eq!(
+                        cells, 5,
+                        "table row must have 3 cells (leading/trailing pipes make 5 fields): {line:?}\n{md}"
+                    );
+                }
+                assert!(saw_table, "no table rows in:\n{md}");
+            }
+        }
+    }
+
+    #[test]
+    fn keys_markdown_renders_within_the_terminal_width() {
+        let theme = crate::theme::Theme::dark();
+        for width in [80usize, 120] {
+            for zh in [false, true] {
+                for mac in [false, true] {
+                    let md = keys_markdown(zh, mac);
+                    let lines = crate::markdown::render(&md, &theme, width);
+                    assert!(!lines.is_empty());
+                    for line in lines {
+                        let w = line.width() as usize;
+                        assert!(
+                            w <= width,
+                            "rendered keys line is {w} wide at {width} ({zh}, mac={mac}): {line:?}"
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn keys_markdown_uses_the_platform_spellings_and_groups_everything() {
+        let mac = keys_markdown(false, true);
+        assert!(mac.contains("⌘←"), "macOS chord missing:\n{mac}");
+        assert!(mac.contains("option+a"), "macOS agent chord missing:\n{mac}");
+        let linux = keys_markdown(false, false);
+        assert!(linux.contains("ctrl+←"), "linux chord missing:\n{linux}");
+        assert!(!linux.contains("⌘←"), "macOS chord leaked to linux:\n{linux}");
+        assert!(linux.contains("ctrl+shift+a"), "linux agent chord missing:\n{linux}");
+        for group in [KeyGroup::Send, KeyGroup::Navigate, KeyGroup::Edit, KeyGroup::App, KeyGroup::Mouse] {
+            assert!(
+                linux.contains(&group.title(false)),
+                "group {:?} missing:\n{linux}",
+                group
+            );
+        }
+        let zh = keys_markdown(true, false);
+        assert!(zh.contains("快捷键"), "zh title missing:\n{zh}");
+        assert!(zh.contains("[空输入时]"), "zh context tag missing:\n{zh}");
+        assert!(zh.contains("发送"), "zh send group missing:\n{zh}");
+    }
+
 }

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -543,8 +543,7 @@ pub struct Theme {
     /// Gray-blue hint text (tip banner, informational chips) — quieter
     /// than `brand_soft`, warmer than the neutral grays.
     pub hint: Color,
-    /// selection/status chip background
-    #[allow(dead_code)]
+    /// selection/status chip background (picker row highlight)
     pub chip_bg: Color,
     dark: TokenMap,
     light: TokenMap,

--- a/src/transcript.rs
+++ b/src/transcript.rs
@@ -86,6 +86,11 @@ pub enum CellKind {
         level: NoticeLevel,
         text: String,
     },
+    /// A notice rendered through the markdown pipeline (headings, tables,
+    /// inline code) instead of plain wrapped text — used by `/keys`.
+    MarkdownNotice {
+        text: String,
+    },
 }
 
 pub struct Cell {
@@ -251,6 +256,13 @@ impl Transcript {
 
     pub fn push_notice(&mut self, level: NoticeLevel, text: String) {
         self.cells.push(Cell::new(CellKind::Notice { level, text }));
+    }
+
+    /// Push a notice rendered through the markdown pipeline (tables,
+    /// headings, inline code). No `· ` prefix and no manual wrapping: the
+    /// markdown renderer owns line layout and truncation.
+    pub fn push_markdown(&mut self, text: String) {
+        self.cells.push(Cell::new(CellKind::MarkdownNotice { text }));
     }
 
     pub fn push_shell(&mut self, command: String) -> usize {
@@ -1190,6 +1202,15 @@ impl Transcript {
                             ]),
                             None,
                         );
+                    }
+                }
+                CellKind::MarkdownNotice { text } => {
+                    if text.trim().is_empty() {
+                        continue;
+                    }
+                    emit(&mut out, &mut owners, Line::default(), None);
+                    for l in crate::markdown::render(text, theme, width) {
+                        emit(&mut out, &mut owners, l, None);
                     }
                 }
             }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,9 +1,11 @@
 //! Rendering: banner, scrollback, tips row, status bar, prompt, hints, overlays.
 
-use ratatui::layout::{Alignment, Rect};
+use ratatui::layout::{Alignment, Margin, Rect};
 use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
-use ratatui::widgets::{Block, BorderType, Borders, Clear, Paragraph, Scrollbar, ScrollbarOrientation};
+use ratatui::widgets::{
+    Block, BorderType, Borders, Clear, Paragraph, Scrollbar, ScrollbarOrientation, ScrollbarState,
+};
 use ratatui::Frame;
 use tui_widget_list::{ListBuilder, ListState, ListView};
 use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
@@ -1555,12 +1557,18 @@ fn draw_model_picker(f: &mut Frame, app: &mut App, screen: Rect) {
         .max()
         .unwrap_or(0) as u16;
     let cap = screen.width.saturating_sub(4).max(24);
-    let w = (needed + 2).max(58).min(cap);
+    let overflow = items.len() as u16 + 2 > h;
+    // The scrollbar gets its own column inside the popup when rows overflow,
+    // so the rounded border never has glyphs drawn over its corners.
+    let w = if overflow {
+        ((needed + 2).max(58) + 1).min(cap)
+    } else {
+        (needed + 2).max(58).min(cap)
+    };
     let x = screen.x + (screen.width - w) / 2;
     let y = screen.y + (screen.height - h) / 3;
     let area = Rect::new(x, y, w, h);
     f.render_widget(Clear, area);
-    let overflow = items.len() as u16 + 2 > h;
     let item_count = items.len();
     let mut list_state = ListState::new_with_index(Some(sel.min(items.len().saturating_sub(1))));
     let builder = ListBuilder::new(move |ctx| {
@@ -1605,9 +1613,10 @@ fn draw_model_picker(f: &mut Frame, app: &mut App, screen: Rect) {
             spans.push(Span::styled(item.meta.clone(), meta_style));
         }
         // Pad the remaining row width so the selection background reaches
-        // the right edge (gap after the label, tail after the meta).
+        // the right edge (gap after the label, tail after the meta). When
+        // the scrollbar is shown, its gutter column stays free.
         let width: usize = spans.iter().map(|s| s.width()).sum();
-        let fill = ctx.cross_axis_size as usize;
+        let fill = (ctx.cross_axis_size as usize).saturating_sub(if overflow { 1 } else { 0 });
         if width < fill {
             let fill_style = if selected {
                 Style::default().bg(theme.chip_bg)
@@ -1627,19 +1636,27 @@ fn draw_model_picker(f: &mut Frame, app: &mut App, screen: Rect) {
             Style::default().fg(theme.caption),
         ))
         .style(Style::default().bg(theme.panel));
-    let mut list = ListView::new(builder, item_count)
+    let list = ListView::new(builder, item_count)
         .block(block)
         // Keep the picker's wrap-around ↑/↓ semantics.
         .infinite_scrolling(true);
+    // The list keeps the full popup area, so the rounded border stays at
+    // the popup's real edges; the scrollbar renders into the rightmost
+    // inner column, which the rows leave free when overflowing.
+    f.render_stateful_widget(list, area, &mut list_state);
     if overflow {
-        // The scrollbar's ▲/▼ replace the right border corners, so the
-        // popup keeps its rounded frame while showing position.
-        list = list.scrollbar(
+        let inner = area.inner(Margin::new(1, 1));
+        let mut sb_state =
+            ScrollbarState::new(item_count).position(list_state.scroll_offset_index());
+        f.render_stateful_widget(
             Scrollbar::new(ScrollbarOrientation::VerticalRight)
+                .begin_symbol(None)
+                .end_symbol(None)
                 .style(Style::default().fg(theme.border)),
+            inner,
+            &mut sb_state,
         );
     }
-    f.render_stateful_widget(list, area, &mut list_state);
     // The viewport is the source of truth for what is visible; selection
     // moves (mouse later, programmatic now) land back in the picker.
     if let Some(picker) = &mut app.picker {
@@ -2664,7 +2681,15 @@ mod tests {
         let top = dump_frame(&mut app, 100, 24);
         assert!(top.contains("session 00"), "head row visible:\n{top}");
         assert!(!top.contains("session 39"), "tail not visible yet:\n{top}");
-        assert!(top.contains("▲"), "scroll affordance shown:\n{top}");
+        // The rounded border stays intact: the scrollbar lives in its own
+        // column inside the popup, between the rows and the right border.
+        assert!(top.contains("╮"), "top-right corner intact:\n{top}");
+        assert!(top.contains("║"), "scrollbar track shown:\n{top}");
+        assert!(
+            top.lines()
+                .any(|l| l.contains("session 00") && l.trim_end().ends_with('│')),
+            "right border column intact next to the scrollbar:\n{top}"
+        );
 
         // Jump to the tail: the window follows, so the last row is
         // reachable instead of being clipped out of the paragraph.
@@ -2672,7 +2697,8 @@ mod tests {
         let tail = dump_frame(&mut app, 100, 24);
         assert!(tail.contains("session 39"), "tail row visible:\n{tail}");
         assert!(!tail.contains("session 00"), "head scrolled away:\n{tail}");
-        assert!(tail.contains("▼"), "scroll affordance shown:\n{tail}");
+        assert!(tail.contains("█"), "scrollbar thumb shown:\n{tail}");
+        assert!(tail.contains("╰"), "bottom corners intact:\n{tail}");
         assert_eq!(app.picker_page_rows, 20, "page size = visible rows");
     }
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -3,8 +3,9 @@
 use ratatui::layout::{Alignment, Rect};
 use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
-use ratatui::widgets::{Block, BorderType, Borders, Clear, Paragraph};
+use ratatui::widgets::{Block, BorderType, Borders, Clear, Paragraph, Scrollbar, ScrollbarOrientation};
 use ratatui::Frame;
+use tui_widget_list::{ListBuilder, ListState, ListView};
 use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
 use crate::app::{App, RunState};
@@ -1506,35 +1507,46 @@ fn pad_to_width(s: &str, width: usize) -> String {
     }
 }
 
-fn draw_model_picker(f: &mut Frame, app: &App, screen: Rect) {
+fn draw_model_picker(f: &mut Frame, app: &mut App, screen: Rect) {
+    let theme = app.theme;
     let Some(picker) = &app.picker else {
         return;
     };
-    let theme = app.theme;
     // The active model is identified by provider + id because multiple
     // coding plans can expose the same upstream model id.
+    let kind = picker.kind;
+    let title = picker.title.clone();
+    let sel = picker.sel;
+    let items = picker.items.clone();
+    // Current-identity ids, precomputed so the row builder below never
+    // borrows `app` (the ListView render needs a mutable picker).
+    let current_model = app.cfg.model.clone();
+    let current_provider = app.cfg.provider.clone();
     let current_mode = app.current_mode();
-    let is_current = |item: &crate::app::PickerItem| match picker.kind {
+    let current_palette = app.active_palette_id.clone();
+    let current_permission = app.current_permission().to_string();
+    let is_current = move |item: &crate::app::PickerItem| match kind {
         crate::app::PickerKind::Model => {
-            item.id == app.cfg.model
+            item.id == current_model
                 && item
                     .provider
                     .as_deref()
-                    .is_none_or(|provider| provider == app.cfg.provider)
+                    .is_none_or(|provider| provider == current_provider)
         }
         crate::app::PickerKind::Mode => item.id == current_mode,
-        crate::app::PickerKind::Theme => item.id == app.active_palette_id,
-        crate::app::PickerKind::Permission => item.id == app.current_permission(),
+        crate::app::PickerKind::Theme => item.id == current_palette,
+        crate::app::PickerKind::Permission => item.id == current_permission,
         crate::app::PickerKind::Effort
         | crate::app::PickerKind::Session
         | crate::app::PickerKind::Subagent
         | crate::app::PickerKind::Auth
         | crate::app::PickerKind::Plugin => false,
     };
-    let h = (picker.items.len() as u16 + 2).min(screen.height.saturating_sub(2));
+    // The popup caps at the screen; `ListView` scrolls the overflow instead
+    // of clipping it out of reach.
+    let h = (items.len() as u16 + 2).min(screen.height.saturating_sub(2));
     // Fit the widest row (marker + padded label + ✓ + meta); cap to the screen.
-    let needed = picker
-        .items
+    let needed = items
         .iter()
         .map(|item| {
             let label_w = item.label.width() + if is_current(item) { 2 } else { 0 };
@@ -1548,17 +1560,29 @@ fn draw_model_picker(f: &mut Frame, app: &App, screen: Rect) {
     let y = screen.y + (screen.height - h) / 3;
     let area = Rect::new(x, y, w, h);
     f.render_widget(Clear, area);
-    let mut lines = Vec::new();
-    for (i, item) in picker.items.iter().enumerate() {
-        let selected = i == picker.sel;
-        let marker = if selected { "▸ " } else { "  " };
-        let style = if selected {
+    let overflow = items.len() as u16 + 2 > h;
+    let item_count = items.len();
+    let mut list_state = ListState::new_with_index(Some(sel.min(items.len().saturating_sub(1))));
+    let builder = ListBuilder::new(move |ctx| {
+        let item = &items[ctx.index];
+        let selected = ctx.is_selected;
+        // Full-row selection: the soft chip background spans the whole line
+        // (marker, label, meta, and the tail), so the highlight reads as one
+        // row — not just the label column.
+        let base = if selected {
             Style::default()
                 .fg(theme.brand)
+                .bg(theme.chip_bg)
                 .add_modifier(Modifier::BOLD)
         } else {
             Style::default().fg(theme.fg_secondary)
         };
+        let marker_style = if selected {
+            Style::default().fg(theme.brand).bg(theme.chip_bg)
+        } else {
+            Style::default().fg(theme.brand)
+        };
+        let marker = if selected { "▸ " } else { "  " };
         // The current model/mode gets a ✓ pinned to its label — it survives
         // narrow terminals, unlike a right-edge tag.
         let label = if is_current(item) {
@@ -1567,27 +1591,64 @@ fn draw_model_picker(f: &mut Frame, app: &App, screen: Rect) {
             item.label.clone()
         };
         let mut spans = vec![
-            Span::styled(marker.to_string(), Style::default().fg(theme.brand)),
-            Span::styled(pad_to_width(&label, crate::app::PICKER_LABEL_COL), style),
+            Span::styled(marker.to_string(), marker_style),
+            Span::styled(pad_to_width(&label, crate::app::PICKER_LABEL_COL), base),
         ];
         if !item.meta.is_empty() {
-            spans.push(Span::styled(
-                item.meta.clone(),
-                Style::default().fg(theme.caption),
-            ));
+            // On the highlighted row the meta steps up from caption gray so
+            // the whole row reads selected.
+            let meta_style = if selected {
+                Style::default().fg(theme.fg).bg(theme.chip_bg)
+            } else {
+                Style::default().fg(theme.caption)
+            };
+            spans.push(Span::styled(item.meta.clone(), meta_style));
         }
-        lines.push(Line::from(spans));
-    }
+        // Pad the remaining row width so the selection background reaches
+        // the right edge (gap after the label, tail after the meta).
+        let width: usize = spans.iter().map(|s| s.width()).sum();
+        let fill = ctx.cross_axis_size as usize;
+        if width < fill {
+            let fill_style = if selected {
+                Style::default().bg(theme.chip_bg)
+            } else {
+                Style::default()
+            };
+            spans.push(Span::styled(" ".repeat(fill - width), fill_style));
+        }
+        (Line::from(spans), 1)
+    });
     let block = Block::default()
         .borders(Borders::ALL)
         .border_type(BorderType::Rounded)
         .border_style(Style::default().fg(theme.brand))
         .title(Span::styled(
-            picker.title.clone(),
+            title,
             Style::default().fg(theme.caption),
         ))
         .style(Style::default().bg(theme.panel));
-    f.render_widget(Paragraph::new(lines).block(block), area);
+    let mut list = ListView::new(builder, item_count)
+        .block(block)
+        // Keep the picker's wrap-around ↑/↓ semantics.
+        .infinite_scrolling(true);
+    if overflow {
+        // The scrollbar's ▲/▼ replace the right border corners, so the
+        // popup keeps its rounded frame while showing position.
+        list = list.scrollbar(
+            Scrollbar::new(ScrollbarOrientation::VerticalRight)
+                .style(Style::default().fg(theme.border)),
+        );
+    }
+    f.render_stateful_widget(list, area, &mut list_state);
+    // The viewport is the source of truth for what is visible; selection
+    // moves (mouse later, programmatic now) land back in the picker.
+    if let Some(picker) = &mut app.picker {
+        if let Some(selected) = list_state.selected {
+            picker.sel = selected;
+        }
+        // Page keys jump a screenful: the rows the popup actually shows.
+        app.picker_page_rows = h.saturating_sub(2) as usize;
+    }
 }
 
 fn draw_permission_ask(f: &mut Frame, app: &App, screen: Rect) {
@@ -2577,6 +2638,114 @@ mod tests {
             ascii_row.chars().count() >= 2 + PICKER_LABEL_COL + 8,
             "label column padded to {PICKER_LABEL_COL}"
         );
+    }
+
+    #[test]
+    fn picker_window_follows_the_selection_and_shows_a_scrollbar() {
+        use crate::app::{Picker, PickerItem, PickerKind};
+        let mut app = test_app();
+        app.show_banner = false;
+        let items: Vec<PickerItem> = (0..40)
+            .map(|i| PickerItem {
+                id: format!("sess-{i:02}"),
+                label: format!("session {i:02}"),
+                meta: format!("meta {i:02}"),
+                provider: None,
+            })
+            .collect();
+        app.picker = Some(Picker {
+            kind: PickerKind::Session,
+            title: " resume session · 40 sessions · enter select · esc close ".into(),
+            sel: 0,
+            items,
+        });
+
+        // 24-row terminal: the popup caps at 22 rows and must scroll.
+        let top = dump_frame(&mut app, 100, 24);
+        assert!(top.contains("session 00"), "head row visible:\n{top}");
+        assert!(!top.contains("session 39"), "tail not visible yet:\n{top}");
+        assert!(top.contains("▲"), "scroll affordance shown:\n{top}");
+
+        // Jump to the tail: the window follows, so the last row is
+        // reachable instead of being clipped out of the paragraph.
+        app.picker.as_mut().unwrap().sel = 39;
+        let tail = dump_frame(&mut app, 100, 24);
+        assert!(tail.contains("session 39"), "tail row visible:\n{tail}");
+        assert!(!tail.contains("session 00"), "head scrolled away:\n{tail}");
+        assert!(tail.contains("▼"), "scroll affordance shown:\n{tail}");
+        assert_eq!(app.picker_page_rows, 20, "page size = visible rows");
+    }
+
+    #[test]
+    fn picker_selection_highlights_the_whole_row() {
+        use crate::app::{Picker, PickerItem, PickerKind};
+        use ratatui::backend::TestBackend;
+        use ratatui::Terminal;
+        let mut app = test_app();
+        app.show_banner = false;
+        app.picker = Some(Picker {
+            kind: PickerKind::Session,
+            title: " resume session · 2 sessions ".into(),
+            sel: 0,
+            items: vec![
+                PickerItem {
+                    id: "a".into(),
+                    label: "first".into(),
+                    meta: "meta a".into(),
+                    provider: None,
+                },
+                PickerItem {
+                    id: "b".into(),
+                    label: "second".into(),
+                    meta: "meta b".into(),
+                    provider: None,
+                },
+            ],
+        });
+        let backend = TestBackend::new(80, 20);
+        let mut terminal = Terminal::new(backend).expect("terminal");
+        terminal.draw(|f| draw(f, &mut app)).expect("draw");
+        let buf = terminal.backend().buffer();
+        let chip = app.theme.chip_bg;
+        // Cells hold single symbols, so search rows by joining them first.
+        let row_of = |needle: &str| {
+            (0..20u16)
+                .find(|&r| {
+                    (0..80u16)
+                        .map(|c| buf[(c, r)].symbol())
+                        .collect::<String>()
+                        .contains(needle)
+                })
+                .unwrap_or_else(|| panic!("row with {needle:?} not found"))
+        };
+        // The selected row: marker, label, meta and the tail padding all
+        // carry the chip background — the highlight spans the whole line.
+        let sel_row = row_of("first");
+        let marker_col = (0..80u16)
+            .find(|&c| buf[(c, sel_row)].symbol() == "▸")
+            .expect("selection marker");
+        let right_border = (marker_col..80u16)
+            .find(|&c| buf[(c, sel_row)].symbol() == "│")
+            .expect("popup right border");
+        for c in marker_col..right_border {
+            assert_eq!(
+                buf[(c, sel_row)].style().bg,
+                Some(chip),
+                "selected row cell {c} carries the highlight bg"
+            );
+        }
+        // The unselected row keeps the panel background.
+        let other_row = row_of("second");
+        for c in 0..80u16 {
+            let cell = &buf[(c, other_row)];
+            if !cell.symbol().trim().is_empty() {
+                assert_ne!(
+                    cell.style().bg,
+                    Some(chip),
+                    "unselected row cell {c} must not carry the highlight bg"
+                );
+            }
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

The `/keys` shortcut wall was hand-written text in `push_keys` and drifted from the real bindings. It is now generated from the keymap table in `src/input/keymap.rs` and rendered through the transcript's markdown pipeline.

## Changes

- **`src/input/keymap.rs`** — new `KEY_ROWS` / `MOUSE_ROWS` tables document every `Action` with platform-appropriate chord spellings (⌘/⌥ vs ctrl) and `[empty]`/`[typing]` context tags for dual-use keys; `keys_markdown()` emits one GFM table per group (`send · interrupt`, `scroll · navigate`, `edit · readline`, `app shortcuts`, `mouse`).
- **`src/transcript.rs`** — new `MarkdownNotice` cell kind + `push_markdown()`; notices render through the markdown pipeline, so tables get box-drawing frames and truncate with an ellipsis on narrow terminals instead of breaking mid-line.
- **`src/app.rs`** — `push_keys` delegates to `keys_markdown()`; `/keys` is the first markdown-notice consumer. Integration test added.
- **`CHANGELOG.md`** — entry added.

## Anti-drift guarantees

- Tests assert every `Action` has exactly one documented row (except plain typing `Insert`).
- Every displayed chord resolves back to its action through `classify()` probes.
- Previously undocumented bindings are now listed: `ctrl+q`, `shift+enter`, `shift+tab`, `ctrl+v`, `ctrl+shift+a`, `⌘←/⌘→`, `⌥←/⌥→`, `⌘⌫`, `⌥⌫`, `esc-b/f`, …

`/help` stays the command overview; `/keys` is the complete key map.