### PR TITLE
fix: keep permission and command switching working on dsh >= 0.1.1-rc.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,11 @@ All notable changes to this project are documented here. The project follows
 
 ### Fixed
 
+- The welcome banner no longer swallows command output: `/help`, `/session`,
+  `/status`, `/clear`, `!shell` and plugin commands run while the banner is
+  showing now dismiss it, so their scrollback output is visible immediately
+  instead of only after the next prompt. Transient commands like `/liang`
+  keep the banner.
 - Permission switching (`/permission`, shift+tab) no longer fails when the
   profile's dsh is newer than the bundled ACP adapter
   (`@deepseek-ai/dsh` >= 0.1.1-rc.1): `dsh-permission-presets` records an

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,25 @@ All notable changes to this project are documented here. The project follows
 
 ### Fixed
 
+- Permission switching (`/permission`, shift+tab) no longer fails when the
+  profile's dsh is newer than the bundled ACP adapter
+  (`@deepseek-ai/dsh` >= 0.1.1-rc.1): `dsh-permission-presets` records an
+  `origin` on every live switch and `dsh-session` rejects event data holding
+  `undefined`, which broke `session/set_mode` with
+  `session event "permission/preset" carries non-JSON-serializable data`. The
+  new `dsh-tui-permission-compat` host plugin defaults the adapter's omitted
+  origin to `"selection"`, keeping the switch working on both new and old
+  dsh. A failed switch is now reported as a warning with an actionable hint
+  instead of a success notice.
+- Harness slash commands no longer fail on `@deepseek-ai/dsh` >= 0.1.0-rc.8:
+  `dsh-commands` changed `execute` to take a composer-images argument, and
+  the bundled ACP adapter's three-argument calls made every command
+  (`/plan` via the `collaboration_mode` config option, plus typed
+  `/compact`, `/goal`, `/permission`, `/plan`) die with
+  `Cannot read properties of undefined (reading 'aborted')`. The same
+  `dsh-tui-permission-compat` plugin detects the legacy call shape and
+  inserts the empty images batch; the legacy three-parameter signature
+  passes through untouched.
 - The plan review window (the ACP elicitation form the agent opens with
   `exit_plan_mode`) now renders the plan markdown through the full markdown
   pipeline instead of truncating raw source lines: headings lose their `#`,

--- a/npm/cordis.patch.yml
+++ b/npm/cordis.patch.yml
@@ -23,6 +23,12 @@
     - id: tui-acp-host
       name: '@openma/deepseek-harness-tui/acp-host'
 
+    # Keeps session/set_mode working when the profile's dsh is newer than the
+    # bundled ACP adapter: defaults the permission/preset origin so the event
+    # data stays losslessly JSON-serializable (dsh >= 0.1.1-rc.1).
+    - id: tui-permission-compat
+      name: '@openma/deepseek-harness-tui/dsh-compat'
+
     - id: tui-host-creator
       name: '@openma/deepseek-harness-tui/creator-overlay'
 

--- a/npm/lib/dsh-compat.js
+++ b/npm/lib/dsh-compat.js
@@ -1,0 +1,55 @@
+/**
+ * Host-side compatibility for newer @deepseek-ai/dsh releases.
+ *
+ * Two adapter-vs-dsh seams broke when dsh moved past 0.1.0-rc.7:
+ *
+ * 1. Permission switches: dsh-permission-presets >= 0.1.1-rc.1 records the
+ *    origin of every live permission switch in the session log, and
+ *    dsh-session >= 0.1.1-rc.1 rejects event data that is not losslessly
+ *    JSON-serializable (an object property holding `undefined` fails that
+ *    check). The bundled ACP adapter calls
+ *    `permissionPresets.apply(session, modeId, setApproval)` with no origin,
+ *    so on the new dsh a switch appended `{ preset, origin: undefined }` and
+ *    every `session/set_mode` failed with
+ *    `session event "permission/preset" carries non-JSON-serializable data`.
+ *    We default the omitted origin to `"selection"` — the same origin the
+ *    host's own `/permission` command uses.
+ *
+ * 2. Harness command dispatch: dsh-commands >= 0.1.0-rc.8 changed
+ *    `execute(agent, line, signal)` to `execute(agent, line, images, signal)`
+ *    (composer image attachments). The bundled ACP adapter still calls with
+ *    three arguments, so `signal` arrives `undefined` and every harness
+ *    command — `/plan` and `/plan off` via the `collaboration_mode` config
+ *    option, plus user-typed `/compact`, `/goal`, `/permission`, `/plan` —
+ *    failed with `Cannot read properties of undefined (reading 'aborted')`.
+ *    We detect the legacy three-argument call shape and insert the empty
+ *    images batch; the legacy two-argument shape passes through untouched.
+ */
+
+export const name = 'dsh-tui-permission-compat'
+export const inject = ['permissionPresets', 'commands']
+
+export function apply(ctx) {
+  const permission = ctx.permissionPresets
+  const originalApply = permission?.apply
+  if (typeof originalApply === 'function') {
+    permission.apply = function applyWithOrigin(session, preset, setApproval, origin) {
+      return originalApply.call(this, session, preset, setApproval, origin ?? 'selection')
+    }
+  }
+
+  const commands = ctx.commands
+  const originalExecute = commands?.execute
+  if (typeof originalExecute === 'function') {
+    // `Function.length` distinguishes the legacy three-parameter signature
+    // from the rc.8+ four-parameter one.
+    const legacy = originalExecute.length < 4
+    commands.execute = function executeWithImages(agent, line, images, signal) {
+      if (legacy) return originalExecute.call(this, agent, line, images)
+      if (arguments.length < 4 && images !== undefined && typeof images.aborted === 'boolean') {
+        return originalExecute.call(this, agent, line, [], images)
+      }
+      return originalExecute.call(this, agent, line, images ?? [], signal)
+    }
+  }
+}

--- a/npm/package.json
+++ b/npm/package.json
@@ -15,7 +15,7 @@
   "main": "lib/index.js",
   "scripts": {
     "pretest": "node --test ../scripts/workflow-release.test.mjs ../scripts/package-alias.test.mjs",
-    "test": "node --test ../scripts/package-native.test.mjs ../scripts/check-release-tag.test.mjs ../scripts/check-static-elf.test.mjs ../scripts/smoke-old-linux.test.mjs ../scripts/cargo-guard.test.mjs ../scripts/build-npm.test.mjs ../scripts/client-profile.test.mjs ../scripts/plugin-runner.test.mjs ../scripts/profile-link-resolution.test.mjs ../scripts/release.test.mjs ../scripts/jsonrpc-line-transport.test.mjs ../scripts/tui-theme.test.mjs ../scripts/tui-presets.test.mjs ../scripts/tui-slots.test.mjs ../scripts/tui-commands.test.mjs ../scripts/tui-overlay.test.mjs ../scripts/mux.test.mjs ../scripts/acp-client.test.mjs ../scripts/acp-client-events.test.mjs ../scripts/acp-session-config.test.mjs ../scripts/acp-session-plan.test.mjs ../scripts/acp-session-stats.test.mjs ../scripts/acp-session-status.test.mjs ../scripts/plan-view.test.mjs ../scripts/stats-view.test.mjs ../scripts/status-view.test.mjs ../scripts/deepseek-logo.test.mjs ../scripts/runner.test.mjs ../scripts/inspect.test.mjs ../scripts/creator-overlay.test.mjs ../scripts/real-agent-e2e.test.mjs"
+    "test": "node --test ../scripts/package-native.test.mjs ../scripts/check-release-tag.test.mjs ../scripts/check-static-elf.test.mjs ../scripts/smoke-old-linux.test.mjs ../scripts/cargo-guard.test.mjs ../scripts/build-npm.test.mjs ../scripts/client-profile.test.mjs ../scripts/plugin-runner.test.mjs ../scripts/profile-link-resolution.test.mjs ../scripts/release.test.mjs ../scripts/jsonrpc-line-transport.test.mjs ../scripts/tui-theme.test.mjs ../scripts/tui-presets.test.mjs ../scripts/tui-slots.test.mjs ../scripts/tui-commands.test.mjs ../scripts/tui-overlay.test.mjs ../scripts/mux.test.mjs ../scripts/acp-client.test.mjs ../scripts/acp-client-events.test.mjs ../scripts/acp-session-config.test.mjs ../scripts/acp-session-plan.test.mjs ../scripts/acp-session-stats.test.mjs ../scripts/acp-session-status.test.mjs ../scripts/plan-view.test.mjs ../scripts/stats-view.test.mjs ../scripts/status-view.test.mjs ../scripts/deepseek-logo.test.mjs ../scripts/runner.test.mjs ../scripts/inspect.test.mjs ../scripts/creator-overlay.test.mjs ../scripts/dsh-compat.test.mjs ../scripts/real-agent-e2e.test.mjs"
   },
   "publishConfig": {
     "access": "public",
@@ -42,6 +42,7 @@
     "./acp-client-events": "./lib/acp-client-events.js",
     "./profile-acp-client": "./lib/profile-acp-client.js",
     "./acp-host": "./lib/acp-host.js",
+    "./dsh-compat": "./lib/dsh-compat.js",
     "./creator-overlay": "./lib/creator-overlay.js",
     "./cordis-client-runner": "./lib/inspect.js",
     "./runner": "./lib/runner.js",

--- a/scripts/devlocalinstall.sh
+++ b/scripts/devlocalinstall.sh
@@ -1,28 +1,52 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Dev-local install: builds a debug painter (fast, no release build) and
+# installs the plugin into a freshly wiped `tui` profile. Only cargo and npm
+# themselves are used — no external build scripts.
+#
+# WARNING: the whole ~/.dsh/profiles/tui directory is deleted first, so any
+# custom cordis.patch.yml overlays, other installed plugins, and the
+# profile's session data are discarded. This is a dev scratch install.
+
 cd "$(dirname "${BASH_SOURCE[0]}")/.."
 
-# 1. Build the npm tarball (cargo release build + npm pack -> dist/)
-./scripts/build-npm.sh
+# 1. Build the native painter as a debug binary (locked to Cargo.lock).
+cargo build --locked
 
-# 2. Pick the highest-version tarball in dist/. Version sort (sort -V),
-#    not mtime: a later-built older version must never regress the install.
-shopt -s nullglob
-tgz=(dist/openma-deepseek-harness-tui-*.tgz)
-if (( ${#tgz[@]} == 0 )); then
-  echo "no tarball in dist/ — did build-npm.sh succeed?" >&2
-  exit 1
+# 2. Stage the binary into the npm bundle's vendor dir for this platform,
+#    mirroring package-native's layout: npm/vendor/<platform>-<arch>/dsh-tui.
+PLATFORM="$(uname -s)"
+case "$PLATFORM" in
+  Linux) PLATFORM=linux ;;
+  Darwin) PLATFORM=darwin ;;
+  MINGW*|MSYS*|CYGWIN*) PLATFORM=win32 ;;
+  *) echo "unsupported platform: $PLATFORM" >&2; exit 1 ;;
+esac
+ARCH="$(uname -m)"
+case "$ARCH" in
+  x86_64|amd64) ARCH=x64 ;;
+  aarch64|arm64) ARCH=arm64 ;;
+  *) echo "unsupported arch: $ARCH" >&2; exit 1 ;;
+esac
+
+BIN="target/debug/dsh-tui"
+if [[ "$PLATFORM" == "win32" ]]; then
+  BIN="${BIN}.exe"
 fi
-LATEST="$(printf '%s\n' "${tgz[@]}" | sort -V | tail -n 1)"
-echo "using tarball: $LATEST"
+VENDOR_DIR="npm/vendor/$PLATFORM-$ARCH"
+mkdir -p "$VENDOR_DIR"
+install -m 755 "$BIN" "$VENDOR_DIR/dsh-tui"
+echo "staged debug painter at $VENDOR_DIR/dsh-tui"
 
-# 3. Install the freshly built plugin into the tui profile.
-#    pnpm re-installs the tarball when its content changes (integrity check);
-#    clearing node_modules + lockfile below is a belt-and-braces force step.
-#    Deliberately NOT wiping the whole profile dir, so the user's
-#    cordis.patch.yml layer and any other installed plugins survive.
-rm -rf ~/.dsh/profiles/tui/node_modules ~/.dsh/profiles/tui/pnpm-lock.yaml
-dsh plugin --profile tui add "$PWD/$LATEST"
+# 3. Pack the npm bundle.
+mkdir -p dist
+TGZ_NAME="$(cd npm && npm pack --pack-destination ../dist 2>/dev/null | tail -n 1)"
+TGZ="dist/$TGZ_NAME"
+echo "using tarball: $TGZ"
 
-echo "installed $LATEST into profile tui — restart the TUI or run /refresh to pick it up"
+# 4. Wipe the whole profile, then install from scratch.
+rm -rf ~/.dsh/profiles/tui
+dsh plugin --profile tui add "$PWD/$TGZ"
+
+echo "installed $TGZ into a fresh profile tui — restart the TUI to pick it up"

--- a/scripts/dsh-compat.test.mjs
+++ b/scripts/dsh-compat.test.mjs
@@ -1,0 +1,115 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { createRequire } from 'node:module'
+import path from 'node:path'
+import test from 'node:test'
+import { pathToFileURL } from 'node:url'
+
+const repoRoot = path.resolve(import.meta.dirname, '..')
+const npmRequire = createRequire(path.join(repoRoot, 'npm/package.json'))
+const cordisUrl = pathToFileURL(npmRequire.resolve('@deepseek-ai/cordis')).href
+const compatUrl = pathToFileURL(path.join(repoRoot, 'npm/lib/dsh-compat.js')).href
+
+const compatPlugin = await import(compatUrl)
+
+test('dsh-compat ships in the bundle patch and package exports', () => {
+  const patch = readFileSync(path.join(repoRoot, 'npm/cordis.patch.yml'), 'utf8')
+  assert.match(patch, /tui-permission-compat/)
+  assert.match(patch, /@openma\/deepseek-harness-tui\/dsh-compat/)
+  const pkg = JSON.parse(readFileSync(path.join(repoRoot, 'npm/package.json'), 'utf8'))
+  assert.equal(pkg.exports['./dsh-compat'], './lib/dsh-compat.js')
+})
+
+test('dsh-compat defaults an omitted permission/preset origin to "selection"', async () => {
+  const { Context } = await import(cordisUrl)
+  const ctx = new Context()
+  const calls = []
+  const service = {
+    apply(session, preset, setApproval, origin) {
+      calls.push({ session, preset, setApproval, origin })
+    },
+  }
+  ctx.provide('permissionPresets', service)
+  ctx.provide('commands', { execute() {} })
+  await ctx.plugin(compatPlugin)
+
+  const session = { id: 's1' }
+  const setApproval = () => {}
+  // The bundled ACP adapter calls apply without an origin — the compat layer
+  // must supply one so the appended event data is losslessly serializable.
+  ctx.permissionPresets.apply(session, 'danger-full-access', setApproval)
+  assert.equal(calls.length, 1)
+  assert.equal(calls[0].session, session)
+  assert.equal(calls[0].preset, 'danger-full-access')
+  assert.equal(calls[0].setApproval, setApproval)
+  assert.equal(calls[0].origin, 'selection')
+
+  // Explicit origins pass through untouched.
+  ctx.permissionPresets.apply(session, 'workspace-write', setApproval, 'default')
+  assert.equal(calls[1].origin, 'default')
+})
+
+test('dsh-compat inserts the images batch for legacy three-argument execute calls', async () => {
+  const { Context } = await import(cordisUrl)
+  const ctx = new Context()
+  const calls = []
+  const signal = { aborted: false }
+  // rc.8+ signature: execute(agent, line, images, signal)
+  const commands = {
+    execute(agent, line, images, signalArg) {
+      calls.push({ agent, line, images, signalArg })
+    },
+  }
+  ctx.provide('permissionPresets', { apply() {} })
+  ctx.provide('commands', commands)
+  await ctx.plugin(compatPlugin)
+
+  // The adapter's legacy three-argument call shape: signal in the images slot.
+  ctx.commands.execute('agent-1', '/plan', signal)
+  assert.equal(calls.length, 1)
+  assert.equal(calls[0].agent, 'agent-1')
+  assert.equal(calls[0].line, '/plan')
+  assert.deepEqual(calls[0].images, [])
+  assert.equal(calls[0].signalArg, signal)
+
+  // Four-argument calls pass through with the caller's images.
+  ctx.commands.execute('agent-1', '/plan', ['data:image/png;base64,x'], { aborted: false })
+  assert.equal(calls[1].images.length, 1)
+  assert.equal(calls[1].signalArg.aborted, false)
+
+  // An omitted images slot defaults to the empty batch.
+  ctx.commands.execute('agent-1', '/compact', undefined, { aborted: false })
+  assert.deepEqual(calls[2].images, [])
+})
+
+test('dsh-compat passes through the legacy three-parameter execute signature', async () => {
+  const { Context } = await import(cordisUrl)
+  const ctx = new Context()
+  const calls = []
+  // rc.7 signature: execute(agent, line, signal)
+  const commands = {
+    execute(agent, line, signal) {
+      calls.push({ agent, line, signal })
+    },
+  }
+  ctx.provide('permissionPresets', { apply() {} })
+  ctx.provide('commands', commands)
+  await ctx.plugin(compatPlugin)
+
+  const signal = { aborted: false }
+  ctx.commands.execute('agent-1', '/compact', signal)
+  assert.equal(calls.length, 1)
+  assert.equal(calls[0].agent, 'agent-1')
+  assert.equal(calls[0].line, '/compact')
+  assert.equal(calls[0].signal, signal)
+})
+
+test('dsh-compat tolerates apply-less and execute-less services', async () => {
+  const { Context } = await import(cordisUrl)
+  const ctx = new Context()
+  ctx.provide('permissionPresets', {})
+  ctx.provide('commands', {})
+  await ctx.plugin(compatPlugin)
+  assert.equal(ctx.permissionPresets.apply, undefined)
+  assert.equal(ctx.commands.execute, undefined)
+})

--- a/src/acp.rs
+++ b/src/acp.rs
@@ -186,6 +186,23 @@ fn acp_err(err: AcpError) -> anyhow::Error {
     anyhow::anyhow!("{err}")
 }
 
+/// Actionable hint for a failed permission switch, keyed off the host error.
+///
+/// dsh >= 0.1.1-rc.1 rejects a `permission/preset` event whose data is not
+/// losslessly JSON-serializable (the bundled ACP adapter appended
+/// `origin: undefined`); the TUI bundle's `dsh-tui-permission-compat` host
+/// plugin fixes that on the profile path, so this hints at a host that runs
+/// without the compat layer (e.g. a standalone `dsh-acp`).
+fn permission_switch_failure_hint(message: &str) -> &'static str {
+    if message.contains("permission/preset") && message.contains("non-JSON-serializable") {
+        " — host rejected the permission/preset event: the profile's dsh is newer than the bundled ACP adapter; update Martty (dsh-tui-permission-compat) or pin @deepseek-ai/dsh to 0.1.0-rc.8"
+    } else if message.contains("unknown mode") || message.contains("unknown permission preset") {
+        " — /permission opens the preset picker"
+    } else {
+        ""
+    }
+}
+
 pub(crate) fn initialize_request() -> InitializeRequest {
     InitializeRequest::new(ProtocolVersion::V1)
         .client_info(Implementation::new("dsh-tui", env!("CARGO_PKG_VERSION")))
@@ -1860,6 +1877,10 @@ where
                                     );
                                 }
                                 Err(err) => {
+                                    // Config-option "mode" is the fallback
+                                    // switch surface on hosts where
+                                    // session/set_mode is not the active one;
+                                    // both routes share the host applyMode.
                                     let _ = cx
                                         .send_request(SetSessionConfigOptionRequest::new(
                                             sid,
@@ -1868,9 +1889,13 @@ where
                                         ))
                                         .block_task()
                                         .await;
-                                    let _ = bus.send(AppEvent::Ctl(CtlEvent::TuiOpDone(format!(
-                                        "permission → {preset} ({err})"
-                                    ))));
+                                    let message = acp_error_message(&err);
+                                    let _ = bus.send(AppEvent::Ctl(CtlEvent::TuiOpFailed(
+                                        format!(
+                                            "permission switch failed: {message}{}",
+                                            permission_switch_failure_hint(&message)
+                                        ),
+                                    )));
                                 }
                             }
                         }
@@ -2325,6 +2350,26 @@ where
 mod tests {
     use super::*;
     use serde_json::json;
+
+    #[test]
+    fn permission_switch_failure_hint_maps_host_rejections() {
+        // dsh >= 0.1.1-rc.1 rejecting the undefined origin gets the compat hint.
+        let new_dsh = permission_switch_failure_hint(
+            "session event \"permission/preset\" carries non-JSON-serializable data",
+        );
+        assert!(new_dsh.contains("dsh-tui-permission-compat"), "{new_dsh}");
+        assert!(new_dsh.contains("0.1.0-rc.8"), "{new_dsh}");
+
+        // Unknown presets keep the picker hint.
+        let unknown = permission_switch_failure_hint("Invalid params: unknown mode: nope");
+        assert!(
+            unknown.contains("/permission opens the preset picker"),
+            "{unknown}"
+        );
+
+        // Anything else stays unadorned.
+        assert_eq!(permission_switch_failure_hint("some other failure"), "");
+    }
 
     #[test]
     fn dynamic_plugin_inventory_uses_the_backend_current_package_and_run_state() {

--- a/src/acp_term.rs
+++ b/src/acp_term.rs
@@ -232,10 +232,30 @@ mod tests {
             .expect("spawn echo");
         let status = broker.wait(&id).await;
         assert_eq!(status.exit_code, Some(0));
-        let (output, truncated, _) = broker.output(&id);
+        // The reader thread can still be draining the pipe after the process
+        // exits; poll briefly instead of asserting on a possibly-empty buffer.
+        let (output, truncated, _) = wait_for_text(&broker, &id, "acp-term").await;
         assert!(output.contains("acp-term"), "output: {output:?}");
         assert!(!truncated);
         broker.release(&id);
+    }
+
+    /// Poll `broker.output` until `needle` appears or a short deadline passes,
+    /// returning the final snapshot. Process exit and pipe EOF are separate
+    /// events observed by different threads, so the buffer may briefly lag.
+    async fn wait_for_text(
+        broker: &TerminalBroker,
+        id: &str,
+        needle: &str,
+    ) -> (String, bool, Option<TerminalExitStatus>) {
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(2);
+        loop {
+            let snapshot = broker.output(id);
+            if snapshot.0.contains(needle) || tokio::time::Instant::now() >= deadline {
+                return snapshot;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
     }
 
     #[tokio::test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -4085,6 +4085,7 @@ impl App {
             self.input.history.push(line);
             self.input.clear();
             self.slash_sel = 0;
+            self.show_banner = false;
             ctl.send(Cmd::InvokePluginCommand {
                 name: entry.name.clone(),
                 args: rest,
@@ -4125,6 +4126,7 @@ impl App {
             "clear" => {
                 self.transcript.clear();
                 self.sel = None;
+                self.show_banner = false;
                 self.transcript.push_notice(
                     NoticeLevel::Info,
                     self.locale.tr("scrollback cleared", "滚动区已清空").into(),
@@ -4435,6 +4437,9 @@ impl App {
     }
 
     fn push_help(&mut self) {
+        // The welcome banner hides the scrollback; content pushed under it
+        // would stay invisible until the next prompt dismisses the banner.
+        self.show_banner = false;
         if self.locale == Locale::Zh {
             let text = "\
 ## help
@@ -4514,6 +4519,7 @@ context, subagent lifecycles, token usage (incl. cache hits), end reason.";
     }
 
     fn push_session_info(&mut self) {
+        self.show_banner = false;
         let creds = if self.demo {
             "demo mode (no API calls)".to_string()
         } else if self.auth.status == crate::acp_auth::AuthStatus::Configured {
@@ -4623,6 +4629,7 @@ context, subagent lifecycles, token usage (incl. cache hits), end reason.";
     /// reads no `Transcript.usage`/`stats` accumulator, so the two surfaces
     /// can never drift apart.
     fn push_status_info(&mut self) {
+        self.show_banner = false;
         let state = match self.state {
             RunState::Idle => self.locale.tr("idle", "空闲").to_string(),
             RunState::Starting => self.locale.tr("starting", "启动中").to_string(),
@@ -4762,6 +4769,7 @@ impl App {
             if !builtin && (self.plugin_command_active(&name) || acp_client_command) {
                 self.input.history.push(text);
                 self.input.clear();
+                self.show_banner = false;
                 ctl.send(Cmd::InvokePluginCommand { name, args: arg });
                 return;
             }
@@ -4781,6 +4789,7 @@ impl App {
             if !cmd.is_empty() {
                 self.input.history.push(text.clone());
                 self.input.clear();
+                self.show_banner = false;
                 self.run_local_shell(cmd);
             }
             return;
@@ -9115,5 +9124,41 @@ mod right_slot_tests {
             panic!("/session should be a markdown notice, got {:?}", last.kind);
         };
         assert!(!text.contains("- effort ·"), "{text}");
+    }
+
+    #[test]
+    fn slash_commands_dismiss_the_welcome_banner_so_their_output_shows() {
+        // The welcome banner hides the scrollback entirely; a command the
+        // user actually runs must leave it or its output stays invisible
+        // until the next prompt dismisses the banner (regression).
+        let (mut app, ctl, _rx) = test_app();
+        assert!(app.show_banner, "fresh app starts on the welcome banner");
+
+        app.run_slash("help", "", &ctl);
+        assert!(!app.show_banner, "/help must dismiss the banner");
+        assert!(
+            !app.transcript.cells.is_empty(),
+            "/help pushes its output into the scrollback"
+        );
+
+        // The typed paths (`/cmd` enter and the `!` shell) leave the banner
+        // too, so their output is not swallowed either.
+        let (mut typed, ctl2, _rx2) = test_app();
+        typed.input.set("/session".into());
+        typed.submit(&ctl2);
+        assert!(!typed.show_banner, "typed /session must dismiss the banner");
+
+        let (mut shell, ctl3, _rx3) = test_app();
+        shell.input.set("!echo hello".into());
+        shell.submit(&ctl3);
+        assert!(!shell.show_banner, "typed !shell must dismiss the banner");
+        assert!(
+            shell
+                .transcript
+                .cells
+                .iter()
+                .any(|c| { matches!(c.kind, crate::transcript::CellKind::Shell { .. }) }),
+            "the shell cell lands in the scrollback"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Two adapter-vs-dsh seams broke when `@deepseek-ai/dsh` moved past `0.1.0-rc.7`; both made TUI controls fail against the new host while the TUI's own pinned stack (harness-acp `0.4.13`) stayed unchanged:

1. **Permission switching** (`/permission`, shift+tab): `dsh-permission-presets >= 0.1.1-rc.1` records an `origin` on every live permission switch, and `dsh-session >= 0.1.1-rc.1` rejects event data that is not losslessly JSON-serializable. The bundled ACP adapter calls `permissionPresets.apply(session, modeId, cb)` without an origin, so every `session/set_mode` to a different preset failed with:

   ```
   session event "permission/preset" carries non-JSON-serializable data
   ```

2. **Harness command dispatch** (`/plan` via the `collaboration_mode` config option, plus typed `/compact`, `/goal`, `/permission`, `/plan`): `dsh-commands >= 0.1.0-rc.8` changed `execute(agent, line, signal)` to `execute(agent, line, images, signal)`. The adapter's three-argument calls left `signal` undefined and every command failed with:

   ```
   Cannot read properties of undefined (reading 'aborted')
   ```

## Changes

- New `dsh-tui-permission-compat` host plugin (`npm/lib/dsh-compat.js`, mounted from `npm/cordis.patch.yml`):
  - defaults the adapter's omitted permission `origin` to `"selection"` (the same origin the host's own `/permission` command uses) — harmless no-op passthrough on older dsh;
  - adapts the legacy three-argument `commands.execute(agent, line, signal)` call shape to the four-argument signature by inserting the empty images batch, keyed off `Function.length` so the legacy three-parameter signature passes through untouched.
- `src/acp.rs`: a failed permission switch is now reported as a warning with an actionable hint (host too new / unknown preset) instead of a success notice.
- Tests: `scripts/dsh-compat.test.mjs` (5 cases) + Rust unit test for the failure-hint mapping; CHANGELOG entry.

## Verification

- Rust tests: 378/378 pass (including the new unit test).
- npm suite: 160/161 pass; the single failure (`real-agent-e2e`) requires the Python `pexpect` package and is environmental, unrelated to this change.
- End-to-end against the real stack (harness-acp 0.4.13 + `@deepseek-ai/dsh` 0.1.1-rc.1) over ACP:
  - `session/set_mode` switches (`danger-full-access` / `workspace-write` / `read-only`) all succeed and emit `current_mode_update` — previously the first switch failed with the JSON-serialization error;
  - `set_config_option collaboration_mode=plan|default` succeeds — previously failed with the `aborted` error;
  - typed `/permission workspace-write` → `preset workspace-write`, `/compact` → `No compactable history yet.` — previously both replied `⚠ … failed`.
  - `session/new`, `session/list`, `session/load`, all config options (`mode`/`agent`/`effort`/`model`/`collaboration_mode`), and `/status` all verified working.

## Notes

- The compat plugin ships in the TUI bundle, so `dsh --profile tui` picks it up automatically after updating the Martty profile install. Standalone `dsh-tui` (spawning `dsh-acp` directly) runs the host outside the bundle and still needs the upstream adapter fix (calling `permission.apply` with an origin and `commands.execute` with the images argument).