### PR TITLE
feat: complete durable TUI plugin lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,10 @@ All notable changes to this project are documented here. The project follows
 
 ### Fixed
 
+- The bundled ACP runtime is now `0.4.17-beta.0`, where ACP profiles own
+  their complete `agent-presets` and `cordis-host-runner` service closure.
+  Permission switching and command execution therefore stay compatible
+  across current dsh hosts without a TUI-side host monkeypatch.
 - The plan review window (the ACP elicitation form the agent opens with
   `exit_plan_mode`) now renders the plan markdown through the full markdown
   pipeline instead of truncating raw source lines: headings lose their `#`,

--- a/README.en.md
+++ b/README.en.md
@@ -298,7 +298,7 @@ The welcome surface is a composable UI Preset. Built-in `default` (Martty) and
 `deepseek` each mount a centered `welcome.hero` (`logo + hint`) and a separate
 dynamic `welcome.info` slot. `/ui` opens the native select form, `/ui ` reuses
 the upward slash menu for candidates, and the choice persists in
-`dsh-tui-settings.json`.
+`$MARTTY_HOME/settings.json`.
 
 ### UI Preset vs Agent Preset
 
@@ -307,16 +307,16 @@ composition—but they live on different Cordis trees and remain separate:
 
 | | Agent Preset | UI Preset |
 |---|---|---|
-| Composes | Host/Agent system prompt, tools, skills, and runtime capabilities | Client UI themes, slots, pets, commands, and overlays |
+| Composes | Host/Agent system prompt, tools, skills, and runtime capabilities | Client UI slots, pets, chrome, and other structural contributions |
 | Switch with | `/agent` | `/ui` |
 | Built-ins | Agent compositions such as standard, code, minimal, and cordis | `default` (Martty) and `deepseek` |
-| Persistence | Session/Agent selection | UI selection in `dsh-tui-settings.json` |
+| Persistence | Session/Agent selection | UI selection in `$MARTTY_HOME/settings.json` |
 
 Creator mode can inspect the real `UiPresets`, `Theme`, `Slots`, `Commands`,
 and `Overlay` contracts, generate a dynamic Package with `code.client`, and
 call `tuiPresets.register({ id, label }, mount)` to create a new UI Preset.
-The mount callback composes that Preset's theme, welcome slots, pet, or other UI
-contributions. Once the Package is saved and mounted, the new Preset appears in
+The mount callback composes that Preset's welcome slots, pet, or other structural
+UI contributions. Once the Package is saved and mounted, the new Preset appears in
 both the `/ui` form and `/ui ` candidates and shares the same switching,
 persistence, and unload lifecycle. Creator produces an ordinary Client Plugin
 composition; it does not receive the TTY, absolute coordinates, or a way around

--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ preset 当前复用同一套动态信息 renderer，但该区域可由插件独�
 `/ui` 打开原生 UI Preset 单选表单；输入 `/ui ` 会在 composer 上方复用 slash
 菜单显示候选。也可直接用 `/ui deepseek` 打开经典
 DeepSeek Harness 大鲸鱼与 wordmark，`/ui default`
-切回 Martty；选择持久化到 `dsh-tui-settings.json`，不写入对话记录。Martty 的
+切回 Martty；选择持久化到 `$MARTTY_HOME/settings.json`，不写入对话记录。Martty 的
 `MAR` 使用海洋蓝白渐变，`TTY` 使用终端主题的黑/白前景色。
 
 ### UI Preset 与 Agent Preset
@@ -267,15 +267,15 @@ DeepSeek Harness 大鲸鱼与 wordmark，`/ui default`
 
 | | Agent Preset | UI Preset |
 |---|---|---|
-| 组合什么 | Host/Agent 的 system prompt、工具、skills 与运行能力 | Client UI 的 theme、slot、pet、command 与 overlay |
+| 组合什么 | Host/Agent 的 system prompt、工具、skills 与运行能力 | Client UI 的 slot、pet、chrome 等结构性贡献 |
 | 切换入口 | `/agent` | `/ui` |
 | 当前内置 | standard、code、minimal、cordis 等 Agent 组合 | `default`（Martty）、`deepseek` |
-| 持久化 | 会话/Agent 选择 | `dsh-tui-settings.json` 中的界面选择 |
+| 持久化 | 会话/Agent 选择 | `$MARTTY_HOME/settings.json` 中的界面选择 |
 
 Creator 模式可以 inspect `UiPresets`、`Theme`、`Slots`、`Commands` 和 `Overlay`
 的真实契约，生成包含 `code.client` 的动态 Package，并在其中调用
 `tuiPresets.register({ id, label }, mount)` 创建新的 UI Preset。`mount` 组合该
-Preset 所需的 theme、欢迎页 slot、pet 或其他 UI contribution；Package 保存并挂载后，
+Preset 所需的欢迎页 slot、pet 或其他结构性 UI contribution；Package 保存并挂载后，
 新 Preset 自动进入 `/ui` 表单和 `/ui ` 上拉候选，也沿用同一套切换、持久化与卸载
 生命周期。Creator 创建的是普通 Client Plugin 组合，不会取得 TTY、绝对坐标或绕过
 slot/overlay 协议。

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -32,7 +32,9 @@ Server 插件要让任意 client 看见：投影成标准 ACP（命令、config�
 
 ```text
 Host 进程：Base Cordis + ACP plugin
+  tui-client-plugin-registry 收集已安装 package 的绝对 Client entry
         │ TUI Client 子进程的标准 stdin/stdout（ACP）
+        │ runner 另以 JSON 环境快照传递 Client entry 目录（不传 Cordis 对象）
 Client 进程：独立 Cordis root
   第三方插件   sibling insert + inject ['tuiTheme' / 'tuiPresets' / 'tuiSlots']
   Client runner inject ['tuiTheme', 'tuiPresets', 'tuiSlots', ...]，执行 dsh-tool-cordis 的 code.client
@@ -50,6 +52,8 @@ Client 进程：独立 Cordis root
   tui-slots    提供 tuiSlots，声明 welcome.hero / welcome.info / chrome.right /
                conversation.input.dock / conversation.composer.dock
   tui-theme    提供 tuiTheme
+  tui-local-plugins 合并已安装 package entries 与 $MARTTY_HOME/plugins，
+               恢复 UI Preset，并按 /theme owner 启停 Theme Plugin
   acp-client   attach Host stdio，提供 acpClient
         │ Client 进程 fd 3/4 仅传 TTY
   Rust painter stdin/stdout 占 TTY；自己的 fd 3/4 是 compositor mux
@@ -138,7 +142,19 @@ UI Preset 是 UI Plugin 的组合，不等同于 Theme。`default`（Martty）�
 与帮助区。两套 preset 当前复用同一个原生动态 info renderer，但该区域可以独立被
 插件替换。旧 DeepSeek Harness 鲸鱼仍复用原版响应式 primitive。Rust 负责内部几何、
 水平居中与整个欢迎块的垂直居中；`/ui deepseek` / `/ui default` 切换并持久化到
-`dsh-tui-settings.json`。
+`$MARTTY_HOME/settings.json`。
+
+Creator 的 `cordis_define/run` Package 属于 Session 进程内预览。显式保存后，Client
+源码以 `$MARTTY_HOME/plugins/<artifact-id>/plugin.json` 为磁盘真源；Client 启动时
+重新发现。第三方 package 则继续由 dsh profile 安装，其 Host registrar 只向
+`tuiClientPlugins` 登记 `{ id, kind, entry }`，runner 把这个可序列化快照交给独立
+Client import。两类来源进入同一个 lifecycle manager；同 id 时安装 package 优先。
+UI Preset 只组合结构性 UI contribution，不拥有 Theme；保存的 `uiPreset`、`theme`
+和 dark/light 相互独立。
+
+`MARTTY_HOME` 依次取显式环境变量、`$DSH_HOME/.martty`、`~/.martty`。默认 Session
+根是 `$MARTTY_HOME/sessions`。旧 settings、Creator artifacts 与 Session 根只作为
+非破坏迁移/发现来源保留。
 
 ## 明确不做
 

--- a/docs/plugins.en.md
+++ b/docs/plugins.en.md
@@ -52,13 +52,17 @@ facts only, also without touching token/timing accumulators.
 `tuiPresets` composes several independent UI Plugin contributions into one
 saved choice. It lives on the Client tree, separate from Agent Presets that
 compose Host/Agent capabilities, and is not an alias for Theme. The `mount`
-callback passed to `ctx.tuiPresets.register({ id, label }, mount)` may register
-a Theme, slots, pet, or other UI contributions and returns one disposer. `/ui`
+callback passed to `ctx.tuiPresets.register({ id, label }, mount)` composes only
+structural UI contributions such as slots, chrome, or a pet and returns one
+disposer. It does not register, select, or generate a Theme: `/ui`, `/theme`,
+and dark/light are independent state dimensions. `/ui`
 opens the native single-select form, `/ui ` reuses the slash menu above the
 composer for candidates, and `/ui <id>` switches directly. The id persists in
-`dsh-tui-settings.json`. Creator can inspect `UiPresets` and adjacent Client
+`$MARTTY_HOME/settings.json`. Creator can inspect `UiPresets` and adjacent Client
 services, generate a `code.client` Package that calls `tuiPresets.register`,
-and save/mount it; the new preset then appears in both selection paths.
+and preview it with `cordis_define/run`. Those operations are process-local;
+after a successful run, `tui_plugin_save` must write it under
+`$MARTTY_HOME/plugins/<artifact-id>/plugin.json` for restart recovery.
 
 The builtin `default` (Martty) and `deepseek` UI Presets both fill two single
 root slots:
@@ -92,7 +96,9 @@ Builtin `default` remains the cold bluish skin and cannot be replaced or removed
 `ctrl+t` only toggles dark/light inside the current theme. `/theme` is a special
 **single-select Theme Plugin switch**: selecting an id starts its owning Client
 Plugin and stops the previously selected Theme Plugin; selecting `default` stops
-the current dynamic Theme Plugin.
+the current dynamic Theme Plugin. Explicit selection persists beside
+`uiPreset` in `$MARTTY_HOME/settings.json`; temporary Creator previews and automatic
+fallbacks do not rewrite that preference.
 
 A Theme Plugin may register a palette, commands, overlays, slots, timers,
 transactions, and Package-private RPC together. None uses a theme condition or
@@ -247,24 +253,56 @@ Plugin modules do not receive: the TTY, stdin, raw mode, kitty escapes, ratatui,
 
 Nodes must not contain RGB; color only by token name. RGB appears only in a palette pack's `dark`/`light` tables.
 
-## Load
+## Persistence and loading
+
+TUI merges builtins, installed package entries, and Creator artifacts into the
+same `/ui` and `/theme` catalogs. Install a third-party package with
+`dsh plugin --profile tui add <package-or-path>`. Its Host registrar registers
+an absolute Client module entry with `tuiClientPlugins`; the Host runner sends
+only that serialized directory to the separate Client process. Creator
+artifacts live under `$MARTTY_HOME/plugins` and are managed by
+`tui_plugin_list/read/save/remove`. Installed packages win same-id conflicts.
+
+`MARTTY_HOME` resolves from the explicit environment variable, then
+`$DSH_HOME/.martty`, then `~/.martty`. On first startup, legacy artifacts and
+settings are copied forward without deleting the source or overwriting current
+Martty data.
+
+An installed package exports a small Host registrar:
+
+```js
+export const inject = ['tuiClientPlugins']
+export function apply(ctx) {
+  return ctx.tuiClientPlugins.register({
+    id: 'paper-lantern',
+    kind: 'theme',
+    entry: new URL('./client.js', import.meta.url).href,
+  })
+}
+```
+
+Its `client.js` exports an ordinary Cordis Client `inject` / `apply` module.
+The package bundle patch inserts only the registrar on the Host profile; no
+Host fiber, service, or plugin tree is synchronized to the Client.
 
 Cordis has **no** parent pointer from one plugin instance onto another.
 `tui-theme`, palette packs, `tui-cordis-client-runner`, and `tui-runner` are
-**sibling inserts** in the profile.
+peer lifecycles in the Client tree.
 
 The protocol that waits on the TUI capability is the service name:
 
 1. `tui-theme` and `tui-slots` provide `ctx.tuiTheme` and `ctx.tuiSlots`.
 2. `tui-cordis-client-runner` injects both, publishes inspect, and evaluates dynamic `code.client`.
-3. Third-party plugins inject the service they use and stay PENDING until it exists.
-4. Cordis owns static disposers; the Client runner owns dynamic contributions.
+3. Third-party Client modules inject the service they use and stay PENDING until it exists.
+4. Package and Creator modules use the same restricted Client facade and lifecycle manager.
 
 Do not stack third parties with `ctx.plugin(ember)` inside the runner. The
 composition mounts third-party packages as siblings. Web
 Web `ctx.slots` and terminal `ctx.tuiSlots` are different services.
 
-Local packages use `dsh plugin add ./path` and load **package exports**. A newly inserted row needs a TUI restart or later `/refresh`. Hot-swap of an already-mounted palette ships by phase.
+Local packages use `dsh plugin --profile tui add ./path` and load **package
+exports**. A new registrar needs a TUI restart or later `/refresh`. Hot-swap of
+an already-mounted palette ships by phase.
 
 ## Later
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -76,12 +76,14 @@ transcript accumulator。没有 Client 树的运行（demo、独立 painter）�
 
 `tuiPresets` 把多个独立 UI Plugin contribution 组合成一个可持久化选择；它与
 组合 Host/Agent 能力的 Agent Preset 分属 Client/Host 两棵树，也不是 Theme 的别名。
-`ctx.tuiPresets.register({ id, label }, mount)` 的 `mount` 可同时注册 Theme、slot、pet
-或其他 UI contribution，并返回统一 disposer。`/ui` 打开原生单选表单，`/ui ` 复用
+`ctx.tuiPresets.register({ id, label }, mount)` 的 `mount` 只组合结构性 UI
+contribution（slot、chrome、pet 等），并返回统一 disposer；它不注册、选择或生成
+Theme。`/ui`、`/theme` 与 dark/light 是三个独立状态维度。`/ui` 打开原生单选表单，`/ui ` 复用
 composer 上方的 slash 菜单列出候选，也可用 `/ui <id>` 直接切换；选择写入
-`dsh-tui-settings.json`，重启后恢复。Creator 可以 inspect `UiPresets` 与相邻 Client
-服务，生成调用 `tuiPresets.register` 的 `code.client` Package；保存并挂载后，新
-preset 自动进入这两个选择入口。
+`$MARTTY_HOME/settings.json`，重启后恢复。Creator 可以 inspect `UiPresets` 与相邻 Client
+服务，生成调用 `tuiPresets.register` 的 `code.client` Package；`cordis_define/run`
+只做当前进程预览，成功后必须由 `tui_plugin_save` 写入
+`$MARTTY_HOME/plugins/<artifact-id>/plugin.json`，新 preset 才会在重启后恢复。
 
 内置 `default`（Martty）和 `deepseek` 两个 UI Preset 都装配两个 single root slot：
 
@@ -111,7 +113,8 @@ Token 名封闭：
 内置 `default` 仍是现在的冷蓝灰皮，永远不能替换或删除。`ctrl+t` 只在当前主题的
 dark/light 之间切。`/theme` 是一个特殊的 **Theme Plugin 单选开关**：选择一个 id
 会启动它所属的 Client Plugin，并停止此前选中的 Theme Plugin；选择 `default` 会
-停止当前动态 Theme Plugin。
+停止当前动态 Theme Plugin。显式选择的 theme id 与 `uiPreset` 并列写入
+`$MARTTY_HOME/settings.json`；临时 Creator 预览和自动回退不会改写用户选择。
 
 一个 Theme Plugin 可以同时注册 palette、command、overlay、slot、timer、事务和
 Package 内 RPC。它们不写主题条件，也不订阅 active theme；它们只是同一个 Cordis
@@ -263,22 +266,56 @@ return {
 
 节点上不得写 RGB；着色只能引用 token 名。RGB 只出现在配色包的 `dark`/`light` 表里。
 
-## 加载
+## 持久化与加载
+
+TUI 合并三个来源，按 builtin、已安装 package、Creator artifact 的顺序装入同一
+`/ui` 与 `/theme` catalog：
+
+1. builtin 随 TUI 包发布；
+2. 第三方 package 由 `dsh plugin --profile tui add <package-or-path>` 安装，其 Host
+   registrar 向 `tuiClientPlugins` 登记绝对 Client entry；Host runner 只把这份 JSON
+   清单交给独立 Client 进程；
+3. Creator artifact 位于 `$MARTTY_HOME/plugins/<artifact-id>/plugin.json`，由
+   `tui_plugin_list/read/save/remove` 管理。已安装 package 与本地 artifact 同 id 时，
+   package 优先，本地项作为 shadowed diagnostic 保留而不执行。
+
+`MARTTY_HOME` 的解析顺序是显式环境变量、`$DSH_HOME/.martty`、`~/.martty`。
+旧 `$DSH_HOME/.tui-plugins` 与 `~/.dsh-tui/sessions/dsh-tui-settings.json` 在首次启动时
+只复制到新位置；不删除旧数据，也不覆盖已经存在的 Martty 数据。
+
+第三方包的 Host registrar 是普通 Cordis 插件：
+
+```js
+export const inject = ['tuiClientPlugins']
+export function apply(ctx) {
+  return ctx.tuiClientPlugins.register({
+    id: 'paper-lantern',
+    kind: 'theme',
+    entry: new URL('./client.js', import.meta.url).href,
+  })
+}
+```
+
+`client.js` 导出普通的 `inject` / `apply` Client Plugin。包自己的 bundle patch 把
+registrar 插入 Host profile；registrar 只登记可序列化 entry，不把 Host fiber、服务或
+插件树同步给 Client。
 
 Cordis **没有**「挂在某个插件实例下面」的父子指针。`tui-theme`、配色包、
-`tui-cordis-client-runner` 和 `tui-runner` 在 profile 里是 **平级 insert**。
+`tui-cordis-client-runner` 和 `tui-runner` 在 Client 树里是平级生命周期。
 
 真正等 TUI 能力的协议是服务名：
 
 1. `tui-theme` / `tui-slots` 分别提供 `ctx.tuiTheme` / `ctx.tuiSlots`。
 2. `tui-cordis-client-runner` 注入两者，向 Host 发布 inspect 目录并执行动态 `code.client`。
-3. 第三方插件声明对应 inject；服务不在就 PENDING，不靠 yaml 行序。
-4. 静态插件的 disposer 由 Cordis 收集，动态插件的贡献由 Client runner 收集。
+3. 第三方 Client module 声明对应 inject；服务不在就 PENDING，不靠 Host yaml 行序。
+4. package 与 Creator artifact 都经过相同的受限 Client facade；Theme owner 的
+   start/stop 与 UI Preset 的常驻 catalog 生命周期由 Client manager 收集。
 
 不要在 runner 里 `ctx.plugin(ember)` 来叠第三方。第三方包由组合层作为 sibling
 挂载。Web 的 `ctx.slots` 与终端的 `ctx.tuiSlots` 是不同服务。
 
-本地包走 `dsh plugin add ./path`，加载 **package exports**。新 insert 一行要重开 TUI 或以后的 `/refresh`。已挂配色包改源码后的热换按阶段落地。
+本地包走 `dsh plugin --profile tui add ./path`，加载 **package exports**。新 registrar
+要重开 TUI 或以后的 `/refresh`。已挂配色包改源码后的热换按阶段落地。
 
 ## 后续
 

--- a/npm/README.md
+++ b/npm/README.md
@@ -57,6 +57,20 @@ The package carries ACP as a runtime dependency and exports its Creator Host
 overlay internally. The profile bundle mounts both on the Host Base tree;
 neither enters the Client tree. Creator adds TUI plugin guidance to the
 existing `cordis` preset and does not use ACP for skill registration.
+Creator-authored UI Presets and Theme Plugins preview as process-local dynamic
+Packages, then persist explicitly under `$MARTTY_HOME/plugins` through
+`tui_plugin_save`; `tui_plugin_read` resumes authoring after restart.
+
+`MARTTY_HOME` resolves explicitly first, then to `$DSH_HOME/.martty`, then to
+`~/.martty`. UI choices live in `$MARTTY_HOME/settings.json`. On first use,
+legacy Creator artifacts and settings are copied forward without deleting or
+overwriting the old files.
+
+Third-party TUI plugins remain ordinary installed packages. Their Host-side
+registrar contributes an absolute Client module entry to `tuiClientPlugins`;
+the Host runner serializes only that directory into the separate Client
+process. Package entries and Creator artifacts share one Client lifecycle
+manager, with installed packages winning same-id conflicts.
 
 Node and Rust use inherited pipes on Unix and an authenticated loopback TCP
 socket on Windows. This compositor channel carries theme/render data only;

--- a/npm/cordis.patch.yml
+++ b/npm/cordis.patch.yml
@@ -20,6 +20,9 @@
   disabled: true
 
 - insert:
+    - id: tui-client-plugins
+      name: '@openma/deepseek-harness-tui/client-plugin-registry'
+
     - id: tui-acp-host
       name: '@openma/deepseek-harness-tui/acp-host'
 

--- a/npm/lib/boot.js
+++ b/npm/lib/boot.js
@@ -7,6 +7,7 @@
  */
 
 import { apply as applyAcpClient } from './acp-client.js'
+import { constants, copyFileSync, existsSync, mkdirSync, readFileSync } from 'node:fs'
 import { homedir } from 'node:os'
 import path from 'node:path'
 import { apply as applyCordisClientRunner } from './inspect.js'
@@ -23,12 +24,17 @@ import { apply as applyStatsView, inject as statsViewInject } from './stats-view
 import { apply as applySessionStatus, inject as sessionStatusInject } from './acp-session-status.js'
 import { apply as applyStatusView, inject as statusViewInject } from './status-view.js'
 import { apply as applyDeepseekLogo, inject as deepseekLogoInject } from './deepseek-logo.js'
+import { createTuiPluginStore, marttyHome } from './tui-plugin-store.js'
+import { installTuiLocalPlugins } from './tui-local-plugins.js'
 
 /**
  * @param {object} [options]
  * @param {{ command: string, args?: string[] }} [options.agent]
  * @param {{ stdin: import('node:stream').Writable, stdout: import('node:stream').Readable, child?: import('node:child_process').ChildProcess }} [options.stream]
  * @param {{ stdin: number | 'inherit', stdout: number | 'inherit' }} [options.tty]
+ * @param {string} [options.settingsPath]
+ * @param {string} [options.artifactRoot]
+ * @param {Array<{ id: string, kind: 'theme' | 'ui-preset', entry: string }>} [options.packagePlugins]
  */
 export async function bootClient(options = {}) {
   const { Context } = await import('@deepseek-ai/cordis')
@@ -36,11 +42,13 @@ export async function bootClient(options = {}) {
   const acpConfig = options.stream !== undefined
     ? { stream: options.stream }
     : { agent: options.agent ?? resolveStackedAgent() }
-  const presetConfig = {
-    settingsPath: options.settingsPath ?? uiSettingsPath(options.extraArgs ?? []),
+  const settingsPath = options.settingsPath ?? uiSettingsPath(options.extraArgs ?? [])
+  if (options.settingsPath === undefined) {
+    migrateLegacyUiSettings(settingsPath, legacyUiSettingsPaths(options.extraArgs ?? []))
   }
+  const presetConfig = { settingsPath }
   if (typeof ctx.plugin === 'function') {
-    await ctx.plugin({ name: 'tui-theme', inject: [], apply: applyTheme })
+    await ctx.plugin({ name: 'tui-theme', inject: [], apply: applyTheme }, presetConfig)
     await ctx.plugin({ name: 'tui-slots', inject: [], apply: applySlots })
     await ctx.plugin({ name: 'tui-commands', inject: [], apply: applyCommands })
     await ctx.plugin({ name: 'tui-overlay', inject: [], apply: applyOverlay })
@@ -52,6 +60,20 @@ export async function bootClient(options = {}) {
     await ctx.plugin({ name: 'acp-session-status', inject: sessionStatusInject, apply: applySessionStatus })
     await ctx.plugin({ name: 'status-view', inject: statusViewInject, apply: applyStatusView })
     await ctx.plugin({ name: 'deepseek-logo', inject: deepseekLogoInject, apply: applyDeepseekLogo })
+    const localPlugins = installTuiLocalPlugins(ctx, {
+      store: createTuiPluginStore({ root: options.artifactRoot }),
+      packages: options.packagePlugins ?? [],
+      tuiTheme: ctx.get('tuiTheme'),
+      tuiPresets: ctx.get('tuiPresets'),
+      tuiSlots: ctx.get('tuiSlots'),
+      tuiCommands: ctx.get('tuiCommands'),
+      tuiOverlay: ctx.get('tuiOverlay'),
+      acpSessionConfig: ctx.get('acpSessionConfig'),
+      acpSessionPlan: ctx.get('acpSessionPlan'),
+      acpSessionStats: ctx.get('acpSessionStats'),
+      acpSessionStatus: ctx.get('acpSessionStatus'),
+    })
+    await localPlugins.discover()
     await ctx.plugin({
       name: 'tui-cordis-client-runner',
       inject: [
@@ -72,7 +94,7 @@ export async function bootClient(options = {}) {
       { extraArgs: options.extraArgs ?? [], tty: options.tty },
     )
   } else {
-    applyTheme(ctx)
+    applyTheme(ctx, presetConfig)
     applySlots(ctx)
     applyCommands(ctx)
     applyOverlay(ctx)
@@ -84,19 +106,100 @@ export async function bootClient(options = {}) {
     applySessionStatus(ctx)
     applyStatusView(ctx)
     applyDeepseekLogo(ctx)
+    const localPlugins = installTuiLocalPlugins(ctx, {
+      store: createTuiPluginStore({ root: options.artifactRoot }),
+      packages: options.packagePlugins ?? [],
+      tuiTheme: ctx.tuiTheme,
+      tuiPresets: ctx.tuiPresets,
+      tuiSlots: ctx.tuiSlots,
+      tuiCommands: ctx.tuiCommands,
+      tuiOverlay: ctx.tuiOverlay,
+      acpSessionConfig: ctx.acpSessionConfig,
+      acpSessionPlan: ctx.acpSessionPlan,
+      acpSessionStats: ctx.acpSessionStats,
+      acpSessionStatus: ctx.acpSessionStatus,
+    })
+    await localPlugins.discover()
     applyCordisClientRunner(ctx)
     await applyShell(ctx, { extraArgs: options.extraArgs ?? [], tty: options.tty })
   }
   return ctx
 }
 
-export function uiSettingsPath(extraArgs = []) {
+/** Parse the Host registry snapshot passed across the process boundary. */
+export function parseClientPluginsEnv(value) {
+  if (value === undefined || value === '') return []
+  let parsed
+  try {
+    parsed = JSON.parse(value)
+  } catch (error) {
+    throw new Error(`dsh-tui: invalid installed Client plugin registry JSON: ${error.message}`)
+  }
+  if (!Array.isArray(parsed)) {
+    throw new Error('dsh-tui: installed Client plugin registry must be an array')
+  }
+  return parsed.map((entry, index) => {
+    if (entry === null || typeof entry !== 'object' || Array.isArray(entry)) {
+      throw new Error(`dsh-tui: installed Client plugin entry ${index} must be an object`)
+    }
+    if (typeof entry.id !== 'string' || !/^[a-z0-9][a-z0-9-]*$/.test(entry.id)) {
+      throw new Error(`dsh-tui: installed Client plugin entry ${index} has an invalid id`)
+    }
+    if (!['theme', 'ui-preset'].includes(entry.kind)) {
+      throw new Error(`dsh-tui: installed Client plugin entry ${index} has an invalid kind`)
+    }
+    if (typeof entry.entry !== 'string') {
+      throw new Error(`dsh-tui: installed Client plugin entry ${index} has no file entry`)
+    }
+    let url
+    try {
+      url = new URL(entry.entry)
+    } catch {
+      throw new Error(`dsh-tui: installed Client plugin entry ${index} has an invalid file entry`)
+    }
+    if (url.protocol !== 'file:') {
+      throw new Error(`dsh-tui: installed Client plugin entry ${index} must use a file URL`)
+    }
+    return { id: entry.id, kind: entry.kind, entry: url.href }
+  })
+}
+
+export function uiSettingsPath(extraArgs = [], env = process.env, userHome = homedir()) {
   for (let index = 0; index < extraArgs.length; index += 1) {
     if (extraArgs[index] === '--session-root' && typeof extraArgs[index + 1] === 'string') {
-      return path.join(extraArgs[index + 1], 'dsh-tui-settings.json')
+      return path.join(extraArgs[index + 1], 'settings.json')
     }
   }
-  return path.join(homedir(), '.dsh-tui', 'sessions', 'dsh-tui-settings.json')
+  return path.join(marttyHome(env, userHome), 'settings.json')
+}
+
+export function legacyUiSettingsPaths(extraArgs = [], userHome = homedir()) {
+  const paths = []
+  for (let index = 0; index < extraArgs.length; index += 1) {
+    if (extraArgs[index] === '--session-root' && typeof extraArgs[index + 1] === 'string') {
+      paths.push(path.join(extraArgs[index + 1], 'dsh-tui-settings.json'))
+      break
+    }
+  }
+  paths.push(path.join(userHome, '.dsh-tui', 'sessions', 'dsh-tui-settings.json'))
+  return [...new Set(paths)]
+}
+
+export function migrateLegacyUiSettings(settingsPath, legacyPaths) {
+  if (existsSync(settingsPath)) return false
+  for (const legacyPath of legacyPaths) {
+    if (!existsSync(legacyPath)) continue
+    try {
+      const value = JSON.parse(readFileSync(legacyPath, 'utf8'))
+      if (value === null || typeof value !== 'object' || Array.isArray(value)) continue
+      mkdirSync(path.dirname(settingsPath), { recursive: true })
+      copyFileSync(legacyPath, settingsPath, constants.COPYFILE_EXCL)
+      return true
+    } catch {
+      // A malformed or racing legacy file must not block TUI startup.
+    }
+  }
+  return false
 }
 
 /**

--- a/npm/lib/client-process.js
+++ b/npm/lib/client-process.js
@@ -2,10 +2,11 @@
 
 /** Independent TUI Client Cordis process launched by the Host runner. */
 
-import { bootClient } from './boot.js'
+import { bootClient, parseClientPluginsEnv } from './boot.js'
 
 await bootClient({
   stream: { stdin: process.stdout, stdout: process.stdin },
   extraArgs: process.argv.slice(2),
   tty: { stdin: 3, stdout: 4 },
+  packagePlugins: parseClientPluginsEnv(process.env.DSH_TUI_CLIENT_PLUGINS_V0),
 })

--- a/npm/lib/client-run.js
+++ b/npm/lib/client-run.js
@@ -76,6 +76,16 @@ export async function applyClientHalf(clientCode, env) {
     }
     throw error
   }
+  return applyClientPlugin(plugin, env)
+}
+
+/**
+ * Apply an already imported Client plugin through the same restricted TUI facade as code.client.
+ * @param {unknown} plugin
+ * @param {{ pluginId?: string, tuiTheme?: object, tuiSlots?: object, tuiCommands?: object, tuiOverlay?: object, acpSessionConfig?: object, acpSessionPlan?: object, acpSessionStats?: object, acpSessionStatus?: object, timer?: object, invoke?: Function }} env
+ * @returns {Promise<{ waitingFor: string[], dispose: () => void }>}
+ */
+export async function applyClientPlugin(plugin, env) {
   const evaluated = normalizePlugin(plugin)
   const inject = evaluated.inject ?? []
   for (const name of inject) {

--- a/npm/lib/creator-overlay.js
+++ b/npm/lib/creator-overlay.js
@@ -4,9 +4,12 @@
  */
 
 import { readFileSync } from 'node:fs'
+import { createTuiPluginStore } from './tui-plugin-store.js'
 
 export const name = 'tui-creator-overlay'
-export const inject = ['agentPresets', 'skills', 'systemPrompt', 'loader']
+export const inject = [
+  'agentPresets', 'skills', 'systemPrompt', 'loader', 'tools', 'dynamicCordisRunner',
+]
 
 const SKILL_NAME = 'tui-plugin-development'
 const ROUTING_PROMPT = `# Dynamic TUI Plugin routing
@@ -15,6 +18,158 @@ Load cordis-plugin-development for every dynamic Plugin; it owns the common Plug
 
 - When any requested behavior belongs to the TUI — terminal themes or backgrounds, native TUI slots, local TUI commands, native overlays, or current ACP Session options — also load tui-plugin-development. Its TUI Provider guidance overrides generic browser UI assumptions only for that half.
 - Browser/Web-only work needs no TUI companion. A mixed Plugin uses the generic skill for common, Host, and Web behavior and the TUI skill for its terminal behavior. Do not translate a TUI request into Web Slots or add Host code unless the requested behavior owns Host data.`
+
+const jsonOutput = {
+  schema: { type: 'json' },
+  render: (_args, value) => [{ type: 'text', text: JSON.stringify(value, null, 2) }],
+}
+
+function requireAgent(exec) {
+  if (exec?.agent === undefined) {
+    throw new Error('TUI artifact tools require an Agent-backed Creator session')
+  }
+  return exec.agent
+}
+
+function registerArtifactTools(ctx, scopedCtx, defineTool, store) {
+  const tools = scopedCtx.get('tools')
+  if (tools === undefined || typeof tools.register !== 'function') {
+    throw new Error('tui-creator-overlay: tools service is unavailable in the preset scope')
+  }
+
+  tools.register(defineTool({
+    name: 'tui_plugin_save',
+    description:
+      'Persist one successfully activated, Client-only Cordis Package as a durable TUI artifact. '
+      + 'Use this only after cordis_run succeeds. UI Presets and Theme Plugins survive restart only '
+      + 'after this Tool returns saved. Replacing an existing artifact must be explicit.',
+    parameters: {
+      artifactId: {
+        type: 'string',
+        required: true,
+        description: 'Stable lowercase artifact id used as its directory name.',
+      },
+      kind: {
+        type: 'string',
+        required: true,
+        enum: ['ui-preset', 'theme'],
+        description: 'Durable TUI contribution kind.',
+      },
+      pluginId: {
+        type: 'string',
+        required: true,
+        description: 'Dynamic Plugin id returned by cordis_define.',
+      },
+      packageId: {
+        type: 'string',
+        required: true,
+        description: 'Exact immutable Package id that cordis_run activated successfully.',
+      },
+      replace: {
+        type: 'boolean',
+        description: 'Replace an existing artifact with this Package. Defaults to false.',
+      },
+    },
+    output: jsonOutput,
+    async execute(args, exec) {
+      const source = ctx.dynamicCordisRunner.inspectPackage(
+        requireAgent(exec),
+        args.pluginId,
+        args.packageId,
+      )
+      if (source.currentPackageId !== args.packageId) {
+        throw new Error(
+          `tui_plugin_save: ${args.pluginId}/${args.packageId} is not the successful current Package; `
+          + 'run it successfully before persisting it',
+        )
+      }
+      if (typeof source.code?.host === 'string') {
+        throw new Error(
+          'tui_plugin_save: durable TUI artifacts are client-only; a Package with a Host half '
+          + 'must be shipped as a standard profile plugin instead',
+        )
+      }
+      if (typeof source.code?.client !== 'string') {
+        throw new Error('tui_plugin_save: Package has no Client half')
+      }
+      const saved = store.save({
+        id: args.artifactId,
+        kind: args.kind,
+        name: source.name,
+        purpose: source.purpose,
+        source: { pluginId: args.pluginId, packageId: args.packageId },
+        clientCode: source.code.client,
+      }, { replace: args.replace === true })
+      return {
+        status: 'saved',
+        artifact: { id: args.artifactId, kind: args.kind },
+        path: saved.path,
+        recovery: 'The TUI Client discovers this artifact from disk on startup.',
+      }
+    },
+  }))
+
+  tools.register(defineTool({
+    name: 'tui_plugin_list',
+    description:
+      'List durable user-authored TUI artifacts from disk, including broken rows that need repair or removal.',
+    parameters: {},
+    output: jsonOutput,
+    execute(_args, exec) {
+      requireAgent(exec)
+      return Promise.resolve({ root: store.root, artifacts: store.list() })
+    },
+    isConcurrencySafe() {
+      return true
+    },
+  }))
+
+  tools.register(defineTool({
+    name: 'tui_plugin_read',
+    description:
+      'Read one durable Creator-authored TUI artifact including its exact code.client source. '
+      + 'Use this before continuing development after a restart; define a new temporary preview '
+      + 'Plugin from the source, then save the successful result with replace:true.',
+    parameters: {
+      artifactId: {
+        type: 'string',
+        required: true,
+        description: 'Exact durable artifact id returned by tui_plugin_list.',
+      },
+    },
+    output: jsonOutput,
+    execute(args, exec) {
+      requireAgent(exec)
+      return Promise.resolve({ artifact: store.resolve(args.artifactId) })
+    },
+    isConcurrencySafe() {
+      return true
+    },
+  }))
+
+  tools.register(defineTool({
+    name: 'tui_plugin_remove',
+    description:
+      'Remove one durable user-authored TUI artifact from disk. This does not undefine the current '
+      + 'Session\'s temporary preview Plugin.',
+    parameters: {
+      artifactId: {
+        type: 'string',
+        required: true,
+        description: 'Exact durable artifact id returned by tui_plugin_list.',
+      },
+    },
+    output: jsonOutput,
+    execute(args, exec) {
+      requireAgent(exec)
+      const removed = store.remove(args.artifactId)
+      return Promise.resolve({
+        status: removed ? 'removed' : 'absent',
+        artifactId: args.artifactId,
+      })
+    },
+  }))
+}
 
 const skillDocument = readFileSync(
   new URL('../skills/tui-plugin-development/SKILL.md', import.meta.url),
@@ -49,6 +204,10 @@ export async function apply(ctx, config = {}) {
   const { createScope } = scopeModule
   const overlay = createScope(ctx, key)
   try {
+    const toolsModule = await ctx.loader.import('@deepseek-ai/dsh-tools')
+    if (typeof toolsModule?.defineTool !== 'function') {
+      throw new Error('tui-creator-overlay: profile dsh-tools module is unavailable')
+    }
     const skills = overlay.ctx.get('skills')
     if (skills === undefined || typeof skills.register !== 'function') {
       throw new Error('tui-creator-overlay: skills service is unavailable in the preset scope')
@@ -69,6 +228,12 @@ export async function apply(ctx, config = {}) {
       order: 116,
       text: ROUTING_PROMPT,
     })
+    registerArtifactTools(
+      ctx,
+      overlay.ctx,
+      toolsModule.defineTool,
+      createTuiPluginStore({ root: config.artifactRoot }),
+    )
     ctx.effect(() => () => overlay.dispose(), `tui-creator-overlay(${JSON.stringify(preset)})`)
   } catch (error) {
     await overlay.dispose()

--- a/npm/lib/index.js
+++ b/npm/lib/index.js
@@ -30,16 +30,23 @@ const shellStateKey = Symbol.for('@openma/deepseek-harness-tui/shell-state')
  *   livePainter: null | ({ muxed: boolean } & Awaited<ReturnType<typeof spawnPluginTui>>),
  *   startingPainter: null | Promise<{ muxed: boolean } & Awaited<ReturnType<typeof spawnPluginTui>>>,
  *   refuseRespawn: boolean,
+ *   processExitListener: null | (() => void),
  * }}
  */
 const shellState = globalThis[shellStateKey] ??= {
   livePainter: null,
   startingPainter: null,
   refuseRespawn: false,
+  processExitListener: null,
 }
+if (shellState.processExitListener === undefined) shellState.processExitListener = null
 
 /** Drop the sticky painter so tests can apply() more than once in-process. */
 export function resetShellForTests() {
+  if (shellState.processExitListener !== null) {
+    process.off('exit', shellState.processExitListener)
+    shellState.processExitListener = null
+  }
   shellState.livePainter = null
   shellState.startingPainter = null
   shellState.refuseRespawn = false
@@ -150,6 +157,10 @@ export async function applyShell(ctx, options = {}) {
         shellState.livePainter = live
         const { child } = live
         child.on('exit', (code, signal) => {
+          if (shellState.processExitListener === processExitListener) {
+            process.off('exit', processExitListener)
+            shellState.processExitListener = null
+          }
           try {
             agent.child?.kill('SIGTERM')
           } catch {
@@ -165,13 +176,15 @@ export async function applyShell(ctx, options = {}) {
           console.error(`dsh-tui: ${err.message}`)
           process.exit(1)
         })
-        process.once('exit', () => {
+        const processExitListener = () => {
           try {
             child.kill('SIGTERM')
           } catch {
             // already gone
           }
-        })
+        }
+        shellState.processExitListener = processExitListener
+        process.once('exit', processExitListener)
         return live
       })()
     }

--- a/npm/lib/inspect.js
+++ b/npm/lib/inspect.js
@@ -162,7 +162,7 @@ export function uiPresetInspectProvider(tuiPresets) {
               'A synchronous callback that mounts multiple UI contributions and returns one disposer.',
           },
           selection: '/ui <id>',
-          persistence: 'The selected id survives restart in dsh-tui-settings.json.',
+          persistence: 'The selected id survives restart in $MARTTY_HOME/settings.json.',
         },
       }
     },
@@ -754,6 +754,7 @@ async function mountClientHalf(
  *   acpSessionPlan?: object,
  *   acpSessionStats?: object,
  *   acpSessionStatus?: object,
+ *   localPlugins?: object,
  *   requestAgent: (method: string, params?: object) => Promise<unknown>,
  * }} opts
  * @returns {{ onHost: (message: object) => void }}
@@ -761,7 +762,7 @@ async function mountClientHalf(
 export function attachTuiClient(opts) {
   const {
     ctx, tuiTheme, tuiPresets, tuiSlots, tuiCommands, tuiOverlay, acpSessionConfig, acpSessionPlan,
-    acpSessionStats, acpSessionStatus,
+    acpSessionStats, acpSessionStatus, localPlugins,
     requestAgent,
   } = opts
   const providers = [
@@ -779,6 +780,19 @@ export function attachTuiClient(opts) {
   /** @type {Map<string, () => void>} */
   const loaded = new Map()
   const pendingThemeSelections = new Map()
+
+  async function stopOwner(agentId, pluginId) {
+    if (localPlugins?.has?.(pluginId) === true) {
+      await localPlugins.stop(pluginId)
+      return
+    }
+    const stopped = await requestAgent(CORDIS_METHODS.pluginStop, { agentId, pluginId })
+    if (stopped?.ok === false) {
+      throw new Error(typeof stopped.message === 'string'
+        ? stopped.message
+        : `failed to stop theme Plugin "${pluginId}"`)
+    }
+  }
 
   function sync() {
     void requestAgent(CORDIS_METHODS.inspectSync, { providers: providers.map((provider) => provider.manifest) }).catch(() => {
@@ -905,15 +919,7 @@ export function attachTuiClient(opts) {
         && previousThemeOwner !== undefined
         && previousThemeOwner !== selectedThemeOwner) {
         try {
-          const stopped = await requestAgent(CORDIS_METHODS.pluginStop, {
-            agentId: request.agentId,
-            pluginId: previousThemeOwner,
-          })
-          if (stopped?.ok === false) {
-            throw new Error(typeof stopped.message === 'string'
-              ? stopped.message
-              : `failed to stop theme Plugin "${previousThemeOwner}"`)
-          }
+          await stopOwner(request.agentId, previousThemeOwner)
         } catch (error) {
           if (loaded.get(request.pluginId) === applied.dispose) {
             loaded.delete(request.pluginId)
@@ -981,19 +987,31 @@ export function attachTuiClient(opts) {
     const previousOwner = tuiTheme.owner?.(previousId)
     const targetOwner = tuiTheme.owner?.(request.id)
 
+    if (targetOwner !== undefined && localPlugins?.has?.(targetOwner) === true) {
+      if (localPlugins.isLoaded?.(targetOwner) !== true) {
+        await localPlugins.start(targetOwner)
+      }
+      if (tuiTheme.isLoaded?.(request.id) !== true) {
+        throw new Error(`local theme Plugin "${targetOwner}" did not load palette "${request.id}"`)
+      }
+      tuiTheme.activate(request.id)
+      if (previousOwner !== undefined && previousOwner !== targetOwner) {
+        try {
+          await stopOwner(request.agentId, previousOwner)
+        } catch (error) {
+          await localPlugins.stop(targetOwner)
+          if (tuiTheme.isLoaded?.(previousId) === true) tuiTheme.activate(previousId)
+          throw error
+        }
+      }
+      return { ok: true, status: 'selected', id: request.id }
+    }
+
     if (targetOwner === undefined || loaded.has(targetOwner)) {
       tuiTheme.activate(request.id)
       if (previousOwner !== undefined && previousOwner !== targetOwner) {
         try {
-          const stopped = await requestAgent(CORDIS_METHODS.pluginStop, {
-            agentId: request.agentId,
-            pluginId: previousOwner,
-          })
-          if (stopped?.ok === false) {
-            throw new Error(typeof stopped.message === 'string'
-              ? stopped.message
-              : `failed to stop theme Plugin "${previousOwner}"`)
-          }
+          await stopOwner(request.agentId, previousOwner)
         } catch (error) {
           if (tuiTheme.isLoaded?.(previousId) === true) tuiTheme.activate(previousId)
           throw error
@@ -1043,13 +1061,14 @@ export function apply(ctx) {
   const acpSessionPlan = ctx.acpSessionPlan ?? ctx.get?.('acpSessionPlan')
   const acpSessionStats = ctx.acpSessionStats ?? ctx.get?.('acpSessionStats')
   const acpSessionStatus = ctx.acpSessionStatus ?? ctx.get?.('acpSessionStatus')
+  const localPlugins = ctx.get?.('tuiLocalPlugins')
   let client
   const service = {
     bindTransport(requestAgent) {
       client?.dispose()
       client = attachTuiClient({
         ctx, tuiTheme, tuiPresets, tuiSlots, tuiCommands, tuiOverlay, acpSessionConfig, acpSessionPlan,
-        acpSessionStats, acpSessionStatus,
+        acpSessionStats, acpSessionStatus, localPlugins,
         requestAgent,
       })
       const attached = client

--- a/npm/lib/runner.js
+++ b/npm/lib/runner.js
@@ -12,7 +12,7 @@ import { createRequire } from 'node:module'
 import { fileURLToPath } from 'node:url'
 
 export const name = 'dsh-tui-runner'
-export const inject = ['loader', 'acpServer', 'cmdlineArgs', 'appExit']
+export const inject = ['loader', 'acpServer', 'cmdlineArgs', 'appExit', 'tuiClientPlugins']
 
 const clientEntry = fileURLToPath(new URL('./client-process.js', import.meta.url))
 const requireFromTui = createRequire(import.meta.url)
@@ -44,7 +44,10 @@ export async function apply(ctx) {
       // ACP owns the Client process's stdin/stdout. Its fd 3/4 retain the
       // user's terminal for the Rust painter spawned inside that process.
       stdio: ['pipe', 'pipe', 'inherit', process.stdin, process.stdout],
-      env: process.env,
+      env: {
+        ...process.env,
+        DSH_TUI_CLIENT_PLUGINS_V0: JSON.stringify(ctx.tuiClientPlugins.list()),
+      },
     },
   )
   const agentToClient = child.stdin

--- a/npm/lib/tui-client-plugin-registry.js
+++ b/npm/lib/tui-client-plugin-registry.js
@@ -1,0 +1,70 @@
+/** Host-side directory of installed package entries for the separate TUI Client tree. */
+
+import path from 'node:path'
+import { pathToFileURL } from 'node:url'
+import { Service } from '@deepseek-ai/cordis'
+
+export const name = 'tui-client-plugin-registry'
+export const inject = []
+
+const ID = /^[a-z0-9][a-z0-9-]*$/
+const KINDS = new Set(['theme', 'ui-preset'])
+
+function normalizeEntry(value) {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new Error('tuiClientPlugins.register: entry must be an absolute path or file URL')
+  }
+  if (path.isAbsolute(value)) return pathToFileURL(value).href
+  let url
+  try {
+    url = new URL(value)
+  } catch {
+    throw new Error('tuiClientPlugins.register: entry must be an absolute path or file URL')
+  }
+  if (url.protocol !== 'file:') {
+    throw new Error('tuiClientPlugins.register: entry must use the file protocol')
+  }
+  return url.href
+}
+
+class TuiClientPluginsService extends Service {
+  constructor(ctx) {
+    super(ctx, 'tuiClientPlugins')
+    this.entries = new Map()
+  }
+
+  register(options) {
+    if (options === null || typeof options !== 'object' || Array.isArray(options)) {
+      throw new Error('tuiClientPlugins.register: options must be an object')
+    }
+    if (typeof options.id !== 'string' || !ID.test(options.id)) {
+      throw new Error('tuiClientPlugins.register: id must be a lowercase package identifier')
+    }
+    if (!KINDS.has(options.kind)) {
+      throw new Error('tuiClientPlugins.register: kind must be "theme" or "ui-preset"')
+    }
+    if (this.entries.has(options.id)) {
+      throw new Error(`tuiClientPlugins.register: id ${JSON.stringify(options.id)} is already registered`)
+    }
+    const entry = {
+      id: options.id,
+      kind: options.kind,
+      entry: normalizeEntry(options.entry),
+    }
+    this.entries.set(entry.id, entry)
+    let disposed = false
+    return () => {
+      if (disposed) return
+      disposed = true
+      if (this.entries.get(entry.id) === entry) this.entries.delete(entry.id)
+    }
+  }
+
+  list() {
+    return [...this.entries.values()].map((entry) => ({ ...entry }))
+  }
+}
+
+export function apply(ctx) {
+  return new TuiClientPluginsService(ctx)
+}

--- a/npm/lib/tui-local-plugins.js
+++ b/npm/lib/tui-local-plugins.js
@@ -1,0 +1,213 @@
+/** Merge installed package entries and Creator-authored TUI Client plugins. */
+
+import { applyClientHalf, applyClientPlugin, createClientTimer } from './client-run.js'
+
+const LOCAL_PREFIX = 'tui-local:'
+const PACKAGE_PREFIX = 'tui-package:'
+
+/**
+ * @param {object} ctx
+ * @param {{
+ *   store: object,
+ *   packages?: Array<{ id: string, kind: 'theme' | 'ui-preset', entry: string }>,
+ *   tuiTheme?: object,
+ *   tuiPresets?: object,
+ *   tuiSlots?: object,
+ *   tuiCommands?: object,
+ *   tuiOverlay?: object,
+ *   acpSessionConfig?: object,
+ *   acpSessionPlan?: object,
+ *   acpSessionStats?: object,
+ *   acpSessionStatus?: object,
+ * }} options
+ */
+export function installTuiLocalPlugins(ctx, options) {
+  const { store } = options
+  if (store === undefined || typeof store.list !== 'function' || typeof store.resolve !== 'function') {
+    throw new Error('tuiLocalPlugins: a durable store is required')
+  }
+  const records = new Map()
+  const failures = []
+  const timer = createClientTimer()
+  let discovered = false
+  let disposed = false
+
+  const env = (pluginId) => ({
+    pluginId,
+    tuiTheme: options.tuiTheme,
+    tuiPresets: options.tuiPresets,
+    tuiSlots: options.tuiSlots,
+    tuiCommands: options.tuiCommands,
+    tuiOverlay: options.tuiOverlay,
+    acpSessionConfig: options.acpSessionConfig,
+    acpSessionPlan: options.acpSessionPlan,
+    acpSessionStats: options.acpSessionStats,
+    acpSessionStatus: options.acpSessionStatus,
+    timer,
+  })
+
+  async function mount(record) {
+    let applied
+    if (record.entry !== undefined) {
+      record.module ??= await import(record.entry)
+      const plugin = typeof record.module.apply === 'function'
+        ? record.module
+        : record.module.default
+      applied = await applyClientPlugin(plugin, env(record.pluginId))
+    } else {
+      applied = await applyClientHalf(record.artifact.code.client, env(record.pluginId))
+    }
+    if (applied.waitingFor.length > 0) {
+      applied.dispose()
+      throw new Error(`waiting for unavailable service(s): ${applied.waitingFor.join(', ')}`)
+    }
+    record.release = applied.dispose
+    record.loaded = true
+  }
+
+  async function recover(record) {
+    records.set(record.pluginId, record)
+    try {
+      await mount(record)
+      if (record.kind === 'theme') {
+        record.release?.()
+        record.release = undefined
+        record.loaded = false
+      }
+      return true
+    } catch (error) {
+      record.release?.()
+      records.delete(record.pluginId)
+      failures.push({
+        artifactId: record.artifactId,
+        message: error instanceof Error ? error.message : String(error),
+      })
+      return false
+    }
+  }
+
+  async function discover() {
+    if (disposed) throw new Error('tuiLocalPlugins: registry is disposed')
+    if (discovered) return
+    discovered = true
+    const installedIds = new Set()
+    for (const entry of options.packages ?? []) {
+      installedIds.add(entry.id)
+      await recover({
+        artifactId: entry.id,
+        pluginId: `${PACKAGE_PREFIX}${entry.id}`,
+        kind: entry.kind,
+        entry: entry.entry,
+        module: undefined,
+        loaded: false,
+        release: undefined,
+      })
+    }
+    for (const row of store.list()) {
+      if (installedIds.has(row.id)) {
+        failures.push({
+          artifactId: row.id,
+          message: 'Creator artifact is shadowed by an installed package with the same id',
+        })
+        continue
+      }
+      if (row.broken !== undefined) {
+        failures.push({ artifactId: row.id, message: row.broken })
+        continue
+      }
+      let artifact
+      try {
+        artifact = store.resolve(row.id)
+      } catch (error) {
+        failures.push({
+          artifactId: row.id,
+          message: error instanceof Error ? error.message : String(error),
+        })
+        continue
+      }
+      const pluginId = `${LOCAL_PREFIX}${artifact.id}`
+      const record = {
+        artifact,
+        artifactId: artifact.id,
+        pluginId,
+        kind: artifact.kind,
+        loaded: false,
+        release: undefined,
+      }
+      await recover(record)
+    }
+    const preferredTheme = options.tuiTheme?.preferred?.()
+    const preferredOwner = typeof preferredTheme === 'string'
+      ? options.tuiTheme?.owner?.(preferredTheme)
+      : undefined
+    if (typeof preferredOwner === 'string' && records.has(preferredOwner)) {
+      try {
+        await start(preferredOwner)
+        options.tuiTheme.activate(preferredTheme)
+      } catch (error) {
+        failures.push({
+          artifactId: records.get(preferredOwner)?.artifactId ?? preferredOwner,
+          message: `failed to restore preferred theme: ${error instanceof Error ? error.message : String(error)}`,
+        })
+      }
+    }
+  }
+
+  async function start(pluginId) {
+    if (disposed) throw new Error('tuiLocalPlugins: registry is disposed')
+    const record = records.get(pluginId)
+    if (record === undefined) throw new Error(`tuiLocalPlugins: unknown Plugin ${JSON.stringify(pluginId)}`)
+    if (record.loaded) return
+    await mount(record)
+  }
+
+  async function stop(pluginId) {
+    const record = records.get(pluginId)
+    if (record === undefined || !record.loaded) return false
+    record.release?.()
+    record.release = undefined
+    record.loaded = false
+    return true
+  }
+
+  function has(pluginId) {
+    return records.has(pluginId)
+  }
+
+  function isLoaded(pluginId) {
+    return records.get(pluginId)?.loaded === true
+  }
+
+  function list() {
+    return [...records.values()].map((record) => ({
+      artifactId: record.artifactId,
+      pluginId: record.pluginId,
+      kind: record.kind,
+      loaded: record.loaded,
+    }))
+  }
+
+  function diagnostics() {
+    return failures.map((failure) => ({ ...failure }))
+  }
+
+  async function dispose() {
+    if (disposed) return
+    disposed = true
+    for (const record of [...records.values()].reverse()) {
+      record.release?.()
+      record.release = undefined
+      record.loaded = false
+    }
+    records.clear()
+  }
+
+  const service = { discover, start, stop, has, isLoaded, list, diagnostics, dispose }
+  if (typeof ctx.provide === 'function') ctx.provide('tuiLocalPlugins', service)
+  if (typeof ctx.effect === 'function') {
+    ctx.effect(() => () => service.dispose(), 'tui-local-plugins')
+  } else {
+    ctx.tuiLocalPlugins = service
+  }
+  return service
+}

--- a/npm/lib/tui-plugin-store.js
+++ b/npm/lib/tui-plugin-store.js
@@ -1,0 +1,197 @@
+/** Durable user-authored TUI Client plugins. */
+
+import {
+  cpSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs'
+import { homedir } from 'node:os'
+import path from 'node:path'
+
+const ARTIFACT_ID = /^[a-z0-9][a-z0-9-]*$/
+const KINDS = new Set(['theme', 'ui-preset'])
+const MANIFEST = 'plugin.json'
+
+function artifactId(value) {
+  if (typeof value !== 'string' || !ARTIFACT_ID.test(value)) {
+    throw new Error('tuiPluginStore: id must be a lowercase artifact identifier')
+  }
+  return value
+}
+
+function nonEmpty(value, field) {
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    throw new Error(`tuiPluginStore: ${field} must be a non-empty string`)
+  }
+  return value
+}
+
+function validateManifest(value, expectedId) {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error('manifest must be an object')
+  }
+  if (value.schemaVersion !== 0) throw new Error('schemaVersion must be 0')
+  const id = artifactId(value.id)
+  if (id !== expectedId) throw new Error(`manifest id must match directory ${JSON.stringify(expectedId)}`)
+  if (!KINDS.has(value.kind)) throw new Error('kind must be "theme" or "ui-preset"')
+  const name = nonEmpty(value.name, 'name')
+  const purpose = nonEmpty(value.purpose, 'purpose')
+  if (value.source === null || typeof value.source !== 'object' || Array.isArray(value.source)) {
+    throw new Error('source must be an object')
+  }
+  const pluginId = nonEmpty(value.source.pluginId, 'source.pluginId')
+  const packageId = nonEmpty(value.source.packageId, 'source.packageId')
+  if (value.code === null || typeof value.code !== 'object' || Array.isArray(value.code)) {
+    throw new Error('code must be an object')
+  }
+  const client = nonEmpty(value.code.client, 'code.client')
+  return {
+    schemaVersion: 0,
+    id,
+    kind: value.kind,
+    name,
+    purpose,
+    source: { pluginId, packageId },
+    code: { client },
+  }
+}
+
+function readManifest(file, id) {
+  let parsed
+  try {
+    parsed = JSON.parse(readFileSync(file, 'utf8'))
+  } catch (error) {
+    throw new Error(`invalid JSON: ${error instanceof Error ? error.message : String(error)}`)
+  }
+  return validateManifest(parsed, id)
+}
+
+export function tuiPluginRoot(env = process.env) {
+  return path.join(marttyHome(env), 'plugins')
+}
+
+export function marttyHome(env = process.env, userHome = homedir()) {
+  if (typeof env.MARTTY_HOME === 'string' && env.MARTTY_HOME.length > 0) {
+    return env.MARTTY_HOME
+  }
+  if (typeof env.DSH_HOME === 'string' && env.DSH_HOME.length > 0) {
+    return path.join(env.DSH_HOME, '.martty')
+  }
+  return path.join(userHome, '.martty')
+}
+
+export function legacyTuiPluginRoot(env = process.env, userHome = homedir()) {
+  const dshHome = typeof env.DSH_HOME === 'string' && env.DSH_HOME.length > 0
+    ? env.DSH_HOME
+    : path.join(userHome, '.dsh')
+  return path.join(dshHome, '.tui-plugins')
+}
+
+/**
+ * @param {{ root?: string }} [options]
+ */
+export function createTuiPluginStore(options = {}) {
+  const root = options.root ?? tuiPluginRoot()
+  if (typeof root !== 'string' || root.length === 0 || !path.isAbsolute(root)) {
+    throw new Error('tuiPluginStore: root must be an absolute path')
+  }
+  const legacyRoot = options.legacyRoot
+    ?? (options.root === undefined ? legacyTuiPluginRoot() : undefined)
+  if (legacyRoot !== undefined && legacyRoot !== root && existsSync(legacyRoot)) {
+    mkdirSync(root, { recursive: true })
+    for (const entry of readdirSync(legacyRoot, { withFileTypes: true })) {
+      if (!entry.isDirectory() || !ARTIFACT_ID.test(entry.name)) continue
+      const source = path.join(legacyRoot, entry.name)
+      const target = path.join(root, entry.name)
+      if (!existsSync(target)) cpSync(source, target, { recursive: true, errorOnExist: true })
+    }
+  }
+
+  const paths = (id) => {
+    const safe = artifactId(id)
+    const dir = path.join(root, safe)
+    return { dir, file: path.join(dir, MANIFEST) }
+  }
+
+  function list() {
+    if (!existsSync(root)) return []
+    return readdirSync(root, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory() && ARTIFACT_ID.test(entry.name))
+      .sort((left, right) => left.name.localeCompare(right.name))
+      .map((entry) => {
+        const { file } = paths(entry.name)
+        try {
+          const artifact = readManifest(file, entry.name)
+          return {
+            id: artifact.id,
+            kind: artifact.kind,
+            name: artifact.name,
+            purpose: artifact.purpose,
+            path: file,
+            broken: undefined,
+          }
+        } catch (error) {
+          return {
+            id: entry.name,
+            kind: undefined,
+            name: entry.name,
+            purpose: '',
+            path: file,
+            broken: error instanceof Error ? error.message : String(error),
+          }
+        }
+      })
+  }
+
+  function resolve(id) {
+    const { file } = paths(id)
+    try {
+      return { ...readManifest(file, id), path: file }
+    } catch (error) {
+      throw new Error(
+        `tuiPluginStore: artifact ${JSON.stringify(id)} is broken: `
+        + `${error instanceof Error ? error.message : String(error)}`,
+      )
+    }
+  }
+
+  function save(input, saveOptions = {}) {
+    const manifest = validateManifest({
+      schemaVersion: 0,
+      id: input?.id,
+      kind: input?.kind,
+      name: input?.name,
+      purpose: input?.purpose,
+      source: input?.source,
+      code: { client: input?.clientCode },
+    }, input?.id)
+    const { dir, file } = paths(manifest.id)
+    const replace = saveOptions.replace === true
+    if (existsSync(dir) && !replace) {
+      throw new Error(`tuiPluginStore: artifact ${JSON.stringify(manifest.id)} already exists`)
+    }
+    mkdirSync(dir, { recursive: true })
+    const temporary = path.join(dir, `.${MANIFEST}.${process.pid}.${Date.now()}.tmp`)
+    try {
+      writeFileSync(temporary, `${JSON.stringify(manifest, null, 2)}\n`, { flag: 'wx' })
+      renameSync(temporary, file)
+    } finally {
+      rmSync(temporary, { force: true })
+    }
+    return { id: manifest.id, path: file }
+  }
+
+  function remove(id) {
+    const { dir } = paths(id)
+    if (!existsSync(dir)) return false
+    rmSync(dir, { recursive: true, force: false })
+    return true
+  }
+
+  return { root, list, resolve, save, remove }
+}

--- a/npm/lib/tui-theme.js
+++ b/npm/lib/tui-theme.js
@@ -7,8 +7,8 @@
  * flushed from `bindNotify`.
  */
 
-import { readFileSync } from 'node:fs'
-import { isAbsolute } from 'node:path'
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { dirname, isAbsolute } from 'node:path'
 import { CORDIS_METHODS } from './cordis-protocol.js'
 
 export const name = 'tui-theme'
@@ -76,6 +76,24 @@ const BACKGROUND_FIELDS = new Set(['source', 'fit', 'anchor', 'opacity'])
 const BACKGROUND_SOURCE_FIELDS = new Set(['kind', 'path', 'mediaType', 'base64'])
 const BACKGROUND_ANCHOR_FIELDS = new Set(['x', 'y'])
 const PROTOCOL = 0
+
+function readSettings(settingsPath) {
+  if (typeof settingsPath !== 'string' || settingsPath.length === 0) return {}
+  try {
+    const value = JSON.parse(readFileSync(settingsPath, 'utf8'))
+    return value !== null && typeof value === 'object' && !Array.isArray(value) ? value : {}
+  } catch {
+    return {}
+  }
+}
+
+function writePreferred(settingsPath, id) {
+  if (typeof settingsPath !== 'string' || settingsPath.length === 0) return
+  const settings = readSettings(settingsPath)
+  settings.theme = id
+  mkdirSync(dirname(settingsPath), { recursive: true })
+  writeFileSync(settingsPath, `${JSON.stringify(settings, null, 2)}\n`)
+}
 
 /**
  * Validate a palette against tui-palette protocol 0 (closed token names).
@@ -207,13 +225,18 @@ function validateTokenMap(map, which) {
  * `register` grows the catalog (like adding an agent preset). `/theme` and
  * `activate` switch which pack covers. Builtin `default` is never mutated.
  * @param {object} ctx
- * @param {{ notify?: (method: string, params: object) => void }} [options]
- * @returns {{ register: Function, activate: Function, list: Function, active: Function, subscribe: Function, observeSelected: Function, exportInspectTokens: Function, bindNotify: Function, flush: Function }}
+ * @param {{ notify?: (method: string, params: object) => void, settingsPath?: string }} [options]
+ * @returns {{ register: Function, activate: Function, list: Function, active: Function, preferred: Function, subscribe: Function, observeSelected: Function, exportInspectTokens: Function, bindNotify: Function, flush: Function }}
  */
 export function installTuiTheme(ctx, options = {}) {
   const palettes = new Map()
   const queue = []
   const listeners = new Set()
+  const settingsPath = options.settingsPath
+  const savedTheme = readSettings(settingsPath).theme
+  let preferredId = typeof savedTheme === 'string' && savedTheme.length > 0
+    ? savedTheme
+    : 'default'
   let send = typeof options.notify === 'function' ? options.notify : undefined
   let activeId = 'default'
   let activationRevision = 0
@@ -271,6 +294,8 @@ export function installTuiTheme(ctx, options = {}) {
 
   function activate(id) {
     select(id, true)
+    preferredId = id
+    writePreferred(settingsPath, id)
   }
 
   function observeSelected(params) {
@@ -279,6 +304,8 @@ export function installTuiTheme(ctx, options = {}) {
     }
     if (params.protocol !== PROTOCOL) return false
     select(params.id, false)
+    preferredId = params.id
+    writePreferred(settingsPath, params.id)
     return true
   }
 
@@ -319,7 +346,7 @@ export function installTuiTheme(ctx, options = {}) {
         ...(owner === undefined ? {} : { owner: { pluginId: owner } }),
       })
       if (cover) {
-        activate(validated.id)
+        select(validated.id, true)
         leaseRevision = activationRevision
       }
       return () => {
@@ -331,9 +358,9 @@ export function installTuiTheme(ctx, options = {}) {
           const restoreId = previousId !== undefined && palettes.get(previousId)?.loaded === true
             ? previousId
             : 'default'
-          activate(restoreId)
+          select(restoreId, true)
         } else if (wasActive) {
-          activate('default')
+          select('default', true)
         }
         if (owner === undefined) {
           palettes.delete(validated.id)
@@ -403,6 +430,10 @@ export function installTuiTheme(ctx, options = {}) {
     return activeId
   }
 
+  function preferred() {
+    return preferredId
+  }
+
   function owner(id) {
     return palettes.get(id)?.owner
   }
@@ -440,6 +471,7 @@ export function installTuiTheme(ctx, options = {}) {
     activate,
     list,
     active,
+    preferred,
     owner,
     isLoaded,
     subscribe,
@@ -458,6 +490,6 @@ export function installTuiTheme(ctx, options = {}) {
 }
 
 /** Cordis plugin entry: provide the client-tree theme registry. */
-export function apply(ctx) {
-  installTuiTheme(ctx)
+export function apply(ctx, options) {
+  installTuiTheme(ctx, options)
 }

--- a/npm/package-lock.json
+++ b/npm/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@openma/deepseek-harness-acp": "0.4.13"
+        "@openma/deepseek-harness-acp": "0.4.17-beta.0"
       },
       "bin": {
         "dsb": "bin/dsh-tui.js",
@@ -4983,9 +4983,9 @@
       }
     },
     "node_modules/@openma/deepseek-harness-acp": {
-      "version": "0.4.13",
-      "resolved": "https://registry.npmjs.org/@openma/deepseek-harness-acp/-/deepseek-harness-acp-0.4.13.tgz",
-      "integrity": "sha512-mLJI48ffSZNItm5mzTCbRvnzIkScNzatvm44SgjNITR3mdc5PTnFzWzYNj4Nq9mwyFgGcaS5RUdLhkOmmp1U2g==",
+      "version": "0.4.17-beta.0",
+      "resolved": "https://registry.npmjs.org/@openma/deepseek-harness-acp/-/deepseek-harness-acp-0.4.17-beta.0.tgz",
+      "integrity": "sha512-4FInqBxNmqtktOn4Cwoocy4HUTDjG+ogu93717e2RYZSBwGRwuagCD06Jlyiekdr9bXqwxskkX9o3sMJWmCTLA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@agentclientprotocol/sdk": "^1.3.0",

--- a/npm/package.json
+++ b/npm/package.json
@@ -70,7 +70,7 @@
   },
   "dependencies": {
     "@deepseek-ai/cordis": "^4.0.1",
-    "@openma/deepseek-harness-acp": "0.4.13"
+    "@openma/deepseek-harness-acp": "0.4.17-beta.0"
   },
   "devDependencies": {
     "@deepseek-ai/dsh": "0.1.0-rc.6"

--- a/npm/package.json
+++ b/npm/package.json
@@ -15,7 +15,7 @@
   "main": "lib/index.js",
   "scripts": {
     "pretest": "node --test ../scripts/workflow-release.test.mjs ../scripts/package-alias.test.mjs",
-    "test": "node --test ../scripts/package-native.test.mjs ../scripts/check-release-tag.test.mjs ../scripts/check-static-elf.test.mjs ../scripts/smoke-old-linux.test.mjs ../scripts/cargo-guard.test.mjs ../scripts/build-npm.test.mjs ../scripts/client-profile.test.mjs ../scripts/plugin-runner.test.mjs ../scripts/profile-link-resolution.test.mjs ../scripts/release.test.mjs ../scripts/jsonrpc-line-transport.test.mjs ../scripts/tui-theme.test.mjs ../scripts/tui-presets.test.mjs ../scripts/tui-slots.test.mjs ../scripts/tui-commands.test.mjs ../scripts/tui-overlay.test.mjs ../scripts/mux.test.mjs ../scripts/acp-client.test.mjs ../scripts/acp-client-events.test.mjs ../scripts/acp-session-config.test.mjs ../scripts/acp-session-plan.test.mjs ../scripts/acp-session-stats.test.mjs ../scripts/acp-session-status.test.mjs ../scripts/plan-view.test.mjs ../scripts/stats-view.test.mjs ../scripts/status-view.test.mjs ../scripts/deepseek-logo.test.mjs ../scripts/runner.test.mjs ../scripts/inspect.test.mjs ../scripts/creator-overlay.test.mjs ../scripts/real-agent-e2e.test.mjs"
+    "test": "node --test ../scripts/package-native.test.mjs ../scripts/check-release-tag.test.mjs ../scripts/check-static-elf.test.mjs ../scripts/smoke-old-linux.test.mjs ../scripts/cargo-guard.test.mjs ../scripts/build-npm.test.mjs ../scripts/client-profile.test.mjs ../scripts/plugin-runner.test.mjs ../scripts/profile-link-resolution.test.mjs ../scripts/release.test.mjs ../scripts/jsonrpc-line-transport.test.mjs ../scripts/tui-theme.test.mjs ../scripts/tui-presets.test.mjs ../scripts/tui-plugin-store.test.mjs ../scripts/tui-local-plugins.test.mjs ../scripts/tui-client-plugin-registry.test.mjs ../scripts/tui-slots.test.mjs ../scripts/tui-commands.test.mjs ../scripts/tui-overlay.test.mjs ../scripts/mux.test.mjs ../scripts/acp-client.test.mjs ../scripts/acp-client-events.test.mjs ../scripts/acp-session-config.test.mjs ../scripts/acp-session-plan.test.mjs ../scripts/acp-session-stats.test.mjs ../scripts/acp-session-status.test.mjs ../scripts/plan-view.test.mjs ../scripts/stats-view.test.mjs ../scripts/status-view.test.mjs ../scripts/deepseek-logo.test.mjs ../scripts/runner.test.mjs ../scripts/inspect.test.mjs ../scripts/creator-overlay.test.mjs ../scripts/real-agent-e2e.test.mjs"
   },
   "publishConfig": {
     "access": "public",
@@ -43,6 +43,7 @@
     "./profile-acp-client": "./lib/profile-acp-client.js",
     "./acp-host": "./lib/acp-host.js",
     "./creator-overlay": "./lib/creator-overlay.js",
+    "./client-plugin-registry": "./lib/tui-client-plugin-registry.js",
     "./cordis-client-runner": "./lib/inspect.js",
     "./runner": "./lib/runner.js",
     "./cordis.patch.yml": "./cordis.patch.yml",

--- a/npm/skills/tui-plugin-development/SKILL.md
+++ b/npm/skills/tui-plugin-development/SKILL.md
@@ -18,8 +18,10 @@ skill for shared Cordis behavior and for any genuine Host or Web half.
    assets: asset contents do not determine which TUI Providers own the UI.
 2. Query only the smallest Client Providers that own the requested behavior,
    using the exact methods shown by the list.
-3. For an existing `@pluginId`, call `cordis_inspect_self` once; skip it for a
-   new Plugin.
+3. For an existing temporary `@pluginId`, call `cordis_inspect_self` once. To
+   continue a durable Creator artifact after restart, call `tui_plugin_list`
+   and `tui_plugin_read` instead, then use its exact `code.client` as the base
+   of a new temporary preview Plugin.
 4. Write plain JavaScript in `code.client`. Add `code.host` only when the task
    genuinely owns Host data or operations.
 5. Call `cordis_define` once, then `cordis_run` once with the returned exact
@@ -28,17 +30,32 @@ skill for shared Cordis behavior and for any genuine Host or Web half.
 6. If run reports `awaiting-approval` or `starting`, stop the Tool flow and let
    later state updates finish activation. Reply with one short status sentence;
    do not summarize the implementation while approval is pending.
-7. After the later state update confirms activation, report success and stop.
-   Do not re-query Providers merely to verify effects that activation already
-   confirmed; query again only for a concrete runtime diagnostic.
+7. After the later state update confirms activation, persist a new or modified
+   UI Preset or Theme Plugin with `tui_plugin_save`, unless the user explicitly
+   requested a temporary preview. Use the returned exact `pluginId` and
+   `packageId`; use a stable `artifactId`, the matching `kind`, and
+   `replace: true` only when updating an artifact already read from disk.
+8. Report success only after `tui_plugin_save` returns `saved`, including its
+   exact path. Do not call a temporary dynamic Plugin durable. Other dynamic
+   TUI Plugins remain process-local unless a separate shipping path was
+   explicitly requested.
 
-The normal new-plugin trajectory is therefore one list, one query per needed
-Provider, one define, and one run. Once inspect returns a sufficient live
+The normal preview trajectory is therefore one list, one query per needed
+Provider, one define, and one run. A durable UI Preset or Theme Plugin adds one
+save after successful activation. Once inspect returns a sufficient live
 contract, author immediately; do not re-prove it from generic Cordis concepts.
 
-`define` stores an immutable Package; `run` activates it. Stop/update/unload
-dispose the owning Client Plugin effects. Never depend on a value returned by
-`apply()` as the disposer; register effects through the inspected Cordis APIs.
+`define` stores an immutable Package only in the current process; `run`
+activates it. Neither operation persists it across restart. `tui_plugin_save`
+copies the successful Client source into the TUI-owned authoring root; use
+`tui_plugin_read` to continue development later and `tui_plugin_remove` to
+delete it. Stop/update/unload dispose the owning Client Plugin effects. Never
+depend on a value returned by `apply()` as the disposer; register effects
+through the inspected Cordis APIs.
+
+The authoring root is `$MARTTY_HOME/plugins`; `MARTTY_HOME` resolves from the
+explicit environment variable, then `$DSH_HOME/.martty`, then `~/.martty`.
+User selections live separately in `$MARTTY_HOME/settings.json`.
 
 ## Inspect is the authority
 
@@ -88,8 +105,11 @@ compose only in the Plugin code. The services do not imply one another:
   option and enters the same Plugin seat.
 - **UI Presets:** use `tuiPresets.register({ id, label }, mount)` when the user
   wants one saved `/ui` choice to mount several UI contributions together.
-  The synchronous mount callback returns one disposer. A UI Preset composes
-  Theme, slots, pet, or other UI Plugins; it is not another name for Theme.
+  The synchronous mount callback returns one disposer. A UI Preset owns
+  structural UI contributions such as slots, chrome, or a pet. It does not
+  register, select, clone, or generate a Theme: `/ui`, `/theme`, and dark/light
+  are independent state dimensions. A preset may document a recommended
+  Theme, but recommendation is not runtime ownership.
 - **Commands:** register a local slash command. Registration publishes slash
   completion and keeps invocation out of the ACP prompt. Its availability is
   the registration's lifetime; Commands does not know about themes, overlays,

--- a/scripts/client-profile.test.mjs
+++ b/scripts/client-profile.test.mjs
@@ -31,6 +31,7 @@ test('one TUI install adds no duplicate Base loader entries', () => {
     assert.equal(dump.status, 0, dump.stderr)
     assert.equal(dump.stdout.match(/^- id: timer$/gm)?.length, 1)
     assert.equal(dump.stdout.match(/^- id: hmr$/gm)?.length, 1)
+    assert.equal(dump.stdout.match(/^- id: tui-client-plugins$/gm)?.length, 1)
   } finally {
     rmSync(home, { recursive: true, force: true })
   }

--- a/scripts/creator-overlay.test.mjs
+++ b/scripts/creator-overlay.test.mjs
@@ -1,4 +1,7 @@
 import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
 import test from 'node:test'
 
 import * as creatorOverlay from '../npm/lib/creator-overlay.js'
@@ -6,11 +9,21 @@ import * as creatorOverlay from '../npm/lib/creator-overlay.js'
 function harness() {
   const skills = new Map()
   const promptSections = []
+  const tools = new Map()
   const effects = []
   const standingKey = { preset: 'cordis' }
-  let requestedModule
+  const requestedModules = []
   let requestedPreset
   let disposed = false
+  let inspected
+  let packageSource = {
+    pluginId: 'skin-1',
+    packageId: 'dyn-1',
+    name: 'Paper Lantern',
+    purpose: 'Warm terminal palette',
+    code: { client: 'return { apply() {} }' },
+    currentPackageId: 'dyn-1',
+  }
 
   const overlay = {
     ctx: {
@@ -26,6 +39,14 @@ function harness() {
           return {
             section(section) {
               promptSections.push(section)
+            },
+          }
+        }
+        if (name === 'tools') {
+          return {
+            register(tool) {
+              tools.set(tool.name, tool)
+              return () => tools.delete(tool.name)
             },
           }
         }
@@ -48,7 +69,10 @@ function harness() {
     },
     loader: {
       async import(name) {
-        requestedModule = name
+        requestedModules.push(name)
+        if (name === '@deepseek-ai/dsh-tools') {
+          return { defineTool: (definition) => definition }
+        }
         return {
           createScope(parent, key) {
             assert.equal(parent, ctx)
@@ -56,6 +80,12 @@ function harness() {
             return overlay
           },
         }
+      },
+    },
+    dynamicCordisRunner: {
+      inspectPackage(agent, pluginId, packageId) {
+        inspected = { agent, pluginId, packageId }
+        return packageSource
       },
     },
     effect(setup, label) {
@@ -68,7 +98,11 @@ function harness() {
     effects,
     promptSections,
     skills,
-    state: () => ({ disposed, requestedModule, requestedPreset }),
+    tools,
+    setPackageSource(value) {
+      packageSource = value
+    },
+    state: () => ({ disposed, inspected, requestedModules, requestedPreset }),
   }
 }
 
@@ -76,7 +110,7 @@ test('exports one internal Host overlay with the required injected services', ()
   assert.equal(creatorOverlay.name, 'tui-creator-overlay')
   assert.deepEqual(
     creatorOverlay.inject,
-    ['agentPresets', 'skills', 'systemPrompt', 'loader'],
+    ['agentPresets', 'skills', 'systemPrompt', 'loader', 'tools', 'dynamicCordisRunner'],
   )
 })
 
@@ -96,7 +130,7 @@ test('adds the TUI companion skill only to the requested preset scope', async ()
 test('loads the profile-owned scope module instead of importing a private copy', async () => {
   const fixture = harness()
   await creatorOverlay.apply(fixture.ctx)
-  assert.equal(fixture.state().requestedModule, '@deepseek-ai/dsh-scope')
+  assert.ok(fixture.state().requestedModules.includes('@deepseek-ai/dsh-scope'))
 })
 
 test('routes generic Cordis first and TUI behavior to the companion skill', async () => {
@@ -131,4 +165,101 @@ test('rejects an empty preset id without touching the preset registry', async ()
     /preset must be a non-empty string/,
   )
   assert.equal(fixture.state().requestedPreset, undefined)
+})
+
+test('Creator scope exposes explicit durable TUI artifact tools', async () => {
+  const fixture = harness()
+  const root = mkdtempSync(path.join(tmpdir(), 'martty-creator-artifacts-'))
+  try {
+    await creatorOverlay.apply(fixture.ctx, { artifactRoot: root })
+
+    assert.deepEqual([...fixture.tools.keys()].sort(), [
+      'tui_plugin_list',
+      'tui_plugin_read',
+      'tui_plugin_remove',
+      'tui_plugin_save',
+    ])
+
+    const agent = { id: 'agent-1' }
+    const saved = await fixture.tools.get('tui_plugin_save').execute({
+      artifactId: 'paper-lantern',
+      kind: 'theme',
+      pluginId: 'skin-1',
+      packageId: 'dyn-1',
+    }, { agent })
+    assert.deepEqual(fixture.state().inspected, {
+      agent,
+      pluginId: 'skin-1',
+      packageId: 'dyn-1',
+    })
+    assert.equal(saved.status, 'saved')
+    assert.equal(saved.artifact.id, 'paper-lantern')
+    assert.equal(saved.artifact.kind, 'theme')
+    assert.equal(saved.path, path.join(root, 'paper-lantern', 'plugin.json'))
+
+    const listed = await fixture.tools.get('tui_plugin_list').execute({}, { agent })
+    assert.equal(listed.artifacts[0].id, 'paper-lantern')
+
+    const read = await fixture.tools.get('tui_plugin_read').execute({
+      artifactId: 'paper-lantern',
+    }, { agent })
+    assert.equal(read.artifact.id, 'paper-lantern')
+    assert.equal(read.artifact.source.packageId, 'dyn-1')
+    assert.equal(read.artifact.code.client, 'return { apply() {} }')
+
+    const removed = await fixture.tools.get('tui_plugin_remove').execute({
+      artifactId: 'paper-lantern',
+    }, { agent })
+    assert.deepEqual(removed, { status: 'removed', artifactId: 'paper-lantern' })
+  } finally {
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('Creator refuses to persist unvalidated or Host-backed dynamic Packages as TUI artifacts', async () => {
+  const fixture = harness()
+  const root = mkdtempSync(path.join(tmpdir(), 'martty-creator-artifacts-'))
+  try {
+    await creatorOverlay.apply(fixture.ctx, { artifactRoot: root })
+    const save = fixture.tools.get('tui_plugin_save')
+    assert.equal(typeof save?.execute, 'function')
+    if (typeof save?.execute !== 'function') return
+
+    fixture.setPackageSource({
+      pluginId: 'skin-1',
+      packageId: 'dyn-2',
+      name: 'Not run',
+      purpose: 'Not validated',
+      code: { client: 'return {}' },
+    })
+    await assert.rejects(
+      save.execute({
+        artifactId: 'not-run',
+        kind: 'theme',
+        pluginId: 'skin-1',
+        packageId: 'dyn-2',
+      }, { agent: { id: 'agent-1' } }),
+      /successful|current|run/i,
+    )
+
+    fixture.setPackageSource({
+      pluginId: 'mixed-1',
+      packageId: 'dyn-3',
+      name: 'Mixed',
+      purpose: 'Has Host behavior',
+      code: { host: 'return {}', client: 'return {}' },
+      currentPackageId: 'dyn-3',
+    })
+    await assert.rejects(
+      save.execute({
+        artifactId: 'mixed',
+        kind: 'ui-preset',
+        pluginId: 'mixed-1',
+        packageId: 'dyn-3',
+      }, { agent: { id: 'agent-1' } }),
+      /Host|client-only/i,
+    )
+  } finally {
+    rmSync(root, { recursive: true, force: true })
+  }
 })

--- a/scripts/inspect.test.mjs
+++ b/scripts/inspect.test.mjs
@@ -507,6 +507,59 @@ test('dynamic Client halves can subscribe to ACP session stats', async () => {
   delete globalThis.__dshStatsLatest
 })
 
+test('/theme starts and stops durable local Theme Plugins without asking the Agent', async () => {
+  const theme = installTuiTheme(makeCtx())
+  const colors = Object.fromEntries(TOKEN_NAMES.map((name) => [name, '#224466']))
+  const paper = {
+    id: 'paper-lantern',
+    label: 'Paper Lantern',
+    dark: colors,
+    light: colors,
+  }
+  const owner = 'tui-local:paper-lantern'
+  theme.registerOwned(owner, paper)()
+
+  const lifecycle = []
+  let release
+  const localPlugins = {
+    has(pluginId) {
+      return pluginId === owner
+    },
+    isLoaded(pluginId) {
+      return pluginId === owner && release !== undefined
+    },
+    async start(pluginId) {
+      lifecycle.push(`start:${pluginId}`)
+      release = theme.registerOwned(owner, paper)
+    },
+    async stop(pluginId) {
+      lifecycle.push(`stop:${pluginId}`)
+      release?.()
+      release = undefined
+    },
+  }
+  const remoteCalls = []
+  const client = attachTuiClient({
+    ctx: makeCtx(),
+    tuiTheme: theme,
+    localPlugins,
+    requestAgent(method, params) {
+      remoteCalls.push({ method, params })
+      return Promise.resolve({ ok: true })
+    },
+  })
+
+  await client.selectTheme({ protocol: 0, agentId: 'agent-1', id: 'paper-lantern' })
+  assert.equal(theme.active(), 'paper-lantern')
+  assert.deepEqual(lifecycle, [`start:${owner}`])
+  assert.equal(remoteCalls.some(({ method }) => method === CORDIS_METHODS.pluginStart), false)
+
+  await client.selectTheme({ protocol: 0, agentId: 'agent-1', id: 'default' })
+  assert.equal(theme.active(), 'default')
+  assert.deepEqual(lifecycle, [`start:${owner}`, `stop:${owner}`])
+  assert.equal(remoteCalls.some(({ method }) => method === CORDIS_METHODS.pluginStop), false)
+})
+
 test('/theme replaces one dynamic Client Plugin with another as a single lifecycle', async () => {
   const theme = installTuiTheme(makeCtx())
   const commands = installTuiCommands(makeCtx())

--- a/scripts/plugin-runner.test.mjs
+++ b/scripts/plugin-runner.test.mjs
@@ -32,7 +32,12 @@ registerHooks({
 })
 
 const runner = await import(pathToFileURL(runnerPath).href)
-const { bootClient } = await import(pathToFileURL(bootPath).href)
+const {
+  bootClient,
+  migrateLegacyUiSettings,
+  parseClientPluginsEnv,
+  uiSettingsPath,
+} = await import(pathToFileURL(bootPath).href)
 const { installTuiTheme } = await import(
   pathToFileURL(path.join(repoRoot, 'npm', 'lib', 'tui-theme.js')).href
 )
@@ -54,6 +59,9 @@ const { installAcpClientEvents } = await import(
 const { installAcpSessionPlan } = await import(
   pathToFileURL(path.join(repoRoot, 'npm', 'lib', 'acp-session-plan.js')).href
 )
+const { createTuiPluginStore } = await import(
+  pathToFileURL(path.join(repoRoot, 'npm', 'lib', 'tui-plugin-store.js')).href
+)
 const { selectNativeBinary } = await import(
   pathToFileURL(path.join(repoRoot, 'npm', 'lib', 'spawn-tui.js')).href
 )
@@ -73,6 +81,48 @@ test('a source checkout prefers its current debug painter over a stale packaged 
       selectNativeBinary({ envBin: '/missing/override', devBin: debug, packagedBin: packaged }),
       debug,
     )
+  } finally {
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('Martty settings live under the branded home with explicit environment precedence', () => {
+  assert.equal(
+    uiSettingsPath([], { MARTTY_HOME: '/opt/martty', DSH_HOME: '/opt/dsh' }, '/Users/test'),
+    path.join('/opt/martty', 'settings.json'),
+  )
+  assert.equal(
+    uiSettingsPath([], { DSH_HOME: '/opt/dsh' }, '/Users/test'),
+    path.join('/opt/dsh', '.martty', 'settings.json'),
+  )
+  assert.equal(
+    uiSettingsPath([], {}, '/Users/test'),
+    path.join('/Users/test', '.martty', 'settings.json'),
+  )
+  assert.equal(
+    uiSettingsPath(['--session-root', '/tmp/isolated'], {}, '/Users/test'),
+    path.join('/tmp/isolated', 'settings.json'),
+  )
+})
+
+test('legacy UI settings copy into Martty home without overwriting either side', () => {
+  const root = mkdtempSync(path.join(tmpdir(), 'martty-settings-migration-'))
+  try {
+    const legacy = path.join(root, 'legacy', 'dsh-tui-settings.json')
+    const current = path.join(root, '.martty', 'settings.json')
+    mkdirSync(path.dirname(legacy), { recursive: true })
+    writeFileSync(legacy, '{"uiPreset":"deepseek","theme":"ember"}\n')
+
+    assert.equal(migrateLegacyUiSettings(current, [legacy]), true)
+    assert.deepEqual(JSON.parse(readFileSync(current, 'utf8')), {
+      uiPreset: 'deepseek',
+      theme: 'ember',
+    })
+    assert.equal(existsSync(legacy), true, 'migration must preserve legacy settings')
+
+    writeFileSync(current, '{"theme":"custom"}\n')
+    assert.equal(migrateLegacyUiSettings(current, [legacy]), false)
+    assert.equal(JSON.parse(readFileSync(current, 'utf8')).theme, 'custom')
   } finally {
     rmSync(root, { recursive: true, force: true })
   }
@@ -148,6 +198,98 @@ test('standalone boot mounts the Cordis Client runner before the shell', async (
     )
   } finally {
     restore()
+  }
+})
+
+test('Client boot rehydrates Creator-authored UI Presets from the durable user root', async () => {
+  runner.resetShellForTests()
+  const restore = ensureTestNative()
+  const home = mkdtempSync(path.join(tmpdir(), 'dsh-tui-client-artifacts-'))
+  let ctx
+  try {
+    const artifactRoot = path.join(home, '.tui-plugins')
+    createTuiPluginStore({ root: artifactRoot }).save({
+      id: 'focused-ui',
+      kind: 'ui-preset',
+      name: 'Focused UI',
+      purpose: 'Focused startup layout',
+      source: { pluginId: 'ui-1', packageId: 'dyn-1' },
+      clientCode: `return {
+        inject: ['tuiPresets'],
+        apply(ctx) {
+          return ctx.tuiPresets.register({ id: 'focused', label: 'Focused' }, () => () => {})
+        },
+      }`,
+    })
+
+    ctx = await bootClient({
+      stream: { stdin: fakeStream(), stdout: fakeStream() },
+      extraArgs: [],
+      settingsPath: path.join(home, 'dsh-tui-settings.json'),
+      artifactRoot,
+    })
+
+    assert.equal(typeof ctx.get('tuiLocalPlugins')?.list, 'function')
+    assert.ok(ctx.get('tuiPresets').list().some(({ id }) => id === 'focused'))
+    assert.deepEqual(ctx.get('tuiLocalPlugins').list(), [{
+      artifactId: 'focused-ui',
+      pluginId: 'tui-local:focused-ui',
+      kind: 'ui-preset',
+      loaded: true,
+    }])
+  } finally {
+    await ctx?.dispose?.()
+    runner.resetShellForTests()
+    restore()
+    rmSync(home, { recursive: true, force: true })
+  }
+})
+
+test('Client boot mounts installed package entries received from the Host registry', async () => {
+  runner.resetShellForTests()
+  const restore = ensureTestNative()
+  const home = mkdtempSync(path.join(tmpdir(), 'dsh-tui-package-entries-'))
+  let ctx
+  try {
+    const entry = path.join(home, 'installed-ui.mjs')
+    writeFileSync(entry, `
+      export const inject = ['tuiPresets']
+      export function apply(ctx) {
+        return ctx.tuiPresets.register(
+          { id: 'installed', label: 'Installed package' },
+          () => () => {},
+        )
+      }
+    `)
+    const packagePlugins = [{
+      id: 'installed-ui',
+      kind: 'ui-preset',
+      entry: pathToFileURL(entry).href,
+    }]
+    assert.equal(typeof parseClientPluginsEnv, 'function')
+    if (typeof parseClientPluginsEnv !== 'function') return
+    assert.deepEqual(parseClientPluginsEnv(JSON.stringify(packagePlugins)), packagePlugins)
+
+    ctx = await bootClient({
+      stream: { stdin: fakeStream(), stdout: fakeStream() },
+      extraArgs: [],
+      settingsPath: path.join(home, 'dsh-tui-settings.json'),
+      artifactRoot: path.join(home, '.tui-plugins'),
+      packagePlugins,
+    })
+
+    assert.ok(ctx.get('tuiPresets').list().some(({ id }) => id === 'installed'))
+    assert.deepEqual(ctx.get('tuiLocalPlugins').list(), [{
+      artifactId: 'installed-ui',
+      pluginId: 'tui-package:installed-ui',
+      kind: 'ui-preset',
+      loaded: true,
+    }])
+  } finally {
+    await ctx?.dispose?.()
+    runner.resetShellForTests()
+    restore()
+    rmSync(home, { recursive: true, force: true })
   }
 })
 
@@ -555,6 +697,21 @@ test('hot-reloaded shell modules keep exactly one TTY painter', async () => {
     )
   } finally {
     first.resetShellForTests()
+    restore()
+  }
+})
+
+test('test shell reset retracts its process-exit listener', async () => {
+  runner.resetShellForTests()
+  const restore = ensureTestNative()
+  const before = process.listenerCount('exit')
+  try {
+    await runner.apply(makeCtx())
+    assert.equal(process.listenerCount('exit'), before + 1)
+    runner.resetShellForTests()
+    assert.equal(process.listenerCount('exit'), before)
+  } finally {
+    runner.resetShellForTests()
     restore()
   }
 })

--- a/scripts/profile-link-resolution.test.mjs
+++ b/scripts/profile-link-resolution.test.mjs
@@ -82,10 +82,13 @@ test('Host entries resolve ACP from the TUI dependency graph through the profile
     acpServer: { connect: () => connection },
     cmdlineArgs: { get: () => [] },
     appExit() {},
+    tuiClientPlugins: { list: () => [] },
     effect() {},
   })
 
-  assert.deepEqual(runner.inject, ['loader', 'acpServer', 'cmdlineArgs', 'appExit'])
+  assert.deepEqual(runner.inject, [
+    'loader', 'acpServer', 'cmdlineArgs', 'appExit', 'tuiClientPlugins',
+  ])
   assert.deepEqual(imports, [
     ownAcpPlugin,
     ownAcpBridge,

--- a/scripts/real-agent-e2e.py
+++ b/scripts/real-agent-e2e.py
@@ -295,7 +295,12 @@ def workspace_slug(workspace: Path) -> str:
 
 def session_roots(configured: Path) -> list[Path]:
     dsh_home = Path(os.environ.get("DSH_HOME", str(Path.home() / ".dsh")))
-    roots = [configured, dsh_home / "sessions", Path.home() / ".dsh-tui" / "sessions"]
+    roots = [
+        configured,
+        dsh_home / "sessions",
+        Path.home() / ".martty" / "sessions",
+        Path.home() / ".dsh-tui" / "sessions",
+    ]
     return list(dict.fromkeys(path.resolve() for path in roots))
 
 

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -67,8 +67,8 @@ try {
   const dryRun = process.argv.includes('--dry-run')
   if (!rawVersion) throw new Error('usage: release.mjs <version> [--dry-run]')
 
-  const match = rawVersion.match(/^v?(\d+\.\d+\.\d+)$/)
-  if (!match) throw new Error(`invalid version: ${rawVersion} (expected X.Y.Z)`)
+  const match = rawVersion.match(/^v?(\d+\.\d+\.\d+(?:-(?:alpha|beta|rc)\.\d+)?)$/)
+  if (!match) throw new Error(`invalid version: ${rawVersion} (expected X.Y.Z or X.Y.Z-{alpha,beta,rc}.N)`)
   const version = match[1]
   const tag = `v${version}`
 

--- a/scripts/release.test.mjs
+++ b/scripts/release.test.mjs
@@ -71,6 +71,16 @@ test('bumps all package versions, commits, and tags', (t) => {
   assert.equal(git(root, ['status', '--porcelain']), '')
 })
 
+test('bumps and tags a beta prerelease', (t) => {
+  const root = fixture(t)
+  const result = run(root, '0.2.17-beta.0')
+  assert.equal(result.status, 0, result.stderr)
+  assert.equal(JSON.parse(readFileSync(path.join(root, 'npm', 'package.json'), 'utf8')).version, '0.2.17-beta.0')
+  assert.match(readFileSync(path.join(root, 'Cargo.toml'), 'utf8'), /^version = "0\.2\.17-beta\.0"$/m)
+  assert.equal(git(root, ['log', '-1', '--format=%s']), 'release: v0.2.17-beta.0')
+  assert.equal(git(root, ['tag', '--list']), 'v0.2.17-beta.0')
+})
+
 test('accepts a v-prefixed version and dry-run changes nothing', (t) => {
   const root = fixture(t)
   const result = run(root, 'v0.3.0', ['--dry-run'])

--- a/scripts/runner.test.mjs
+++ b/scripts/runner.test.mjs
@@ -68,7 +68,39 @@ const { restoreHostTty, shouldQuitOnPainterExit } = await import(
 )
 
 test('profile runner waits for the Host ACP server and launcher lifecycle', () => {
-  assert.deepEqual(runner.inject, ['loader', 'acpServer', 'cmdlineArgs', 'appExit'])
+  assert.deepEqual(runner.inject, [
+    'loader', 'acpServer', 'cmdlineArgs', 'appExit', 'tuiClientPlugins',
+  ])
+})
+
+test('profile runner serializes installed package entries into the Client process', async () => {
+  runner.resetProfileRunnerForTests?.()
+  profileHarness.reset()
+  const entries = [{
+    id: 'paper-lantern',
+    kind: 'theme',
+    entry: 'file:///opt/example/paper-lantern.js',
+  }]
+  const ctx = {
+    loader: {
+      async import() {
+        return { nodeAcpStream: profileHarness.nodeAcpStream }
+      },
+    },
+    acpServer: profileHarness.makeServer('host-plugin'),
+    cmdlineArgs: { get: () => [] },
+    appExit() {},
+    tuiClientPlugins: { list: () => entries.map((entry) => ({ ...entry })) },
+    effect() {},
+  }
+
+  await runner.apply(ctx)
+
+  const spawned = profileHarness.state.clientSpawns[0]
+  assert.deepEqual(
+    JSON.parse(spawned.options.env.DSH_TUI_CLIENT_PLUGINS_V0),
+    entries,
+  )
 })
 
 test('profile runner connects Host ACP to a separate TUI Client process', async () => {
@@ -86,6 +118,7 @@ test('profile runner connects Host ACP to a separate TUI Client process', async 
     },
     acpServer: profileHarness.makeServer('host-plugin'),
     cmdlineArgs: { get: () => ['--workspace', '/tmp/eval'] },
+    tuiClientPlugins: { list: () => [] },
     appExit() {
       throw new Error('scoped appExit accessor must not own process shutdown')
     },
@@ -132,6 +165,7 @@ test('independent runner fibers own independent Client processes', async () => {
     },
     acpServer: profileHarness.makeServer(owner),
     cmdlineArgs: { get: () => [] },
+    tuiClientPlugins: { list: () => [] },
     appExit() {},
     effect(callback) {
       effects.push(callback())
@@ -165,6 +199,7 @@ test('a failed ACP connection retracts the Client process it already spawned', a
       },
     },
     cmdlineArgs: { get: () => [] },
+    tuiClientPlugins: { list: () => [] },
     appExit() {},
     effect() {},
   }
@@ -199,6 +234,7 @@ test('Client exit requests app shutdown before ACP cleanup settles', async () =>
     },
     acpServer: { connect: () => connection },
     cmdlineArgs: { get: () => [] },
+    tuiClientPlugins: { list: () => [] },
     appExit() {
       throw new Error('scoped appExit accessor must not own process shutdown')
     },

--- a/scripts/tui-client-plugin-registry.test.mjs
+++ b/scripts/tui-client-plugin-registry.test.mjs
@@ -1,0 +1,66 @@
+import assert from 'node:assert/strict'
+import path from 'node:path'
+import test from 'node:test'
+import { pathToFileURL } from 'node:url'
+
+const registryModule = await import('../npm/lib/tui-client-plugin-registry.js').catch(() => ({}))
+const cordisModule = await import('../npm/node_modules/@deepseek-ai/cordis/lib/index.js')
+
+test('installed packages register serializable Client entries on the Host tree', async () => {
+  assert.equal(typeof registryModule.apply, 'function')
+  if (typeof registryModule.apply !== 'function') return
+
+  const { Context } = cordisModule
+  const ctx = new Context()
+  await ctx.plugin(registryModule)
+  const entry = path.resolve('/opt/example/paper-lantern.js')
+  const registration = ctx.plugin({
+    name: 'paper-lantern-host-registration',
+    inject: ['tuiClientPlugins'],
+    apply(pluginCtx) {
+      return pluginCtx.tuiClientPlugins.register({
+        id: 'paper-lantern',
+        kind: 'theme',
+        entry,
+      })
+    },
+  })
+  await registration
+
+  assert.deepEqual(ctx.tuiClientPlugins.list(), [{
+    id: 'paper-lantern',
+    kind: 'theme',
+    entry: pathToFileURL(entry).href,
+  }])
+  const snapshot = ctx.tuiClientPlugins.list()
+  snapshot[0].id = 'mutated'
+  assert.equal(ctx.tuiClientPlugins.list()[0].id, 'paper-lantern')
+
+  await registration.dispose()
+  assert.deepEqual(ctx.tuiClientPlugins.list(), [])
+})
+
+test('installed package registry rejects duplicate ids and non-file Client entries', async () => {
+  assert.equal(typeof registryModule.apply, 'function')
+  if (typeof registryModule.apply !== 'function') return
+
+  const { Context } = cordisModule
+  const ctx = new Context()
+  await ctx.plugin(registryModule)
+  const release = ctx.tuiClientPlugins.register({
+    id: 'focused-ui',
+    kind: 'ui-preset',
+    entry: '/opt/example/focused-ui.js',
+  })
+  assert.throws(() => ctx.tuiClientPlugins.register({
+    id: 'focused-ui',
+    kind: 'ui-preset',
+    entry: '/opt/example/other.js',
+  }), /already registered|duplicate/i)
+  assert.throws(() => ctx.tuiClientPlugins.register({
+    id: 'remote-ui',
+    kind: 'ui-preset',
+    entry: 'https://example.com/plugin.js',
+  }), /file|absolute|entry/i)
+  release()
+})

--- a/scripts/tui-local-plugins.test.mjs
+++ b/scripts/tui-local-plugins.test.mjs
@@ -1,0 +1,280 @@
+import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import test from 'node:test'
+import { pathToFileURL } from 'node:url'
+
+import { createTuiPluginStore } from '../npm/lib/tui-plugin-store.js'
+import { installTuiCommands } from '../npm/lib/tui-commands.js'
+import { installTuiOverlay } from '../npm/lib/tui-overlay.js'
+import { installTuiPresets } from '../npm/lib/tui-presets.js'
+import { installTuiSlots } from '../npm/lib/tui-slots.js'
+import { installTuiTheme, TOKEN_NAMES } from '../npm/lib/tui-theme.js'
+
+const localModule = await import('../npm/lib/tui-local-plugins.js').catch(() => ({}))
+
+function makeCtx() {
+  return {
+    effect(fn) {
+      return fn()
+    },
+    get() {},
+    on() {
+      return () => {}
+    },
+  }
+}
+
+function services(ctx, options = {}) {
+  const tuiCommands = installTuiCommands(ctx)
+  const tuiOverlay = installTuiOverlay(ctx)
+  const tuiTheme = installTuiTheme(ctx, { settingsPath: options.settingsPath })
+  const tuiSlots = installTuiSlots(ctx)
+  const tuiPresets = installTuiPresets({ tuiCommands, tuiOverlay })
+  return { tuiCommands, tuiOverlay, tuiTheme, tuiSlots, tuiPresets }
+}
+
+function palette(id, label) {
+  return {
+    id,
+    label,
+    dark: Object.fromEntries(TOKEN_NAMES.map((token) => [token, '#111111'])),
+    light: Object.fromEntries(TOKEN_NAMES.map((token) => [token, '#EEEEEE'])),
+  }
+}
+
+test('a new Client process discovers and mounts saved UI Preset artifacts', async () => {
+  assert.equal(typeof localModule.installTuiLocalPlugins, 'function')
+  if (typeof localModule.installTuiLocalPlugins !== 'function') return
+
+  const root = mkdtempSync(path.join(tmpdir(), 'martty-local-plugins-'))
+  try {
+    const store = createTuiPluginStore({ root })
+    store.save({
+      id: 'focused-ui',
+      kind: 'ui-preset',
+      name: 'Focused UI',
+      purpose: 'A focused welcome layout',
+      source: { pluginId: 'ui-1', packageId: 'dyn-1' },
+      clientCode: `return {
+        inject: ['tuiPresets'],
+        apply(ctx) {
+          return ctx.tuiPresets.register(
+            { id: 'focused', label: 'Focused' },
+            () => () => {},
+          )
+        },
+      }`,
+    })
+
+    const ctx = makeCtx()
+    const runtime = services(ctx)
+    runtime.tuiPresets.register({ id: 'default', label: 'Martty' }, () => () => {})
+    const local = localModule.installTuiLocalPlugins(ctx, { store, ...runtime })
+
+    await local.discover()
+
+    assert.deepEqual(runtime.tuiPresets.list(), [
+      { id: 'default', label: 'Martty' },
+      { id: 'focused', label: 'Focused' },
+    ])
+    assert.deepEqual(local.list(), [{
+      artifactId: 'focused-ui',
+      pluginId: 'tui-local:focused-ui',
+      kind: 'ui-preset',
+      loaded: true,
+    }])
+
+    await local.dispose()
+    assert.deepEqual(runtime.tuiPresets.list(), [{ id: 'default', label: 'Martty' }])
+  } finally {
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('saved Theme Plugins are catalogued on discovery and load only when selected', async () => {
+  assert.equal(typeof localModule.installTuiLocalPlugins, 'function')
+  if (typeof localModule.installTuiLocalPlugins !== 'function') return
+
+  const root = mkdtempSync(path.join(tmpdir(), 'martty-local-plugins-'))
+  try {
+    const store = createTuiPluginStore({ root })
+    const paper = palette('paper-lantern', 'Paper Lantern')
+    store.save({
+      id: 'paper-lantern',
+      kind: 'theme',
+      name: 'Paper Lantern',
+      purpose: 'Warm terminal palette',
+      source: { pluginId: 'skin-1', packageId: 'dyn-1' },
+      clientCode: `return {
+        inject: ['tuiTheme'],
+        apply(ctx) { return ctx.tuiTheme.register(${JSON.stringify(paper)}) },
+      }`,
+    })
+
+    const ctx = makeCtx()
+    const runtime = services(ctx)
+    const local = localModule.installTuiLocalPlugins(ctx, { store, ...runtime })
+    await local.discover()
+
+    assert.deepEqual(runtime.tuiTheme.list().map(({ id }) => id), ['default', 'paper-lantern'])
+    assert.equal(runtime.tuiTheme.active(), 'default')
+    assert.equal(runtime.tuiTheme.isLoaded('paper-lantern'), false)
+    assert.equal(runtime.tuiTheme.owner('paper-lantern'), 'tui-local:paper-lantern')
+    assert.equal(local.has('tui-local:paper-lantern'), true)
+    assert.equal(local.isLoaded('tui-local:paper-lantern'), false)
+
+    await local.start('tui-local:paper-lantern')
+    assert.equal(runtime.tuiTheme.active(), 'paper-lantern')
+    assert.equal(runtime.tuiTheme.isLoaded('paper-lantern'), true)
+    assert.equal(local.isLoaded('tui-local:paper-lantern'), true)
+
+    await local.stop('tui-local:paper-lantern')
+    assert.equal(runtime.tuiTheme.active(), 'default')
+    assert.equal(runtime.tuiTheme.isLoaded('paper-lantern'), false)
+    assert.equal(local.isLoaded('tui-local:paper-lantern'), false)
+    await local.dispose()
+  } finally {
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('one broken artifact does not block healthy startup recovery', async () => {
+  assert.equal(typeof localModule.installTuiLocalPlugins, 'function')
+  if (typeof localModule.installTuiLocalPlugins !== 'function') return
+
+  const root = mkdtempSync(path.join(tmpdir(), 'martty-local-plugins-'))
+  try {
+    const store = createTuiPluginStore({ root })
+    store.save({
+      id: 'healthy-ui',
+      kind: 'ui-preset',
+      name: 'Healthy UI',
+      purpose: 'Still loads',
+      source: { pluginId: 'ui-1', packageId: 'dyn-1' },
+      clientCode: `return {
+        inject: ['tuiPresets'],
+        apply(ctx) {
+          return ctx.tuiPresets.register({ id: 'healthy', label: 'Healthy' }, () => () => {})
+        },
+      }`,
+    })
+    store.save({
+      id: 'broken-ui',
+      kind: 'ui-preset',
+      name: 'Broken UI',
+      purpose: 'Fails to parse',
+      source: { pluginId: 'ui-2', packageId: 'dyn-2' },
+      clientCode: 'return {',
+    })
+
+    const ctx = makeCtx()
+    const runtime = services(ctx)
+    const local = localModule.installTuiLocalPlugins(ctx, { store, ...runtime })
+    await local.discover()
+
+    assert.ok(runtime.tuiPresets.list().some(({ id }) => id === 'healthy'))
+    assert.match(local.diagnostics().find(({ artifactId }) => artifactId === 'broken-ui').message, /parse|syntax/i)
+    await local.dispose()
+  } finally {
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('discovery restarts the locally persisted preferred Theme Plugin', async () => {
+  assert.equal(typeof localModule.installTuiLocalPlugins, 'function')
+  if (typeof localModule.installTuiLocalPlugins !== 'function') return
+
+  const root = mkdtempSync(path.join(tmpdir(), 'martty-local-plugins-'))
+  const settingsPath = path.join(root, 'dsh-tui-settings.json')
+  try {
+    const store = createTuiPluginStore({ root: path.join(root, 'artifacts') })
+    const paper = palette('paper-lantern', 'Paper Lantern')
+    store.save({
+      id: 'paper-lantern',
+      kind: 'theme',
+      name: 'Paper Lantern',
+      purpose: 'Warm terminal palette',
+      source: { pluginId: 'skin-1', packageId: 'dyn-1' },
+      clientCode: `return {
+        inject: ['tuiTheme'],
+        apply(ctx) { return ctx.tuiTheme.register(${JSON.stringify(paper)}) },
+      }`,
+    })
+    writeFileSync(settingsPath, JSON.stringify({ theme: 'paper-lantern' }))
+
+    const ctx = makeCtx()
+    const runtime = services(ctx, { settingsPath })
+    const local = localModule.installTuiLocalPlugins(ctx, { store, ...runtime })
+    await local.discover()
+
+    assert.equal(runtime.tuiTheme.active(), 'paper-lantern')
+    assert.equal(local.isLoaded('tui-local:paper-lantern'), true)
+    await local.dispose()
+  } finally {
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('installed package Client modules merge ahead of same-id Creator artifacts', async () => {
+  assert.equal(typeof localModule.installTuiLocalPlugins, 'function')
+  if (typeof localModule.installTuiLocalPlugins !== 'function') return
+
+  const root = mkdtempSync(path.join(tmpdir(), 'martty-package-plugins-'))
+  try {
+    const entry = path.join(root, 'installed-ui.mjs')
+    writeFileSync(entry, `
+      export const inject = ['tuiPresets']
+      export function apply(ctx) {
+        return ctx.tuiPresets.register(
+          { id: 'installed', label: 'Installed package' },
+          () => () => {},
+        )
+      }
+    `)
+    const store = createTuiPluginStore({ root: path.join(root, 'artifacts') })
+    store.save({
+      id: 'shared-ui',
+      kind: 'ui-preset',
+      name: 'Shadowed Creator UI',
+      purpose: 'Must not replace the installed package',
+      source: { pluginId: 'ui-1', packageId: 'dyn-1' },
+      clientCode: `return {
+        inject: ['tuiPresets'],
+        apply(ctx) {
+          return ctx.tuiPresets.register({ id: 'local-copy', label: 'Local copy' }, () => () => {})
+        },
+      }`,
+    })
+
+    const ctx = makeCtx()
+    const runtime = services(ctx)
+    const local = localModule.installTuiLocalPlugins(ctx, {
+      store,
+      packages: [{
+        id: 'shared-ui',
+        kind: 'ui-preset',
+        entry: pathToFileURL(entry).href,
+      }],
+      ...runtime,
+    })
+    await local.discover()
+
+    assert.ok(runtime.tuiPresets.list().some(({ id }) => id === 'installed'))
+    assert.equal(runtime.tuiPresets.list().some(({ id }) => id === 'local-copy'), false)
+    assert.deepEqual(local.list(), [{
+      artifactId: 'shared-ui',
+      pluginId: 'tui-package:shared-ui',
+      kind: 'ui-preset',
+      loaded: true,
+    }])
+    assert.match(
+      local.diagnostics().find(({ artifactId }) => artifactId === 'shared-ui').message,
+      /installed package|shadow/i,
+    )
+    await local.dispose()
+  } finally {
+    rmSync(root, { recursive: true, force: true })
+  }
+})

--- a/scripts/tui-plugin-store.test.mjs
+++ b/scripts/tui-plugin-store.test.mjs
@@ -1,0 +1,182 @@
+import assert from 'node:assert/strict'
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import test from 'node:test'
+
+const storeModule = await import('../npm/lib/tui-plugin-store.js').catch(() => ({}))
+
+test('Martty home owns Creator plugins with explicit environment precedence', () => {
+  assert.equal(
+    storeModule.tuiPluginRoot({ MARTTY_HOME: '/opt/martty', DSH_HOME: '/opt/dsh' }),
+    path.join('/opt/martty', 'plugins'),
+  )
+  assert.equal(
+    storeModule.tuiPluginRoot({ DSH_HOME: '/opt/dsh' }),
+    path.join('/opt/dsh', '.martty', 'plugins'),
+  )
+})
+
+test('legacy Creator artifacts copy into Martty home without deleting the source', () => {
+  const home = mkdtempSync(path.join(tmpdir(), 'martty-plugin-migration-'))
+  try {
+    const legacyRoot = path.join(home, '.tui-plugins')
+    const root = path.join(home, '.martty', 'plugins')
+    const input = {
+      id: 'paper-lantern',
+      kind: 'theme',
+      name: 'Paper Lantern',
+      purpose: 'Warm terminal palette',
+      source: { pluginId: 'skin-1', packageId: 'dyn-1' },
+      clientCode: 'return { apply() {} }',
+    }
+    const legacy = storeModule.createTuiPluginStore({ root: legacyRoot })
+    const legacyPath = legacy.save(input).path
+
+    const migrated = storeModule.createTuiPluginStore({ root, legacyRoot })
+
+    assert.equal(migrated.resolve(input.id).path, path.join(root, input.id, 'plugin.json'))
+    assert.equal(existsSync(legacyPath), true, 'migration must preserve legacy data')
+  } finally {
+    rmSync(home, { recursive: true, force: true })
+  }
+})
+
+test('Creator TUI artifacts persist under one user root and are discovered from disk', () => {
+  assert.equal(typeof storeModule.createTuiPluginStore, 'function')
+  if (typeof storeModule.createTuiPluginStore !== 'function') return
+
+  const home = mkdtempSync(path.join(tmpdir(), 'martty-tui-artifacts-'))
+  try {
+    const root = path.join(home, '.tui-plugins')
+    const store = storeModule.createTuiPluginStore({ root })
+    const saved = store.save({
+      id: 'paper-lantern',
+      kind: 'theme',
+      name: 'Paper Lantern',
+      purpose: 'Warm terminal palette',
+      source: { pluginId: 'skin-1', packageId: 'dyn-1' },
+      clientCode: 'return { apply() {} }',
+    })
+
+    assert.equal(saved.id, 'paper-lantern')
+    assert.equal(saved.path, path.join(root, 'paper-lantern', 'plugin.json'))
+    assert.deepEqual(store.list(), [{
+      id: 'paper-lantern',
+      kind: 'theme',
+      name: 'Paper Lantern',
+      purpose: 'Warm terminal palette',
+      path: saved.path,
+      broken: undefined,
+    }])
+    assert.deepEqual(store.resolve('paper-lantern'), {
+      schemaVersion: 0,
+      id: 'paper-lantern',
+      kind: 'theme',
+      name: 'Paper Lantern',
+      purpose: 'Warm terminal palette',
+      source: { pluginId: 'skin-1', packageId: 'dyn-1' },
+      code: { client: 'return { apply() {} }' },
+      path: saved.path,
+    })
+
+    const manifest = JSON.parse(readFileSync(saved.path, 'utf8'))
+    assert.equal(manifest.code.client, 'return { apply() {} }')
+
+    writeFileSync(saved.path, JSON.stringify({
+      ...manifest,
+      name: 'Edited on disk',
+    }))
+    assert.equal(store.list()[0].name, 'Edited on disk', 'discovery is not memoized')
+  } finally {
+    rmSync(home, { recursive: true, force: true })
+  }
+})
+
+test('saving an existing artifact requires explicit replacement', () => {
+  assert.equal(typeof storeModule.createTuiPluginStore, 'function')
+  if (typeof storeModule.createTuiPluginStore !== 'function') return
+
+  const root = mkdtempSync(path.join(tmpdir(), 'martty-tui-artifacts-'))
+  try {
+    const store = storeModule.createTuiPluginStore({ root })
+    const first = {
+      id: 'focused-ui',
+      kind: 'ui-preset',
+      name: 'Focused UI',
+      purpose: 'A focused layout',
+      source: { pluginId: 'ui-1', packageId: 'dyn-1' },
+      clientCode: 'return { apply() {} }',
+    }
+    store.save(first)
+    assert.throws(() => store.save({ ...first, clientCode: 'return {}' }), /already exists/i)
+
+    store.save({
+      ...first,
+      source: { pluginId: 'ui-1', packageId: 'dyn-2' },
+      clientCode: 'return { apply() { return 2 } }',
+    }, { replace: true })
+    assert.equal(store.resolve('focused-ui').source.packageId, 'dyn-2')
+    assert.match(store.resolve('focused-ui').code.client, /return 2/)
+  } finally {
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('only valid user artifact ids can be saved or removed', () => {
+  assert.equal(typeof storeModule.createTuiPluginStore, 'function')
+  if (typeof storeModule.createTuiPluginStore !== 'function') return
+
+  const root = mkdtempSync(path.join(tmpdir(), 'martty-tui-artifacts-'))
+  try {
+    const store = storeModule.createTuiPluginStore({ root })
+    assert.throws(() => store.save({
+      id: '../escape',
+      kind: 'theme',
+      name: 'Escape',
+      purpose: 'Bad id',
+      source: { pluginId: 'x', packageId: 'y' },
+      clientCode: 'return {}',
+    }), /id/i)
+
+    store.save({
+      id: 'safe-theme',
+      kind: 'theme',
+      name: 'Safe theme',
+      purpose: 'Safe id',
+      source: { pluginId: 'x', packageId: 'y' },
+      clientCode: 'return {}',
+    })
+    assert.equal(store.remove('safe-theme'), true)
+    assert.equal(store.remove('safe-theme'), false)
+    assert.throws(() => store.remove('../escape'), /id/i)
+  } finally {
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('malformed artifact directories remain visible as broken rows', () => {
+  assert.equal(typeof storeModule.createTuiPluginStore, 'function')
+  if (typeof storeModule.createTuiPluginStore !== 'function') return
+
+  const root = mkdtempSync(path.join(tmpdir(), 'martty-tui-artifacts-'))
+  try {
+    const dir = path.join(root, 'broken-theme')
+    storeModule.createTuiPluginStore({ root }).save({
+      id: 'broken-theme',
+      kind: 'theme',
+      name: 'Broken theme',
+      purpose: 'Will be corrupted',
+      source: { pluginId: 'x', packageId: 'y' },
+      clientCode: 'return {}',
+    })
+    writeFileSync(path.join(dir, 'plugin.json'), '{')
+
+    const [row] = storeModule.createTuiPluginStore({ root }).list()
+    assert.equal(row.id, 'broken-theme')
+    assert.match(row.broken, /JSON|parse|invalid/i)
+    assert.throws(() => storeModule.createTuiPluginStore({ root }).resolve('broken-theme'), /broken/i)
+  } finally {
+    rmSync(root, { recursive: true, force: true })
+  }
+})

--- a/scripts/tui-theme.test.mjs
+++ b/scripts/tui-theme.test.mjs
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict'
-import { readFileSync } from 'node:fs'
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { createRequire } from 'node:module'
+import { tmpdir } from 'node:os'
 import path from 'node:path'
 import test from 'node:test'
 import { pathToFileURL } from 'node:url'
@@ -306,6 +307,39 @@ test('list includes builtin default before any register', () => {
   const theme = installTuiTheme(makeCtx())
   assert.deepEqual(theme.list(), [{ id: 'default', label: 'Default' }])
   assert.equal(theme.active(), 'default')
+})
+
+test('explicit theme selection persists separately from temporary Plugin preview', () => {
+  const root = mkdtempSync(path.join(tmpdir(), 'martty-theme-settings-'))
+  const settingsPath = path.join(root, 'dsh-tui-settings.json')
+  try {
+    writeFileSync(settingsPath, JSON.stringify({ language: 'zh', uiPreset: 'deepseek' }))
+    const theme = installTuiTheme(makeCtx(), { settingsPath })
+    const ember = loadEmber()
+    theme.register(ember)
+
+    const preview = theme.registerOwned('preview-plugin', {
+      ...ember,
+      id: 'preview',
+      label: 'Preview',
+    })
+    assert.equal(theme.active(), 'preview')
+    assert.equal(JSON.parse(readFileSync(settingsPath, 'utf8')).theme, undefined)
+    preview()
+
+    theme.activate('ember')
+    assert.deepEqual(JSON.parse(readFileSync(settingsPath, 'utf8')), {
+      language: 'zh',
+      uiPreset: 'deepseek',
+      theme: 'ember',
+    })
+
+    const restored = installTuiTheme(makeCtx(), { settingsPath })
+    assert.equal(restored.preferred(), 'ember')
+    assert.equal(restored.active(), 'default', 'the saved Plugin is not active before it is loaded')
+  } finally {
+    rmSync(root, { recursive: true, force: true })
+  }
 })
 
 test('exportInspectTokens lists every closed token as #RRGGBB', () => {

--- a/src/app.rs
+++ b/src/app.rs
@@ -24,7 +24,7 @@ use crate::controller::Controller;
 use crate::events::parse_notification;
 use crate::input::Action;
 use crate::locale::{Locale, UiSettings};
-use crate::runtime::RuntimeConfig;
+use crate::runtime::{legacy_settings_path, settings_path, RuntimeConfig};
 use crate::theme::Theme;
 use crate::transcript::{clamp_str, NoticeLevel, Transcript};
 
@@ -2665,14 +2665,35 @@ impl App {
     }
 
     fn locale_settings_path(cfg: &RuntimeConfig) -> std::path::PathBuf {
-        std::path::Path::new(&cfg.session_root).join("dsh-tui-settings.json")
+        settings_path(&cfg.session_root)
     }
 
     fn load_settings(cfg: &RuntimeConfig) -> UiSettings {
-        std::fs::read_to_string(Self::locale_settings_path(cfg))
+        let current = Self::locale_settings_path(cfg);
+        if let Some(settings) = std::fs::read_to_string(&current)
             .ok()
             .and_then(|text| serde_json::from_str::<UiSettings>(&text).ok())
-            .unwrap_or_default()
+        {
+            return settings;
+        }
+        if current.exists() {
+            return UiSettings::default();
+        }
+        let legacy = legacy_settings_path(&cfg.session_root);
+        let Some((text, settings)) = std::fs::read_to_string(legacy).ok().and_then(|text| {
+            serde_json::from_str::<UiSettings>(&text)
+                .ok()
+                .map(|settings| (text, settings))
+        }) else {
+            return UiSettings::default();
+        };
+        if let Some(dir) = current.parent() {
+            let _ = std::fs::create_dir_all(dir);
+        }
+        if !current.exists() {
+            let _ = std::fs::write(current, text);
+        }
+        settings
     }
 
     fn save_settings(&self) {
@@ -2680,11 +2701,13 @@ impl App {
         if let Some(dir) = path.parent() {
             let _ = std::fs::create_dir_all(dir);
         }
-        let current = Self::load_settings(&self.cfg);
-        if let Ok(text) = serde_json::to_string_pretty(&UiSettings {
-            language: self.locale,
-            ui_preset: current.ui_preset,
-        }) {
+        let mut current: serde_json::Value = std::fs::read_to_string(&path)
+            .ok()
+            .and_then(|text| serde_json::from_str(&text).ok())
+            .filter(|value: &serde_json::Value| value.is_object())
+            .unwrap_or_else(|| serde_json::json!({}));
+        current["language"] = serde_json::json!(self.locale);
+        if let Ok(text) = serde_json::to_string_pretty(&current) {
             let _ = std::fs::write(path, text);
         }
     }
@@ -5841,9 +5864,10 @@ mod mode_tests {
     #[test]
     fn lang_switch_repaints_immediately_and_persists_for_the_workspace() {
         let cfg = test_cfg();
+        let legacy = std::path::Path::new(&cfg.session_root).join("dsh-tui-settings.json");
         std::fs::write(
-            App::locale_settings_path(&cfg),
-            r#"{"language":"en","uiPreset":"deepseek"}"#,
+            &legacy,
+            r#"{"language":"en","uiPreset":"deepseek","theme":"ember"}"#,
         )
         .expect("seed UI preset selection");
         let (tx, _rx) = std::sync::mpsc::channel::<AppEvent>();
@@ -5874,6 +5898,23 @@ mod mode_tests {
             "{frame}"
         );
         assert_eq!(restarted.ui_preset, "deepseek", "/lang preserves UI Preset");
+        let current = std::path::Path::new(&restarted.cfg.session_root).join("settings.json");
+        assert!(
+            current.is_file(),
+            "legacy settings migrate to the Martty filename"
+        );
+        assert!(
+            legacy.is_file(),
+            "migration preserves the legacy settings file"
+        );
+        let saved: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(current).expect("read migrated Martty settings"),
+        )
+        .unwrap();
+        assert_eq!(
+            saved["theme"], "ember",
+            "/lang preserves Client-owned settings"
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,7 +44,7 @@ use crossterm::terminal::{
 use crate::app::{App, RunState};
 use crate::bus::{AppEvent, Cmd};
 use crate::controller::Controller;
-use crate::runtime::RuntimeConfig;
+use crate::runtime::{default_session_root, RuntimeConfig};
 
 const HELP: &str = "\
 dsh-tui — terminal-native ACP client UI
@@ -54,7 +54,7 @@ USAGE:
 
 OPTIONS:
   -w, --workspace <dir>     agent workspace (default: cwd)
-      --session-root <dir>  session JSONL root (default: ~/.dsh-tui/sessions)
+      --session-root <dir>  session JSONL root (default: $MARTTY_HOME/sessions)
       --session-id <id>     resume/continue a durable session id
       --provider <id>       provider route (default: deepseek-official)
       --model <id>          model id (default: $DSH_MODEL or deepseek-v4-flash)
@@ -198,10 +198,7 @@ fn build_config(args: &Args) -> Result<RuntimeConfig> {
     };
     let session_root = match &args.session_root {
         Some(r) => r.clone(),
-        None => {
-            let home = std::env::var("HOME").unwrap_or_else(|_| ".".into());
-            format!("{home}/.dsh-tui/sessions")
-        }
+        None => default_session_root().to_string_lossy().into_owned(),
     };
     std::fs::create_dir_all(&session_root).ok();
 
@@ -719,6 +716,26 @@ mod cli_args_tests {
     fn help_mentions_demo_skin() {
         assert!(HELP.contains("--demo-skin"));
         assert!(HELP.contains("--demo"));
+    }
+
+    #[test]
+    fn martty_home_precedence_owns_the_default_session_root() {
+        assert_eq!(
+            crate::runtime::martty_home_from(Some("/opt/martty"), Some("/opt/dsh"), "/Users/test",),
+            PathBuf::from("/opt/martty")
+        );
+        assert_eq!(
+            crate::runtime::martty_home_from(None, Some("/opt/dsh"), "/Users/test"),
+            PathBuf::from("/opt/dsh/.martty")
+        );
+        assert_eq!(
+            crate::runtime::martty_home_from(None, None, "/Users/test"),
+            PathBuf::from("/Users/test/.martty")
+        );
+        assert_eq!(
+            crate::runtime::martty_home_from(None, None, "/Users/test").join("sessions"),
+            PathBuf::from("/Users/test/.martty/sessions")
+        );
     }
 
     #[test]

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1,6 +1,51 @@
 //! Shared launch/display configuration for the ACP client and demo painter.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
+
+pub fn martty_home_from(
+    martty_home: Option<&str>,
+    dsh_home: Option<&str>,
+    user_home: &str,
+) -> PathBuf {
+    if let Some(home) = martty_home.filter(|value| !value.is_empty()) {
+        return PathBuf::from(home);
+    }
+    if let Some(home) = dsh_home.filter(|value| !value.is_empty()) {
+        return Path::new(home).join(".martty");
+    }
+    Path::new(user_home).join(".martty")
+}
+
+pub fn martty_home() -> PathBuf {
+    let martty = std::env::var("MARTTY_HOME").ok();
+    let dsh = std::env::var("DSH_HOME").ok();
+    let user = std::env::var("HOME").unwrap_or_else(|_| ".".into());
+    martty_home_from(martty.as_deref(), dsh.as_deref(), &user)
+}
+
+pub fn default_session_root() -> PathBuf {
+    martty_home().join("sessions")
+}
+
+pub fn settings_path(session_root: &str) -> PathBuf {
+    if Path::new(session_root) == default_session_root() {
+        martty_home().join("settings.json")
+    } else {
+        Path::new(session_root).join("settings.json")
+    }
+}
+
+pub fn legacy_settings_path(session_root: &str) -> PathBuf {
+    if Path::new(session_root) == default_session_root() {
+        let user = std::env::var("HOME").unwrap_or_else(|_| ".".into());
+        Path::new(&user)
+            .join(".dsh-tui")
+            .join("sessions")
+            .join("dsh-tui-settings.json")
+    } else {
+        Path::new(session_root).join("dsh-tui-settings.json")
+    }
+}
 
 #[derive(Clone, Debug)]
 pub struct RuntimeConfig {

--- a/src/sessions.rs
+++ b/src/sessions.rs
@@ -40,15 +40,21 @@ pub fn workspace_slug(workspace: &str) -> String {
 
 /// Candidate session roots, existing ones only: the configured root plus
 /// the local dsh store.
-fn session_roots(cfg_root: &str) -> Vec<PathBuf> {
+fn session_roots_from(cfg_root: &str, home: Option<&Path>) -> Vec<PathBuf> {
     let mut roots = vec![PathBuf::from(cfg_root)];
-    if let Ok(home) = std::env::var("HOME") {
-        roots.push(Path::new(&home).join(".dsh").join("sessions"));
+    if let Some(home) = home {
+        roots.push(home.join(".dsh").join("sessions"));
+        roots.push(home.join(".dsh-tui").join("sessions"));
     }
     roots.sort();
     roots.dedup();
     roots.retain(|r| r.is_dir());
     roots
+}
+
+fn session_roots(cfg_root: &str) -> Vec<PathBuf> {
+    let home = std::env::var_os("HOME").map(PathBuf::from);
+    session_roots_from(cfg_root, home.as_deref())
 }
 
 /// The session log inside one session directory, preferring the live
@@ -304,6 +310,22 @@ mod tests {
         );
         assert_eq!(sessions[1].title, None);
         let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn legacy_dsh_tui_sessions_remain_discoverable_after_the_martty_move() {
+        let home =
+            std::env::temp_dir().join(format!("martty-legacy-sessions-{}", std::process::id()));
+        let current = home.join(".martty/sessions");
+        let legacy = home.join(".dsh-tui/sessions");
+        std::fs::create_dir_all(&current).unwrap();
+        std::fs::create_dir_all(&legacy).unwrap();
+
+        let roots = session_roots_from(current.to_str().unwrap(), Some(&home));
+
+        assert!(roots.contains(&current));
+        assert!(roots.contains(&legacy));
+        let _ = std::fs::remove_dir_all(home);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- complete the durable local TUI plugin lifecycle and installed Client plugin registry
- persist and restore Creator-authored themes and UI presets
- consume ACP 0.4.17-beta.0 so the ACP profile owns its host service closure
- allow the release helper to create alpha/beta/rc versions

PR #28 and PR #29 are intentionally not included.

## Validation

- cargo test --locked (384 passed)
- npm test --prefix npm (180 passed)
- installed ACP dependency verified as 0.4.17-beta.0