### PR TITLE
fix(tui): keep the tip cap row on terminals down to 10 rows

### DIFF
--- a/src/ui.rs
+++ b/src/ui.rs
@@ -131,8 +131,10 @@ pub fn draw(f: &mut Frame, app: &mut App) {
     let gap_h = if child_view { 0 } else { 1 };
     // Exactly one cap row tops the box (the `╭ … ─╮` border line). The
     // plugin input dock (plan-view's PLAN summary) wins the row when it
-    // has nodes; otherwise the tip line carries it.
-    let cap_h = if !child_view && main.height >= 16 {
+    // has nodes; otherwise the tip line carries it. The row is worth
+    // keeping down to 10 rows tall — below that (chat would drop under
+    // ~5 rows) the borderless fallback takes over instead.
+    let cap_h = if !child_view && main.height >= 10 {
         1
     } else {
         0


### PR DESCRIPTION
Fixes #44 — under tmux, `/image hello.png` and `/clip` gave no feedback at all.

## Root cause

The composer cap row — the only surface that renders transient tips (`show_tip`) — was allocated only when the terminal is at least 16 rows tall:

```rust
let cap_h = if !child_view && main.height >= 16 { 1 } else { 0 };
```

Below that, the borderless fallback composer renders only the input well + meta row, so tips set by `show_tip` are silently dropped. `/image` and `/clip` report failures exclusively via `show_tip`, which is why those commands stood out. Small tmux panes (split panes, short windows) are the common way to end up under 16 rows, matching the report that it only happens "under tmux".

## Fix

Lower the cap threshold from 16 to 10 rows — chat keeps at least ~5 rows; below 10 the borderless fallback still takes over. One-line change in `src/ui.rs`.

## Verification

- `cargo test --bin martty`: 399 passed, 0 failed.
- tmux pane at 12 rows (previously silent):
  - `/image hello.png` → `cannot read hello.png: No such file or directory (os error 2)`
  - `/clip` → `clipboard has no image, or this platform isn't supported`
- 9-row pane still uses the borderless fallback (no cap row), as intended.