### PR TITLE
fix: composer input click-to-caret and drag-select copy (#43)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project are documented here. The project follows
 
 ## [Unreleased]
 
+### Added
+
+- The composer input now supports the mouse: left-click places the caret at
+  the clicked character (blank space past the text snaps to the end), and
+  left-drag selects a text span that is copied to the clipboard on release,
+  with the highlight persisting until the next click or Esc. CJK/emoji
+  double-width characters are handled cell-accurately: the caret splits a
+  wide char at its midpoint and a drag covers it whole. Mouse actions never
+  trigger submit, history recall or slash-completion selection.
+
 ## [0.2.24] - 2026-08-24
 
 ### Fixed

--- a/src/app.rs
+++ b/src/app.rs
@@ -467,6 +467,18 @@ impl Selection {
     }
 }
 
+/// Composer drag-selection (same gesture as the chat pane): both endpoints
+/// are cells in the input text-area coordinates — `(row, col)` where the
+/// drag began and where the pointer is now. The covered char range is
+/// derived with [`App::input_selection_range`], which treats both endpoint
+/// cells as inclusive so either drag direction selects exactly the cells
+/// the pointer crossed.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct InputSel {
+    pub anchor: (usize, usize),
+    pub head: (usize, usize),
+}
+
 /// Snapshot of the chat pane layout from the last draw — the seam that
 /// mouse hit-testing and copy extraction read (grok-build's resolved
 /// selection model, scaled way down): pane rect, index of the first
@@ -915,6 +927,17 @@ pub struct App {
     pub input: Input,
     /// Display-cell width of the composer text well from the latest frame.
     pub(crate) composer_wrap_width: usize,
+    /// Screen rect of the composer input well from the latest frame — mouse
+    /// hit-testing (recorded by `ui::draw_input`).
+    pub(crate) input_area: ratatui::layout::Rect,
+    /// First text row shown inside the well (the viewport scroll from
+    /// `ui::draw_input`).
+    pub(crate) input_top: usize,
+    /// Ordered char-index range selected in the composer: drag-select and
+    /// copy highlight, `None` when no input selection is shown.
+    pub(crate) input_sel: Option<InputSel>,
+    /// A left-button drag inside the composer well is in progress.
+    input_selecting: bool,
     pub state: RunState,
     pub state_note: String,
     /// Welcome banner (whale + wordmark) — shown until the first real prompt.
@@ -1308,6 +1331,10 @@ impl App {
             agent_selection: None,
             input: Input::new(),
             composer_wrap_width: 80,
+            input_area: ratatui::layout::Rect::default(),
+            input_top: 0,
+            input_sel: None,
+            input_selecting: false,
             state: RunState::Idle,
             state_note: String::new(),
             show_banner: true,
@@ -2783,6 +2810,7 @@ impl App {
                 }
                 self.slash_completion_dismissed = false;
                 self.input.insert_str(&text.replace('\n', " "));
+                self.input_sel = None;
                 self.reconcile_attachments();
                 self.needs_redraw = true;
             }
@@ -2830,6 +2858,7 @@ impl App {
                     self.sel = None;
                     self.selecting = false;
                     self.last_click = None;
+                    self.input_selecting = false;
                     match action {
                         crate::slots::TuiAction::Command { name, args } => {
                             ctl.send(Cmd::InvokePluginCommand { name, args });
@@ -2843,15 +2872,44 @@ impl App {
                     self.sel = None;
                     self.selecting = false;
                     self.last_click = None;
+                    self.input_selecting = false;
                     self.toggle_tool(ci);
+                    return;
+                }
+                // Click inside the composer well: place the caret at the
+                // clicked char and arm an input drag-selection. Like any
+                // click outside the chat pane, the chat highlight is
+                // dismissed first. The elicitation form owns its own field
+                // and child-view chrome replaces the composer, so the
+                // hidden caret stays put in both cases.
+                if self.elicitation_ask.is_none()
+                    && self.active_subagent.is_none()
+                    && self.input_hit(mouse.column, mouse.row)
+                {
+                    self.sel = None;
+                    self.selecting = false;
+                    self.last_click = None;
+                    let cell = self.input_cell_at(mouse.column, mouse.row);
+                    self.input.cursor =
+                        self.input.char_index_at(self.input_avail(), cell.0, cell.1);
+                    self.input.reset_vertical_goal();
+                    self.input_sel = Some(InputSel {
+                        anchor: cell,
+                        head: cell,
+                    });
+                    self.input_selecting = true;
                     return;
                 }
                 let Some(p) = self.chat_hit(mouse.column, mouse.row) else {
                     // Click outside the chat pane dismisses the highlight.
                     self.sel = None;
                     self.selecting = false;
+                    self.input_sel = None;
+                    self.input_selecting = false;
                     return;
                 };
+                self.input_sel = None;
+                self.input_selecting = false;
                 let double = self.last_click.take().is_some_and(|(at, x, y)| {
                     at.elapsed() < DOUBLE_CLICK_WINDOW
                         && x.abs_diff(mouse.column) <= 1
@@ -2880,9 +2938,22 @@ impl App {
                 }
                 self.needs_redraw = true;
             }
+            MouseEventKind::Drag(MouseButton::Left) if self.input_selecting => {
+                // The head snaps to the well edges: drags above select to
+                // the top visible row, below it to the bottom row.
+                let head = self.input_cell_at(mouse.column, mouse.row);
+                if let Some(sel) = &mut self.input_sel {
+                    sel.head = head;
+                }
+                self.needs_redraw = true;
+            }
             MouseEventKind::Up(MouseButton::Left) if self.selecting => {
                 self.selecting = false;
                 self.finish_selection();
+            }
+            MouseEventKind::Up(MouseButton::Left) if self.input_selecting => {
+                self.input_selecting = false;
+                self.finish_input_selection();
             }
             MouseEventKind::Moved => {
                 // grok-style hover: track which inline chip the pointer is
@@ -3084,6 +3155,83 @@ impl App {
         } else {
             self.show_tip("copy failed — hold shift and drag for the terminal's native selection");
         }
+    }
+
+    /// True when the screen cell lies inside the composer input well.
+    fn input_hit(&self, col: u16, row: u16) -> bool {
+        let a = self.input_area;
+        a.width > 0
+            && a.height > 0
+            && col >= a.x
+            && col < a.x.saturating_add(a.width)
+            && row >= a.y
+            && row < a.y.saturating_add(a.height)
+    }
+
+    /// Display-cell width of the composer text area, matching
+    /// `ui::draw_input` (`area.width - prompt width`).
+    fn input_avail(&self) -> usize {
+        let a = self.input_area;
+        let pw = "❯ "
+            .chars()
+            .map(|c| c.width().unwrap_or(0).max(1))
+            .sum::<usize>();
+        a.width.saturating_sub(pw as u16).max(1) as usize
+    }
+
+    /// Map a screen cell to a text-area cell `(row, col)` in the same
+    /// coordinates as `Input::char_index_at` (prompt offset and viewport
+    /// scroll applied), clamped into the visible well.
+    fn input_cell_at(&self, col: u16, row: u16) -> (usize, usize) {
+        let a = self.input_area;
+        let pw = "❯ "
+            .chars()
+            .map(|c| c.width().unwrap_or(0).max(1))
+            .sum::<usize>();
+        let rel_row = (row.saturating_sub(a.y) as usize)
+            .min(a.height.saturating_sub(1) as usize)
+            .saturating_add(self.input_top);
+        let rel_col = (col.saturating_sub(a.x.saturating_add(pw as u16)) as usize)
+            .min(self.input_avail().saturating_sub(1));
+        (rel_row, rel_col)
+    }
+
+    /// Ordered char boundaries covered by the composer selection — both
+    /// endpoint cells inclusive, so a drag in either direction covers
+    /// exactly the cells the pointer crossed. `None` without a selection.
+    pub(crate) fn input_selection_range(&self) -> Option<(usize, usize)> {
+        let sel = self.input_sel?;
+        let (s, e) = if sel.anchor <= sel.head {
+            (sel.anchor, sel.head)
+        } else {
+            (sel.head, sel.anchor)
+        };
+        let avail = self.input_avail();
+        let start = self.input.char_index_at(avail, s.0, s.1);
+        let end = self.input.char_index_end_at(avail, e.0, e.1);
+        (start < end).then_some((start, end))
+    }
+
+    /// Copy the dragged composer selection; the highlight persists until
+    /// the next click or Esc, mirroring the chat pane. A plain click
+    /// (caret) just clears the highlight.
+    fn finish_input_selection(&mut self) {
+        self.needs_redraw = true;
+        let Some(sel) = self.input_sel else { return };
+        if sel.anchor == sel.head {
+            self.input_sel = None;
+            return;
+        }
+        let Some((a, b)) = self.input_selection_range() else {
+            self.input_sel = None;
+            return;
+        };
+        let text = self.input.chars_between(a, b);
+        if text.trim().is_empty() {
+            self.input_sel = None;
+            return;
+        }
+        self.copy_text(&text);
     }
 
     /// Extract the selected text from the layout snapshot: cell-range slices
@@ -3581,6 +3729,8 @@ impl App {
                 | Action::KillToStart
         ) {
             self.slash_completion_dismissed = false;
+            // Text edits invalidate the drag-selection highlight.
+            self.input_sel = None;
         }
         match action {
             Action::Insert(ch) => {
@@ -3591,6 +3741,7 @@ impl App {
                 self.input.insert('\n');
             }
             Action::Enter => {
+                self.input_sel = None;
                 let menu = if self.slash_completion_open() {
                     self.slash_matches()
                 } else {
@@ -3612,6 +3763,7 @@ impl App {
             }
             Action::TabComplete => {
                 self.slash_completion_dismissed = false;
+                self.input_sel = None;
                 let menu = self.slash_matches();
                 if !menu.is_empty() {
                     let entry = &menu[self.slash_sel.min(menu.len() - 1)];
@@ -4684,7 +4836,9 @@ impl App {
         }
         // A lingering copy highlight is dismissed first (idle only — while
         // running, esc keeps its interrupt meaning and clears it in passing).
-        if self.sel.take().is_some() && matches!(self.state, RunState::Idle) {
+        let had_chat_sel = self.sel.take().is_some();
+        let had_input_sel = self.input_sel.take().is_some();
+        if (had_chat_sel || had_input_sel) && matches!(self.state, RunState::Idle) {
             self.needs_redraw = true;
             return;
         }
@@ -4699,6 +4853,7 @@ impl App {
             } else {
                 self.queue_edit = None;
                 self.input.clear();
+                self.input_sel = None;
                 self.slash_completion_dismissed = false;
                 self.reconcile_attachments();
                 self.show_tip("queued prompt edit cancelled");
@@ -4742,6 +4897,7 @@ impl App {
             self.ctrl_c_armed = None;
             self.input.history.push(self.input.buf.clone());
             self.input.clear();
+            self.input_sel = None;
             self.reconcile_attachments();
             self.show_tip("draft cleared — ↑ recalls it");
             return;
@@ -4767,6 +4923,7 @@ impl App {
     }
 
     fn history_prev(&mut self) {
+        self.input_sel = None;
         if !self.input.is_empty() && self.input.hist_pos.is_none() {
             return; // grok: history opens from an empty prompt
         }
@@ -4786,6 +4943,7 @@ impl App {
     }
 
     fn history_prev_from_draft(&mut self) {
+        self.input_sel = None;
         if self.input.history.is_empty() {
             return;
         }
@@ -4802,6 +4960,7 @@ impl App {
     }
 
     fn history_next(&mut self) {
+        self.input_sel = None;
         let Some(pos) = self.input.hist_pos else {
             return;
         };
@@ -5881,6 +6040,7 @@ impl App {
                 return;
             }
         };
+        self.input_sel = None;
         if !caption.is_empty() {
             self.input.set(caption);
             self.input.insert(' ');
@@ -6088,6 +6248,7 @@ impl App {
     /// Submit a prompt programmatically (used by DSH_TUI_AUTOPROMPT).
     pub fn auto_prompt(&mut self, text: &str, ctl: &Controller) {
         self.show_banner = false;
+        self.input_sel = None;
         self.input.set(text.to_string());
         self.submit(ctl);
     }

--- a/src/input/editor.rs
+++ b/src/input/editor.rs
@@ -165,6 +165,99 @@ impl Input {
         rows
     }
 
+    /// Map a click at display `(row, col)` inside a text area of `width`
+    /// display cells to the caret boundary, using the same soft-wrap layout
+    /// as the renderer (`visual_layout`). A click lands on the boundary
+    /// *before* the char occupying the clicked cell (typing then inserts at
+    /// the clicked position); wide chars split at their midpoint — the left
+    /// half selects the boundary before the char, the right half the
+    /// boundary after it. Blank cells snap to their row's start/end
+    /// boundary; rows beyond the text snap to the end of the buffer.
+    pub fn char_index_at(&self, width: usize, row: usize, col: usize) -> usize {
+        let width = width.max(1);
+        let (chars, carets, rows) = self.visual_layout(width);
+        if row >= rows {
+            return self.len_chars();
+        }
+        let (first, last) = Self::row_boundaries(&carets, row);
+        let Some(first) = first else {
+            return self.len_chars();
+        };
+        // The char occupying the clicked cell, if any.
+        for i in first..=last {
+            if i >= chars.len() {
+                break;
+            }
+            let start = carets[i].1;
+            let w = UnicodeWidthChar::width(chars[i]).unwrap_or(0).max(1);
+            if col >= start && col < start + w {
+                if w > 1 && col >= start + w / 2 {
+                    return i + 1; // right half of a wide char → after it
+                }
+                return i; // narrow char (or left half) → before it
+            }
+        }
+        // Blank cells: the row's leading edge or its trailing blank.
+        if col < carets[first].1 {
+            first
+        } else {
+            last
+        }
+    }
+
+    /// The boundary *after* the char occupying display cell `(row, col)` —
+    /// the inclusive end of a selection covering that cell, so a drag in
+    /// either direction covers exactly the dragged cells. Blank cells snap
+    /// to their row's end; rows beyond the text snap to the buffer end.
+    pub fn char_index_end_at(&self, width: usize, row: usize, col: usize) -> usize {
+        let width = width.max(1);
+        let (chars, carets, rows) = self.visual_layout(width);
+        if row >= rows {
+            return self.len_chars();
+        }
+        let (first, last) = Self::row_boundaries(&carets, row);
+        let Some(first) = first else {
+            return self.len_chars();
+        };
+        for i in first..=last {
+            if i >= chars.len() {
+                break;
+            }
+            let start = carets[i].1;
+            let w = UnicodeWidthChar::width(chars[i]).unwrap_or(0).max(1);
+            if col >= start && col < start + w {
+                return i + 1;
+            }
+        }
+        if col < carets[first].1 {
+            first
+        } else {
+            last
+        }
+    }
+
+    /// First and last caret boundary indices on a layout row.
+    fn row_boundaries(carets: &[(usize, usize)], row: usize) -> (Option<usize>, usize) {
+        let mut first = None;
+        let mut last = 0usize;
+        for (i, &(r, _)) in carets.iter().enumerate() {
+            if r == row {
+                if first.is_none() {
+                    first = Some(i);
+                }
+                last = i;
+            }
+        }
+        (first, last)
+    }
+
+    /// The text between two char boundaries (unordered), for copying a
+    /// drag selection. Out-of-range indices clamp to the buffer.
+    pub fn chars_between(&self, a: usize, b: usize) -> String {
+        let (a, b) = if a <= b { (a, b) } else { (b, a) };
+        self.buf.chars().skip(a).take(b.saturating_sub(a)).collect()
+    }
+
     /// Move by one visual row while preserving the original display column.
     /// Hard newlines and soft wraps share the same caret map as the renderer.
     pub fn move_vertical(&mut self, width: usize, direction: i8) {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -2252,6 +2252,10 @@ fn draw_input(f: &mut Frame, app: &mut App, area: Rect) {
     if area.width < 4 || area.height == 0 {
         return;
     }
+    // Mouse hit-testing for clicks/drags in the well (empty draft: the
+    // whole well maps to boundary 0).
+    app.input_area = area;
+    app.input_top = 0;
     let prompt = "❯ ";
     let pw = prompt.width();
     // The prompt doubles as the working indicator that used to be the brand
@@ -2347,6 +2351,7 @@ fn draw_input(f: &mut Frame, app: &mut App, area: Rect) {
     if cursor.0 < start {
         start = cursor.0;
     }
+    app.input_top = start;
 
     let mut chip_rects: Vec<(Rect, usize)> = Vec::new();
     let mut lines: Vec<Line> = Vec::new();
@@ -2416,11 +2421,46 @@ fn draw_input(f: &mut Frame, app: &mut App, area: Rect) {
     }
     f.render_widget(Paragraph::new(lines), area);
     app.att_chips = chip_rects;
+    draw_input_selection(f, app, area, &rows, start, h, pw);
 
     let cy = area.y + (cursor.0 - start).min(h - 1) as u16;
     let cx = area.x + pw as u16 + cursor.1 as u16;
     if composer_owns_cursor {
         f.set_cursor_position((cx.min(area.x + area.width.saturating_sub(1)), cy));
+    }
+}
+
+/// Paint the composer drag-selection as reversed cells — the same
+/// treatment as the chat pane highlight. Char indices inside the ordered
+/// selection range are highlighted; wide chars cover all of their cells.
+fn draw_input_selection(
+    f: &mut Frame,
+    app: &App,
+    area: Rect,
+    rows: &[Vec<(usize, char)>],
+    start: usize,
+    h: usize,
+    pw: usize,
+) {
+    let Some((a, b)) = app.input_selection_range() else {
+        return;
+    };
+    let buf = f.buffer_mut();
+    for (r, row) in rows.iter().enumerate().skip(start).take(h) {
+        let y = area.y + (r - start) as u16;
+        let mut col = 0usize;
+        for &(i, ch) in row {
+            let cw = UnicodeWidthChar::width(ch).unwrap_or(0).max(1);
+            if i >= a && i < b {
+                for k in 0..cw {
+                    let x = area.x + pw as u16 + (col + k) as u16;
+                    if let Some(cell) = buf.cell_mut((x, y)) {
+                        cell.set_style(Style::default().add_modifier(Modifier::REVERSED));
+                    }
+                }
+            }
+            col += cw;
+        }
     }
 }
 

--- a/tests/unit/app__selection_tests.rs
+++ b/tests/unit/app__selection_tests.rs
@@ -61,6 +61,46 @@ fn test_app() -> App {
     )
 }
 
+fn test_app_and_ctl() -> (App, Controller) {
+    let cfg = RuntimeConfig {
+        bin: "dsh-runtime".into(),
+        cordis: "cordis".into(),
+        workspace: "/tmp".into(),
+        session_root: fresh_root(),
+        provider: "deepseek".into(),
+        model: "deepseek-chat".into(),
+        max_tokens: None,
+        base_url: None,
+        api_key: None,
+    };
+    let (tx, _rx) = std::sync::mpsc::channel::<AppEvent>();
+    let ctl = Controller::start(cfg.clone(), true, None, tx.clone());
+    let app = App::new(
+        crate::theme::Theme::dark(),
+        cfg,
+        "dsh-test".into(),
+        true,
+        false,
+        tx,
+    );
+    (app, ctl)
+}
+
+/// A 40x3 input well whose text starts at screen x = area.x + 2 (the
+/// `❯ ` prompt); text rows map 1:1 to well rows.
+fn input_well() -> ratatui::layout::Rect {
+    ratatui::layout::Rect::new(1, 20, 40, 3)
+}
+
+fn mouse(kind: MouseEventKind, x: u16, y: u16) -> MouseEvent {
+    MouseEvent {
+        kind,
+        column: x,
+        row: y,
+        modifiers: KeyModifiers::NONE,
+    }
+}
+
 #[test]
 fn slice_by_cells_handles_wide_chars() {
     assert_eq!(slice_by_cells("hello world", 6, 11), "world");
@@ -183,4 +223,137 @@ fn tool_click_in_a_child_view_targets_the_child_transcript() {
 
     assert!(app.subagents[0].transcript.cells[0].expanded);
     assert!(app.transcript.cells.is_empty());
+}
+
+#[test]
+fn input_click_places_the_caret_at_the_clicked_char() {
+    let (mut app, ctl) = test_app_and_ctl();
+    app.input.set("hello 世界".into());
+    app.input_area = input_well();
+    app.input_top = 0;
+    // Text starts at screen x = 1 + 2 = 3. Cells: h0 e1 l2 l3 o4 ␣5 世6-7 界8-9.
+    app.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 3, 20), &ctl);
+    assert_eq!(app.input.cursor, 0, "click on 'h' → before it");
+    app.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 7, 20), &ctl);
+    assert_eq!(app.input.cursor, 4, "click on 'o' → before it");
+    app.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 10, 20), &ctl);
+    assert_eq!(app.input.cursor, 7, "right half of 世 → after it");
+    app.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 13, 20), &ctl);
+    assert_eq!(app.input.cursor, 8, "blank past the end → end");
+    app.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 5, 21), &ctl);
+    assert_eq!(app.input.cursor, 8, "row below the text → end");
+}
+
+#[test]
+fn input_click_accounts_for_the_viewport_scroll() {
+    let (mut app, ctl) = test_app_and_ctl();
+    app.input.set("abcd\nefgh\nij".into());
+    app.input_area = input_well();
+    app.input_top = 1; // the well's first row shows "efgh"
+
+    // Visible row 0 (screen y 20) is text row 1: 'e' at screen x 3.
+    app.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 3, 20), &ctl);
+    assert_eq!(app.input.cursor, 5, "'e' → the boundary before it");
+    // Visible row 1 (screen y 21) is text row 2: 'i' at screen x 3.
+    app.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 3, 21), &ctl);
+    assert_eq!(app.input.cursor, 10, "'i' → the boundary before it");
+    // Blank after "ij" on the last row → end of buffer.
+    app.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 8, 21), &ctl);
+    assert_eq!(app.input.cursor, 12, "last text row → end of buffer");
+}
+
+#[test]
+fn input_click_dismisses_a_chat_selection_without_touching_history() {
+    let (mut app, ctl) = test_app_and_ctl();
+    app.chat_view = view(&["chat line"]);
+    app.chat_view.area = ratatui::layout::Rect::new(1, 0, 60, 10);
+    app.sel = Some(sel((0, 0), (0, 8)));
+    app.selecting = true;
+    app.input.set("draft".into());
+    app.input_area = input_well();
+    app.input_top = 0;
+
+    app.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 4, 20), &ctl);
+
+    assert!(app.sel.is_none(), "chat highlight dismissed");
+    assert!(!app.selecting);
+    assert_eq!(app.input.cursor, 1, "click on 'r' → before it");
+    assert!(app.input.hist_pos.is_none(), "no history recall on click");
+}
+
+#[test]
+fn input_drag_selects_the_crossed_cells_and_keeps_the_highlight() {
+    let (mut app, ctl) = test_app_and_ctl();
+    app.input.set("hello world".into());
+    app.input_area = input_well();
+    app.input_top = 0;
+
+    // Down on 'l' (cell 2, screen x 5), drag across to 'd' (cell 10,
+    // screen x 13): cells 2..=10 → "llo world".
+    app.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 5, 20), &ctl);
+    assert_eq!(app.input.cursor, 2, "click on 'l' → before it");
+    app.handle_mouse(mouse(MouseEventKind::Drag(MouseButton::Left), 13, 20), &ctl);
+    assert_eq!(app.input_selection_range(), Some((2, 11)), "cells 2..=10");
+    app.handle_mouse(mouse(MouseEventKind::Up(MouseButton::Left), 13, 20), &ctl);
+    assert!(app.input_sel.is_some(), "highlight persists after the copy");
+    assert!(!app.input_selecting);
+
+    // The same cells covered by a leftward drag.
+    app.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 13, 20), &ctl);
+    app.handle_mouse(mouse(MouseEventKind::Drag(MouseButton::Left), 5, 20), &ctl);
+    assert_eq!(
+        app.input_selection_range(),
+        Some((2, 11)),
+        "leftward drag agrees"
+    );
+
+    // A plain click (down + up on the same cell) leaves no highlight.
+    app.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 5, 20), &ctl);
+    app.handle_mouse(mouse(MouseEventKind::Up(MouseButton::Left), 5, 20), &ctl);
+    assert!(app.input_sel.is_none(), "caret click leaves no selection");
+}
+
+#[test]
+fn input_drag_covers_wide_chars_whole_and_drags_above_the_well_snap_to_start() {
+    let (mut app, ctl) = test_app_and_ctl();
+    app.input.set("a中b".into());
+    app.input_area = input_well();
+    app.input_top = 0;
+
+    // Down on 'a' (cell 0), drag onto 'b' (cell 3): covers 中 whole.
+    app.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 3, 20), &ctl);
+    app.handle_mouse(mouse(MouseEventKind::Drag(MouseButton::Left), 6, 20), &ctl);
+    assert_eq!(app.input_selection_range(), Some((0, 3)), "a中b");
+
+    // Drag above the well clamps to the top visible row → the buffer start.
+    app.handle_mouse(mouse(MouseEventKind::Drag(MouseButton::Left), 6, 19), &ctl);
+    assert_eq!(
+        app.input_selection_range(),
+        Some((0, 3)),
+        "clamped to the top row"
+    );
+}
+
+#[test]
+fn chat_click_clears_the_composer_highlight() {
+    let (mut app, ctl) = test_app_and_ctl();
+    app.chat_view = view(&["chat line"]);
+    app.chat_view.area = ratatui::layout::Rect::new(1, 0, 60, 10);
+    app.input.set("draft".into());
+    app.input_area = input_well();
+    app.input_sel = Some(InputSel {
+        anchor: (0, 1),
+        head: (0, 3),
+    });
+
+    app.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 3, 1), &ctl);
+
+    assert!(
+        app.input_sel.is_none(),
+        "chat click clears the composer highlight"
+    );
+    assert_eq!(
+        app.input.cursor, 5,
+        "composer caret untouched by chat clicks"
+    );
 }

--- a/tests/unit/input__editor__tests.rs
+++ b/tests/unit/input__editor__tests.rs
@@ -77,3 +77,108 @@ fn vertical_motion_uses_soft_wrapped_visual_rows() {
     i.move_vertical(4, -1);
     assert_eq!(i.cursor, 2, "wrapped row 1, display column 2");
 }
+
+#[test]
+fn char_index_at_places_caret_before_the_clicked_char() {
+    let i = editor("hello world");
+    assert_eq!(i.char_index_at(80, 0, 0), 0, "click on 'h' → before it");
+    assert_eq!(i.char_index_at(80, 0, 2), 2, "click on 'l' → before it");
+    assert_eq!(i.char_index_at(80, 0, 10), 10, "click on 'd' → before it");
+    assert_eq!(i.char_index_at(80, 0, 11), 11, "blank past the end → end");
+    assert_eq!(
+        i.char_index_at(80, 0, 40),
+        11,
+        "blank far past the end → end"
+    );
+    assert_eq!(i.char_index_at(80, 1, 3), 11, "row below the text → end");
+    assert_eq!(i.char_index_at(80, 9, 0), 11, "far below the text → end");
+}
+
+#[test]
+fn char_index_at_splits_wide_chars_at_their_midpoint() {
+    let i = editor("a中b");
+    assert_eq!(i.char_index_at(80, 0, 0), 0, "'a' → before it");
+    assert_eq!(i.char_index_at(80, 0, 1), 1, "left half of 中 → before it");
+    assert_eq!(i.char_index_at(80, 0, 2), 2, "right half of 中 → after it");
+    assert_eq!(i.char_index_at(80, 0, 3), 2, "'b' → before it");
+    assert_eq!(i.char_index_at(80, 0, 4), 3, "blank → end");
+}
+
+#[test]
+fn char_index_at_follows_soft_wraps() {
+    let i = editor("abcdefghij");
+    // Width 4 wraps to abcd / efgh / ij.
+    assert_eq!(i.char_index_at(4, 0, 3), 3, "'d' at the wrap edge");
+    assert_eq!(i.char_index_at(4, 1, 0), 4, "'e' → the wrap boundary");
+    assert_eq!(i.char_index_at(4, 1, 2), 6, "'g'");
+    assert_eq!(i.char_index_at(4, 1, 3), 7, "'h' at the second wrap edge");
+    assert_eq!(i.char_index_at(4, 2, 1), 9, "'j'");
+    assert_eq!(i.char_index_at(4, 2, 2), 10, "blank after 'j' → end");
+    assert_eq!(i.char_index_at(4, 3, 0), 10, "row below → end");
+}
+
+#[test]
+fn char_index_at_handles_hard_newlines_and_empty_buffers() {
+    let i = editor("ab\ncd");
+    assert_eq!(i.char_index_at(80, 0, 0), 0, "'a' → before it");
+    assert_eq!(
+        i.char_index_at(80, 0, 2),
+        2,
+        "end of the first line (before \\n)"
+    );
+    assert_eq!(
+        i.char_index_at(80, 1, 0),
+        3,
+        "'c' → start of the second line"
+    );
+    assert_eq!(i.char_index_at(80, 1, 2), 5, "'d' → end of the text");
+    assert_eq!(i.char_index_at(80, 2, 5), 5, "below the text → end");
+
+    let empty = editor("");
+    assert_eq!(empty.char_index_at(80, 0, 7), 0, "empty draft");
+}
+
+#[test]
+fn char_index_end_at_covers_the_clicked_cell_inclusively() {
+    let i = editor("hello world");
+    assert_eq!(
+        i.char_index_end_at(80, 0, 2),
+        3,
+        "drag end on 'l' → after it"
+    );
+    assert_eq!(i.char_index_end_at(80, 0, 10), 11, "drag end on 'd' → end");
+    assert_eq!(i.char_index_end_at(80, 0, 40), 11, "blank far past → end");
+    assert_eq!(i.char_index_end_at(80, 1, 0), 11, "row below → end");
+
+    let wide = editor("a中b");
+    assert_eq!(
+        wide.char_index_end_at(80, 0, 1),
+        2,
+        "left half of 中 → whole char"
+    );
+    assert_eq!(
+        wide.char_index_end_at(80, 0, 2),
+        2,
+        "right half of 中 → after it"
+    );
+    assert_eq!(wide.char_index_end_at(80, 0, 3), 3, "'b' → after it");
+}
+
+#[test]
+fn char_index_end_at_follows_soft_wraps() {
+    let i = editor("abcdefghij");
+    assert_eq!(i.char_index_end_at(4, 0, 3), 4, "'d' → the wrap boundary");
+    assert_eq!(i.char_index_end_at(4, 1, 0), 5, "'e' → after it");
+    assert_eq!(i.char_index_end_at(4, 2, 1), 10, "'j' → end");
+    assert_eq!(i.char_index_end_at(4, 3, 0), 10, "row below → end");
+}
+
+#[test]
+fn chars_between_slices_by_char_boundaries() {
+    let i = editor("a中b");
+    assert_eq!(i.chars_between(0, 2), "a中");
+    assert_eq!(i.chars_between(2, 0), "a中", "unordered drags agree");
+    assert_eq!(i.chars_between(1, 2), "中");
+    assert_eq!(i.chars_between(3, 3), "", "caret-only");
+    assert_eq!(i.chars_between(2, 99), "b", "clamped to the buffer");
+}


### PR DESCRIPTION
Closes #43

## Problem

Text in the Martty composer cannot be selected and copied with the mouse, and clicking a character position does not move the edit caret there.

## What changed

- **Click to place the caret**: a left-click on any visible character moves the caret to that position (the boundary *before* the clicked char, so the next typed character appears at the clicked spot); clicking blank space past the end of the text moves the caret to the end.
- **Drag to select & copy**: left-drag selects a contiguous span, copied to the clipboard on release (native tools + tmux buffer + OSC 52 legs), with the highlight persisting until the next click or Esc.
- **Multi-column-width chars** (CJK/emoji): the caret splits a wide char at its midpoint (left half → before it, right half → after it) and a drag covers it whole, always aligned with what is on screen; soft-wrapped and hard-newline rows share the exact caret map with the renderer.
- **No interference**: mouse actions only touch caret/selection state — they never trigger submit, history recall, or slash-completion selection; chat-pane and composer highlights are mutually exclusive.

## Implementation

- `src/input/editor.rs`: `char_index_at` / `char_index_end_at` (screen cell → char boundary mapping for clicks and drag ends), `chars_between` (char-boundary slicing)
- `src/app.rs`: `InputSel` (cell-based selection endpoints), `input_area` / `input_top` (well rect + viewport scroll recorded by draw), mouse Down/Drag/Up handling, highlight lifecycle (cleared by Esc/click/edits)
- `src/ui.rs`: `draw_input` records hit-testing state; `draw_input_selection` paints the selection as reversed cells (same treatment as the chat pane)

## Tests

19 new unit tests (13 editor + 6 app-level) covering: click caret placement (wide-char midpoint, soft/hard wraps, viewport scroll, empty draft), bidirectional drag ranges, chat/composer highlight mutual exclusion, and no history recall on click. Full suite: 472 tests pass.