### PR TITLE
fix: persist local shell state across ! commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ All notable changes to this project are documented here. The project follows
 
 ### Fixed
 
+- Local `!` commands now share one shell for the lifetime of the TUI session,
+  so working-directory changes, exported variables, and other shell state
+  persist across invocations. Commands remain client-local and start in the
+  configured workspace.
 - Linux x64 packages now ship a statically linked musl binary instead of a
   binary tied to the Ubuntu 24.04 glibc version. Release CI verifies the ELF
   artifact has no dynamic program interpreter and runs it on Ubuntu 20.04
@@ -68,9 +72,6 @@ All notable changes to this project are documented here. The project follows
 
 ### Documentation
 
-- Clarified that each `!cmd` runs in an independent one-shot `sh -lc`
-  process rooted at the workspace, so shell state such as `cd` and exported
-  variables does not carry across calls; examples now show `!cd dir && cmd`.
 - Reworked the repository and npm README mastheads around the centered
   DeepSeek logo, product name, concise positioning, and a consistent badge row.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,9 @@ All notable changes to this project are documented here. The project follows
 
 ### Documentation
 
+- Clarified that each `!cmd` runs in an independent one-shot `sh -lc`
+  process rooted at the workspace, so shell state such as `cd` and exported
+  variables does not carry across calls; examples now show `!cd dir && cmd`.
 - Reworked the repository and npm README mastheads around the centered
   DeepSeek logo, product name, concise positioning, and a consistent badge row.
 

--- a/README.en.md
+++ b/README.en.md
@@ -265,7 +265,7 @@ Requests/Notifications and never enter prompts or conversation history.
 | Linux/Windows | `ctrl+←/→` word hops · `ctrl+⌫` word back |
 | Click tool · wheel | Click a tool to expand/collapse it; wheel always scrolls the conversation |
 | Mouse drag | Copy on release; double-click a word; `shift+drag` uses native selection |
-| `!cmd` | Run a one-shot local shell command on the client, outside the agent; every call starts an independent `sh -lc` in the workspace, so `cd`, environment variables, and other shell state do not carry over. Use `!cd dir && command` when needed |
+| `!cmd` | Run a command in the client's session-local shell, outside the agent; the shell starts in the workspace and keeps `cd`, environment variables, and other state for later `!` commands until the TUI exits |
 
 Use `/help` for commands and `/keys` for the complete shortcut list.
 

--- a/README.en.md
+++ b/README.en.md
@@ -265,7 +265,7 @@ Requests/Notifications and never enter prompts or conversation history.
 | Linux/Windows | `ctrl+←/→` word hops · `ctrl+⌫` word back |
 | Click tool · wheel | Click a tool to expand/collapse it; wheel always scrolls the conversation |
 | Mouse drag | Copy on release; double-click a word; `shift+drag` uses native selection |
-| `!cmd` | Run a local shell command on the client, outside the agent |
+| `!cmd` | Run a one-shot local shell command on the client, outside the agent; every call starts an independent `sh -lc` in the workspace, so `cd`, environment variables, and other shell state do not carry over. Use `!cd dir && command` when needed |
 
 Use `/help` for commands and `/keys` for the complete shortcut list.
 

--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ Unix 上 Node 与 Rust 使用 fd 3/4，Windows 使用带随机 token 的 loopbac
 | Linux/Windows | `ctrl+←/→` 跳词 · `ctrl+⌫` 删词 |
 | 点击工具 · 滚轮 | 点击工具展开/折叠输出；滚轮始终滚动整个对话 |
 | 鼠标拖选 | 松手复制；双击复制单词；`shift+拖选` 使用终端原生选择 |
-| `!cmd` | 在客户端本地执行 shell 命令，不经过 agent |
+| `!cmd` | 在客户端本地执行一次性 shell 命令，不经过 agent；每次调用都从 workspace 启动独立的 `sh -lc`，`cd`、环境变量等状态不会保留。需要切目录时请写成 `!cd dir && command` |
 
 界面内使用 `/help` 查看命令，使用 `/keys` 查看完整快捷键。
 

--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ Unix 上 Node 与 Rust 使用 fd 3/4，Windows 使用带随机 token 的 loopbac
 | Linux/Windows | `ctrl+←/→` 跳词 · `ctrl+⌫` 删词 |
 | 点击工具 · 滚轮 | 点击工具展开/折叠输出；滚轮始终滚动整个对话 |
 | 鼠标拖选 | 松手复制；双击复制单词；`shift+拖选` 使用终端原生选择 |
-| `!cmd` | 在客户端本地执行一次性 shell 命令，不经过 agent；每次调用都从 workspace 启动独立的 `sh -lc`，`cd`、环境变量等状态不会保留。需要切目录时请写成 `!cd dir && command` |
+| `!cmd` | 在客户端的会话级本地 shell 中执行命令，不经过 agent；shell 从 workspace 启动，`cd`、环境变量等状态会在后续 `!` 命令中保留，退出 TUI 后结束 |
 
 界面内使用 `/help` 查看命令，使用 `/keys` 查看完整快捷键。
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -3865,7 +3865,8 @@ DeepSeek Build (dsh-tui) — 终端里的 deepseek-harness
   /resume      恢复持久会话并继续写入原日志
   /image       暂存本地图片：/image ./pic.png [说明]
   /clip        暂存剪贴板图片；ctrl+v 同样可用
-  !cmd         直接运行本地命令，不经过 Agent
+  !cmd         单次运行本地命令，不经过 Agent；每次从 workspace 启动
+               cd/环境变量不会跨命令保留；请用 !cd dir && command
   /<skill>     Agent 命令会进入 / 菜单，选择后由 Host 注入技能正文
   ctrl+o       展开思考和工具输出   ctrl+l 清屏
   点击工具     展开/折叠；滚轮滚动对话
@@ -3899,7 +3900,9 @@ DeepSeek Build (dsh-tui) — deepseek-harness in your terminal
                up to 8 ride one prompt as inline [image n] chips in the text
                — ⌫ on a chip removes it · hover (or park the cursor on) a
                chip for a preview with dimensions, size, and type
-  !cmd         run a local shell command (not the agent)
+  !cmd         run one local shell command (not the agent); every call starts
+               in the workspace — cd/env state does not carry over
+               use !cd dir && command when needed
   /<skill>     agent commands join the / menu — picking one lands
                `/name ` in the composer; enter ships it and the host injects
                the skill body (works for disable-model-invocation skills too)

--- a/src/app.rs
+++ b/src/app.rs
@@ -3,10 +3,11 @@
 //! Enter sends (or queues mid-turn, client-side); Ctrl+X steers the active
 //! turn immediately; Esc cancels a running turn with the draft preserved, and
 //! Esc owns interrupt; Ctrl+C clears a draft, then needs two empty presses to quit;
-//! `!` runs a local shell command; `/` opens the slash menu; Up recalls
+//! `!` runs a command in the session's local shell; `/` opens the slash menu; Up recalls
 //! history on an empty prompt.
 
 use std::collections::{HashMap, VecDeque};
+use std::io::{BufRead, BufReader, Write};
 use std::sync::mpsc::Sender;
 use std::time::{Duration, Instant};
 
@@ -640,6 +641,160 @@ pub struct Modes {
     pub effort: Option<String>,
 }
 
+struct ShellRequest {
+    id: u64,
+    command: String,
+}
+
+struct ShellWorker {
+    tx: Sender<ShellRequest>,
+}
+
+impl ShellWorker {
+    fn spawn(cwd: String, app_tx: Sender<AppEvent>) -> Self {
+        let (tx, rx) = std::sync::mpsc::channel::<ShellRequest>();
+        std::thread::spawn(move || {
+            let mut shell: Option<PersistentShell> = None;
+            for request in rx {
+                if shell.is_none() {
+                    match PersistentShell::spawn(&cwd) {
+                        Ok(started) => shell = Some(started),
+                        Err(err) => {
+                            let _ = app_tx.send(AppEvent::ShellDone {
+                                id: request.id,
+                                code: None,
+                                output: format!("failed to start shell: {err}"),
+                            });
+                            continue;
+                        }
+                    }
+                }
+
+                let result = shell.as_mut().unwrap().run(request.id, &request.command);
+                let (code, output, alive) = match result {
+                    Ok(result) => result,
+                    Err(err) => (None, format!("shell failed: {err}"), false),
+                };
+                if !alive {
+                    shell = None;
+                }
+                let _ = app_tx.send(AppEvent::ShellDone {
+                    id: request.id,
+                    code,
+                    output,
+                });
+            }
+        });
+        Self { tx }
+    }
+
+    fn send(&self, request: ShellRequest) -> Result<(), ShellRequest> {
+        self.tx.send(request).map_err(|err| err.0)
+    }
+}
+
+struct PersistentShell {
+    child: std::process::Child,
+    stdin: std::process::ChildStdin,
+    stdout: BufReader<std::process::ChildStdout>,
+    marker: String,
+}
+
+impl PersistentShell {
+    fn spawn(cwd: &str) -> std::io::Result<Self> {
+        let mut child = std::process::Command::new("sh")
+            .arg("-l")
+            .arg("-s")
+            .current_dir(cwd)
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::null())
+            .spawn()?;
+        let mut stdin = child.stdin.take().ok_or_else(|| {
+            std::io::Error::new(std::io::ErrorKind::BrokenPipe, "shell stdin unavailable")
+        })?;
+        let stdout = child.stdout.take().ok_or_else(|| {
+            std::io::Error::new(std::io::ErrorKind::BrokenPipe, "shell stdout unavailable")
+        })?;
+        // Keep a control fd independent from shell-level stdout redirects.
+        stdin.write_all(b"exec 9>&1\n")?;
+        stdin.flush()?;
+        Ok(Self {
+            child,
+            stdin,
+            stdout: BufReader::new(stdout),
+            marker: format!("MARTTY_SHELL_{}_{}", std::process::id(), timestamp()),
+        })
+    }
+
+    fn run(&mut self, id: u64, command: &str) -> std::io::Result<(Option<i32>, String, bool)> {
+        let marker = format!("\x1e{}:{id}:", self.marker);
+        writeln!(self.stdin, "eval {} 2>&1", shell_quote(command))?;
+        writeln!(self.stdin, "__martty_shell_status=$?")?;
+        writeln!(
+            self.stdin,
+            "command printf '\\036{}:{id}:%s\\037' \"$__martty_shell_status\" >&9",
+            self.marker
+        )?;
+        self.stdin.flush()?;
+
+        let mut captured = Vec::new();
+        loop {
+            let read = self.stdout.read_until(0x1f, &mut captured)?;
+            if read == 0 {
+                let code = self.child.wait().ok().and_then(|status| status.code());
+                return Ok((code, shell_output(captured), false));
+            }
+            let Some(start) = find_bytes(&captured, marker.as_bytes()) else {
+                continue;
+            };
+            let status_start = start + marker.len();
+            let Some(status_len) = captured[status_start..]
+                .iter()
+                .position(|byte| *byte == 0x1f)
+            else {
+                continue;
+            };
+            let status = std::str::from_utf8(&captured[status_start..status_start + status_len])
+                .ok()
+                .and_then(|value| value.parse::<i32>().ok());
+            captured.truncate(start);
+            return Ok((status, shell_output(captured), true));
+        }
+    }
+}
+
+impl Drop for PersistentShell {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+fn shell_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\\\"'\\\"'"))
+}
+
+fn find_bytes(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    haystack
+        .windows(needle.len())
+        .position(|window| window == needle)
+}
+
+fn shell_output(bytes: Vec<u8>) -> String {
+    let mut output = String::from_utf8_lossy(&bytes).into_owned();
+    const LIMIT: usize = 16 * 1024;
+    if output.len() > LIMIT {
+        let mut cut = LIMIT;
+        while cut > 0 && !output.is_char_boundary(cut) {
+            cut -= 1;
+        }
+        output.truncate(cut);
+        output.push_str("\n… (truncated)");
+    }
+    output
+}
+
 pub struct App {
     pub theme: Theme,
     pub locale: Locale,
@@ -751,6 +906,7 @@ pub struct App {
     prompt_pending: bool,
     shell_seq: u64,
     shell_pending: Vec<(u64, usize)>, // (id, cell idx)
+    shell_worker: Option<ShellWorker>,
     bus_tx: Sender<AppEvent>,
     pub server_info: Option<String>,
     pub needs_redraw: bool,
@@ -1040,6 +1196,7 @@ impl App {
             prompt_pending: false,
             shell_seq: 0,
             shell_pending: Vec::new(),
+            shell_worker: None,
             bus_tx,
             server_info: None,
             needs_redraw: true,
@@ -3865,8 +4022,8 @@ DeepSeek Build (dsh-tui) — 终端里的 deepseek-harness
   /resume      恢复持久会话并继续写入原日志
   /image       暂存本地图片：/image ./pic.png [说明]
   /clip        暂存剪贴板图片；ctrl+v 同样可用
-  !cmd         单次运行本地命令，不经过 Agent；每次从 workspace 启动
-               cd/环境变量不会跨命令保留；请用 !cd dir && command
+  !cmd         在会话级本地 shell 中运行命令，不经过 Agent
+               初始目录为 workspace；cd/环境变量会跨命令保留
   /<skill>     Agent 命令会进入 / 菜单，选择后由 Host 注入技能正文
   ctrl+o       展开思考和工具输出   ctrl+l 清屏
   点击工具     展开/折叠；滚轮滚动对话
@@ -3900,9 +4057,8 @@ DeepSeek Build (dsh-tui) — deepseek-harness in your terminal
                up to 8 ride one prompt as inline [image n] chips in the text
                — ⌫ on a chip removes it · hover (or park the cursor on) a
                chip for a preview with dimensions, size, and type
-  !cmd         run one local shell command (not the agent); every call starts
-               in the workspace — cd/env state does not carry over
-               use !cd dir && command when needed
+  !cmd         run in the session's local shell (not the agent); it starts in
+               the workspace and keeps cd/env state across commands
   /<skill>     agent commands join the / menu — picking one lands
                `/name ` in the composer; enter ships it and the host injects
                the skill body (works for disable-model-invocation skills too)
@@ -4345,43 +4501,78 @@ usage (incl. cache hits), and the turn end reason.";
         let id = self.shell_seq;
         let cell = self.transcript.push_shell(cmd.clone());
         self.shell_pending.push((id, cell));
-        let tx = self.bus_tx.clone();
-        let cwd = self.cfg.workspace.clone();
-        std::thread::spawn(move || {
-            let out = std::process::Command::new("sh")
-                .arg("-lc")
-                .arg(&cmd)
-                .current_dir(&cwd)
-                .output();
-            let (code, text) = match out {
-                Ok(o) => {
-                    let mut s = String::from_utf8_lossy(&o.stdout).into_owned();
-                    let e = String::from_utf8_lossy(&o.stderr);
-                    if !e.trim().is_empty() {
-                        if !s.is_empty() {
-                            s.push('\n');
-                        }
-                        s.push_str(&e);
-                    }
-                    const LIMIT: usize = 16 * 1024;
-                    if s.len() > LIMIT {
-                        let mut cut = LIMIT;
-                        while cut > 0 && !s.is_char_boundary(cut) {
-                            cut -= 1;
-                        }
-                        s.truncate(cut);
-                        s.push_str("\n… (truncated)");
-                    }
-                    (o.status.code(), s)
-                }
-                Err(err) => (None, format!("failed to run: {err}")),
-            };
-            let _ = tx.send(AppEvent::ShellDone {
-                id,
-                code,
-                output: text,
-            });
+        let request = ShellRequest { id, command: cmd };
+        let worker = self.shell_worker.get_or_insert_with(|| {
+            ShellWorker::spawn(self.cfg.workspace.clone(), self.bus_tx.clone())
         });
+        if let Err(request) = worker.send(request) {
+            let worker = ShellWorker::spawn(self.cfg.workspace.clone(), self.bus_tx.clone());
+            if let Err(request) = worker.send(request) {
+                let _ = self.bus_tx.send(AppEvent::ShellDone {
+                    id: request.id,
+                    code: None,
+                    output: "failed to start shell worker".into(),
+                });
+            }
+            self.shell_worker = Some(worker);
+        }
+    }
+}
+
+#[cfg(test)]
+mod persistent_shell_tests {
+    use super::*;
+    use std::sync::mpsc::Receiver;
+
+    fn test_app(workspace: &std::path::Path) -> (App, Receiver<AppEvent>) {
+        let cfg = RuntimeConfig {
+            bin: "demo".into(),
+            cordis: "demo".into(),
+            workspace: workspace.to_string_lossy().into_owned(),
+            session_root: workspace.join("sessions").to_string_lossy().into_owned(),
+            provider: "deepseek-official".into(),
+            model: "deepseek-v4-flash".into(),
+            max_tokens: None,
+            base_url: None,
+            api_key: None,
+        };
+        let (tx, rx) = std::sync::mpsc::channel::<AppEvent>();
+        let app = App::new(Theme::dark(), cfg, "dsh-test".into(), true, false, tx);
+        (app, rx)
+    }
+
+    fn wait_for_shell(rx: &Receiver<AppEvent>) -> (Option<i32>, String) {
+        match rx
+            .recv_timeout(Duration::from_secs(5))
+            .expect("local shell result")
+        {
+            AppEvent::ShellDone { code, output, .. } => (code, output),
+            _ => panic!("unexpected app event"),
+        }
+    }
+
+    #[test]
+    fn local_shell_state_persists_between_invocations() {
+        let workspace =
+            std::env::temp_dir().join(format!("martty-shell-state-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&workspace);
+        std::fs::create_dir_all(workspace.join("nested")).unwrap();
+        let (mut app, rx) = test_app(&workspace);
+
+        app.run_local_shell("cd nested; export MARTTY_SHELL_TEST=kept".into());
+        assert_eq!(wait_for_shell(&rx).0, Some(0));
+        app.run_local_shell("printf %s \"$MARTTY_SHELL_TEST\" > shell-state.txt".into());
+        assert_eq!(wait_for_shell(&rx).0, Some(0));
+
+        let state_file = workspace.join("nested/shell-state.txt");
+        assert!(
+            state_file.exists(),
+            "the second command must run in the directory selected by the first"
+        );
+        assert_eq!(std::fs::read_to_string(state_file).unwrap(), "kept");
+        assert!(!workspace.join("shell-state.txt").exists());
+        drop(app);
+        let _ = std::fs::remove_dir_all(workspace);
     }
 }
 

--- a/src/locale.rs
+++ b/src/locale.rs
@@ -68,7 +68,7 @@ impl Locale {
     pub fn ambient_tip(self, index: usize) -> &'static str {
         const EN: [&str; 8] = [
             "esc interrupts a running turn — your draft survives",
-            "type ! to run a one-shot local shell command without the agent",
+            "type ! to run a command in the session's persistent local shell",
             "enter queues a follow-up; ctrl+x steers the active turn now",
             "click a tool to expand it · wheel always scrolls the conversation",
             "the footer under the composer shows token usage + cache hit rate",

--- a/src/locale.rs
+++ b/src/locale.rs
@@ -68,7 +68,7 @@ impl Locale {
     pub fn ambient_tip(self, index: usize) -> &'static str {
         const EN: [&str; 8] = [
             "esc interrupts a running turn — your draft survives",
-            "type ! to run a local shell command without the agent",
+            "type ! to run a one-shot local shell command without the agent",
             "enter queues a follow-up; ctrl+x steers the active turn now",
             "click a tool to expand it · wheel always scrolls the conversation",
             "the footer under the composer shows token usage + cache hit rate",


### PR DESCRIPTION
## Summary

- keep one client-local login shell alive for the lifetime of the TUI
- serialize `!` commands through a background worker so `cd`, exported variables, and other shell state carry across invocations
- preserve the existing transcript/event path, combined output capture, exit status, and 16 KiB display limit
- recreate the shell from the configured workspace after it exits or fails
- update the English and Chinese README, `/help`, ambient tip, and changelog to describe the persistent behavior

## Why

Issue #21 reports that separate `!` commands lose working-directory changes. The first draft documented the existing one-shot behavior, but reviewer feedback confirmed that persistent `cd` behavior is a useful Claude Code workflow and a blocker for adopting Martty. This revision implements that behavior rather than only documenting the limitation.

## Validation

- regression test observed failing before implementation, then passing with `cd` and `export` preserved across two invocations
- `cargo test` — 358 tests passed
- `git diff --check`

Closes #21
