### PR TITLE
fix(client): tear down painter on SIGTERM/SIGINT — no orphan TTY on shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project are documented here. The project follows
 
 ## [Unreleased]
 
+### Fixed
+
+- TUI Client process now converts SIGTERM/SIGINT/SIGHUP into an orderly
+  `process.exit`, so the Rust painter is always torn down (it is killed from
+  the Client's `exit` hook). Previously the Host runner's SIGTERM terminated
+  the Client without running `exit` listeners, orphaning the painter holding
+  the TTY — shutdown appeared to hang until the terminal was closed.
+
+
 ### Added
 
 - New gallery palette pack `kanagawa` (dark from Kanagawa Wave, light from

--- a/npm/lib/client-process.js
+++ b/npm/lib/client-process.js
@@ -4,6 +4,16 @@
 
 import { bootClient, parseClientPluginsEnv } from './boot.js'
 
+// The Host runner kills this process with SIGTERM on shutdown, and the user's
+// Ctrl+C reaches it as SIGINT from the foreground terminal group. Node's
+// default signal handling terminates without running 'exit' listeners, which
+// would strand the Rust painter as an orphan holding the TTY (it is only
+// killed from the Client's 'exit' hook). Convert signals into an orderly
+// process.exit so painter teardown and TTY restore always run.
+for (const [signal, code] of [['SIGTERM', 143], ['SIGINT', 130], ['SIGHUP', 129]]) {
+  process.on(signal, () => process.exit(code))
+}
+
 await bootClient({
   stream: { stdin: process.stdout, stdout: process.stdin },
   extraArgs: process.argv.slice(2),

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openma/deepseek-harness-tui",
-  "version": "0.2.23",
+  "version": "0.2.24",
   "description": "Terminal-native ACP client UI; Cordis client tree, any ACP agent",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## 问题

`dsh --profile martty` 退出时花费时间过长（实测 60s+ 进程树仍未退出）。拆解后发现两层问题叠加：

### ① TUI Client 进程被杀时不触发 `exit` 钩子 → Rust painter 变孤儿（主因）

Host runner 关闭时用 `child.kill('SIGTERM')` 杀 Client 进程；用户 Ctrl+C 时 Client 也会从前台进程组收到 SIGINT。**Node 对信号的默认处理是直接终止，不执行 `process.on('exit')` 监听器**——而 index.js 里"painter 必须由 Client 的 exit 钩子 kill"这条链条因此断裂：Rust painter 成为孤儿进程继续持有 TTY（raw mode），终端看起来卡死，直到 pty 关闭。

### ② 第三方插件长轮询阻塞 Host dispose（加剧因素，见 zhang0098/dsh-telegram-channel）

`dsh-telegram-channel` 的 Telegram `getUpdates` 是 30s 长轮询且不响应 abort，Host dispose 等待 in-flight 请求。已在插件侧修复（fork `zhang0098/dsh-telegram-channel`，不在此 PR 内）。

## 修复

`npm/lib/client-process.js`：Client 进程将 SIGTERM / SIGINT / SIGHUP 转为 `process.exit()`，确保 `exit` 事件触发 → painter 被 kill → painter 走自己的 Terminate 路径恢复终端。npm 版本 0.2.23 → 0.2.24。

## 验证

| 场景 | 修复前 | 修复后 |
|---|---|---|
| Ctrl+C 等效（SIGINT 给 painter） | 60s+ 不退出，进程树残留（Host/Client/painter） | **6s 内全部干净退出，无孤儿** |
| 最小 Host 树 dispose（含插件轮询） | 卡 30s+（长轮询不可中断） | 35ms |

- `scripts/client-profile.test.mjs`、`plugin-runner.test.mjs`、`profile-smoke-tui.test.mjs` 23/23 通过
- 本地 profile 已装 0.2.24 实测通过
