### PR TITLE
feat: popup dialogs, indented bodies, provider-grouped plugins tree (issue #49)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /target
 /dist
+/npm-martty
 /.venv
 /npm/vendor
 /npm/node_modules

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ All notable changes to this project are documented here. The project follows
 
 ### Added
 
+- `/plugins` now renders the static Host plugin inventory as a two-level
+  tree grouped by provider (npm scope) → plugin name, using the
+  tui-tree-widget crate: every provider branch opens expanded by default,
+  ↑/↓ move the selection, ←/→ or enter fold/unfold a branch, pgup/pgdn,
+  home/end and the mouse wheel scroll, esc closes. Leaves keep the
+  enabled/fiber-phase meta of the old flat picker (issue #49).
+
+### Changed
+
+- `/help` and `/session` now open the same popup dialog as `/keys` instead
+  of pushing markdown into the scrollback; the transcript stays untouched
+  (issue #49).
+- Popup dialog bodies (keys/plan-view/status and friends) are indented one
+  level from the border, and markdown wraps one level narrower so
+  continuation lines stay aligned (issue #49).
+
+### Fixed
+
 - The composer input now supports the mouse: left-click places the caret at
   the clicked character (blank space past the text snaps to the end), and
   left-drag selects a text span that is copied to the clipboard on release,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -539,6 +539,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tui-markdown",
+ "tui-tree-widget",
  "unicode-width",
 ]
 
@@ -2527,6 +2528,17 @@ dependencies = [
  "ratatui-core",
  "rstest",
  "tracing",
+]
+
+[[package]]
+name = "tui-tree-widget"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "246c1142baa1e7a42b94f0fb2b60d838fc884c16281e330bf8624da65ed8f89a"
+dependencies = [
+ "ratatui-core",
+ "ratatui-widgets",
+ "unicode-width",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ serde_json = "1"
 ruzstd = "0.8"
 unicode-width = "0.2"
 tui-markdown = { version = "0.3.9", default-features = false }
+tui-tree-widget = "0.24"
 agent-client-protocol = { version = "2.0.0", features = ["unstable_auth_methods", "unstable_elicitation", "unstable_end_turn_token_usage"] }
 tokio = { version = "1.53.1", features = ["rt-multi-thread", "macros", "io-util", "fs", "net", "time", "sync"] }
 tokio-util = { version = "0.7.19", features = ["compat"] }

--- a/npm/lib/stats-view.js
+++ b/npm/lib/stats-view.js
@@ -1,34 +1,48 @@
 /** Built-in Client Plugin: standard ACP usage and timing in the composer dock. */
 
 export const name = 'stats-view'
-export const inject = ['acpSessionStats', 'tuiSlots']
+export const inject = ['acpSessionStats', 'acpSessionStatus', 'tuiSlots']
 
 export function apply(ctx) {
   let current = ctx.acpSessionStats.current()
+  let status = ctx.acpSessionStatus.current()
   let panel
   const stopSlot = ctx.tuiSlots.inject('conversation.composer.dock', () => {
     panel = ctx.tuiSlots.register(
       { name: 'conversation.composer.dock', id: 'stats' },
-      nodesOf(current),
+      nodesOf(current, status),
     )
     return () => panel.dispose()
   })
   const stopStats = ctx.acpSessionStats.subscribe((snapshot) => {
     current = snapshot
-    panel?.update(nodesOf(current))
+    panel?.update(nodesOf(current, status))
+  })
+  const stopStatus = ctx.acpSessionStatus.subscribe((snapshot) => {
+    status = snapshot
+    panel?.update(nodesOf(current, status))
   })
   return () => {
     stopStats?.()
+    stopStatus?.()
     stopSlot?.()
   }
 }
 
-function nodesOf(snapshot) {
+function nodesOf(snapshot, status) {
   const usage = snapshot?.usage ?? {}
   const stats = snapshot?.stats ?? {}
+  const model = status?.model
   const nodes = []
   if ((usage.input ?? 0) > 0 || (usage.output ?? 0) > 0) {
-    nodes.push(node('tokens', `Input ${formatTokens(usage.input)} tok · Output ${formatTokens(usage.output)} tok`))
+    nodes.push(node('tokens', `↑${formatTokens(usage.input)} · ↓${formatTokens(usage.output)}`))
+    const used = (usage.input ?? 0) + (usage.output ?? 0)
+      + (usage.cached ?? 0) + (usage.reasoning ?? 0)
+    const size = contextWindowOf(model)
+    if (used > 0 && size > 0) {
+      const pct = Math.min(100, used / size * 100).toFixed(1)
+      nodes.push(node('context', `${pct}%/${contextSizeLabel(size)}`))
+    }
   }
   if ((stats.turns ?? 0) > 0 || (stats.steps ?? 0) > 0) {
     nodes.push(node(
@@ -67,6 +81,31 @@ function node(id, title) {
 }
 
 function plural(value, singular) { return value === 1 ? singular : `${singular}s` }
+
+/**
+ * Context window of the current model (tokens). The ACP surface does not
+ * carry the window size, so the known DeepSeek family sizes stand in;
+ * unknown models fall back to a common 128K.
+ */
+function contextWindowOf(model) {
+  switch (model) {
+    case 'deepseek-v4-flash':
+    case 'deepseek-v4-pro':
+      return 1_000_000
+    default:
+      return 128_000
+  }
+}
+
+/** `1000000` → `1.0M`, `128000` → `128K` — keeps the one-decimal look of
+ * the percentage side (e.g. `17.5%/1.0M`). */
+function contextSizeLabel(size) {
+  if (size >= 1_000_000) {
+    const scaled = size / 1_000_000
+    return `${scaled >= 100 ? Math.round(scaled) : scaled.toFixed(1)}M`
+  }
+  return formatTokens(size)
+}
 
 function formatTokens(value = 0) {
   if (value < 1000) return String(value)

--- a/scripts/devlocalinstall.sh
+++ b/scripts/devlocalinstall.sh
@@ -3,26 +3,49 @@ set -euo pipefail
 
 cd "$(dirname "${BASH_SOURCE[0]}")/.."
 
-# 1. Build the npm tarball (cargo release build + npm pack -> dist/)
+# Target profile: first CLI arg, else DSH_TUI_PROFILE, else martty (the
+# primary dev profile). Must match the `dsh --profile <name>` you run.
+PROFILE="${1:-${DSH_TUI_PROFILE:-martty}}"
+
+# 1. Build the Rust binary and stage native artifacts into npm/
 ./scripts/build-npm.sh
 
-# 2. Pick the highest-version tarball in dist/. Version sort (sort -V),
+# 2. Produce the tarball under the name users install:
+#    `dsh plugin --profile martty add martty@latest` pulls the aliased
+#    `martty` package from npm, so the dev install must be the same shape:
+#    dist/martty-*.tgz. Mirrors CI (package-npm.yml):
+#    package-alias.mjs npm npm-martty martty && npm pack ./npm-martty
+rm -rf npm-martty
+node scripts/package-alias.mjs npm npm-martty martty
+npm pack ./npm-martty --pack-destination dist
+
+# 3. Pick the highest-version tarball in dist/. Version sort (sort -V),
 #    not mtime: a later-built older version must never regress the install.
 shopt -s nullglob
-tgz=(dist/openma-deepseek-harness-tui-*.tgz)
+tgz=(dist/martty-*.tgz)
 if (( ${#tgz[@]} == 0 )); then
-  echo "no tarball in dist/ — did build-npm.sh succeed?" >&2
+  echo "no tarball in dist/ — did the alias+pack step succeed?" >&2
   exit 1
 fi
 LATEST="$(printf '%s\n' "${tgz[@]}" | sort -V | tail -n 1)"
 echo "using tarball: $LATEST"
 
-# 3. Install the freshly built plugin into the tui profile.
+# 4. Install the freshly built plugin into the target profile.
 #    pnpm re-installs the tarball when its content changes (integrity check);
 #    clearing node_modules + lockfile below is a belt-and-braces force step.
 #    Deliberately NOT wiping the whole profile dir, so the user's
 #    cordis.patch.yml layer and any other installed plugins survive.
-rm -rf ~/.dsh/profiles/tui/node_modules ~/.dsh/profiles/tui/pnpm-lock.yaml
-dsh plugin --profile tui add "$PWD/$LATEST"
+PROFILE_DIR="$HOME/.dsh/profiles/$PROFILE"
+# Note: a missing profile dir is fine — `dsh plugin add` below creates it
+# (with the @deepseek-ai/dsh-base bundle), matching the user flow
+# `dsh plugin --profile martty add martty@latest` on a fresh machine.
+# Drop the legacy-named TUI bundle (@openma/deepseek-harness-tui) if a
+# previous install left it in the profile: `dsh plugin add` would otherwise
+# append `martty` alongside it and mount the TUI twice.
+if grep -q '@openma/deepseek-harness-tui' "$PROFILE_DIR/package.json"; then
+  dsh plugin --profile "$PROFILE" remove '@openma/deepseek-harness-tui'
+fi
+rm -rf "$PROFILE_DIR/node_modules" "$PROFILE_DIR/pnpm-lock.yaml"
+dsh plugin --profile "$PROFILE" add "$PWD/$LATEST"
 
-echo "installed $LATEST into profile tui — restart the TUI or run /refresh to pick it up"
+echo "installed $LATEST into profile $PROFILE — restart the TUI or run /refresh to pick it up"

--- a/scripts/stats-view.test.mjs
+++ b/scripts/stats-view.test.mjs
@@ -8,7 +8,7 @@ const statsView = await import(pathToFileURL(
 ).href).catch(() => ({}))
 
 test('the stats Client Plugin contributes only through the composer dock', () => {
-  assert.deepEqual(statsView.inject, ['acpSessionStats', 'tuiSlots'])
+  assert.deepEqual(statsView.inject, ['acpSessionStats', 'acpSessionStatus', 'tuiSlots'])
   assert.equal(typeof statsView.apply, 'function')
   if (typeof statsView.apply !== 'function') return
 
@@ -29,6 +29,10 @@ test('the stats Client Plugin contributes only through the composer dock', () =>
       }),
       subscribe(next) { listener = next; return () => { listener = undefined } },
     },
+    acpSessionStatus: {
+      current: () => ({ model: 'deepseek-v4-flash' }),
+      subscribe() { return () => {} },
+    },
     tuiSlots: {
       inject(name, callback) {
         assert.equal(name, 'conversation.composer.dock')
@@ -43,9 +47,10 @@ test('the stats Client Plugin contributes only through the composer dock', () =>
   }
 
   statsView.apply(ctx)
-  assert.equal(nodes.length, 5)
+  assert.equal(nodes.length, 6)
   assert.deepEqual(nodes.map((node) => node.title), [
-    'Input 1.8K tok · Output 412 tok',
+    '↑1.8K · ↓412',
+    '0.3%/1.0M',
     '1 turn · 67 steps',
     'Cache hit 40%',
     'LLM 15s · Tool call 0s',

--- a/src/app.rs
+++ b/src/app.rs
@@ -516,7 +516,6 @@ pub enum PickerKind {
     Permission,
     Session,
     Auth,
-    StaticPlugin,
     CordisPlugin,
     CordisApproval,
     AgentHistory,
@@ -691,6 +690,36 @@ pub struct Picker {
     pub title: String,
     pub sel: usize,
     pub items: Vec<PickerItem>,
+}
+
+/// The `/plugins` static inventory as a two-level tree (provider → plugin),
+/// rendered by `ui::draw_plugin_tree` with the tui-tree-widget crate.
+/// Items are rebuilt from `static_plugins` on every draw; the TreeState keeps
+/// the selection and the opened provider branches stable across frames.
+pub struct PluginTree {
+    pub title: String,
+    pub state: tui_tree_widget::TreeState<String>,
+}
+
+/// The provider bucket for one loader entry: the npm scope when the module
+/// name carries one, otherwise a stable `core` bucket. This is the first
+/// level of the `/plugins` tree.
+pub fn plugin_provider(module: &str) -> String {
+    module
+        .split_once('/')
+        .map(|(scope, _)| scope)
+        .unwrap_or("core")
+        .to_string()
+}
+
+/// The plugin name shown under its provider: the module name without the
+/// npm scope (`@deepseek-ai/dsh-agent` → `dsh-agent`).
+pub fn plugin_short_name(module: &str) -> String {
+    module
+        .split_once('/')
+        .map(|(_, name)| name)
+        .unwrap_or(module)
+        .to_string()
 }
 
 pub struct SubagentView {
@@ -989,6 +1018,13 @@ pub struct App {
     /// Read-only modal rendered from a semantic TuiNode tree. Client Plugins
     /// and builtin chrome such as `/keys` share this surface.
     pub view_overlay: Option<ViewOverlay>,
+    /// Provider-grouped static plugin inventory (`/plugins`): a tui-tree-widget
+    /// popup rebuilt from `static_plugins` every draw, selection/open state
+    /// kept by the widget's own TreeState.
+    pub plugin_tree: Option<PluginTree>,
+    /// Rows the open plugin tree actually shows (`h - border`), recorded by
+    /// `ui::draw_plugin_tree` — the page size for PageUp/PageDown.
+    pub plugin_tree_page_rows: usize,
     /// Images staged in the composer as inline `[image N]` chips living in
     /// the draft text; editing a token away un-stages its image.
     pub pending_images: crate::attachments::Staged,
@@ -1009,7 +1045,7 @@ pub struct App {
     /// as their owning Plugin Fiber.
     plugin_commands: Vec<PluginCommand>,
     /// Last Host Loader inventory (`/plugins`).
-    static_plugins: Vec<crate::bus::StaticPluginItem>,
+    pub(crate) static_plugins: Vec<crate::bus::StaticPluginItem>,
     /// Last backend-owned dynamic plugin inventory (`/cordis-plugins`).
     cordis_plugins: Vec<crate::bus::CordisPluginItem>,
     /// Model-requested dynamic activations awaiting a decision.
@@ -1361,6 +1397,8 @@ impl App {
             slider_overlay: None,
             select_overlay: None,
             view_overlay: None,
+            plugin_tree: None,
+            plugin_tree_page_rows: 0,
             pending_images: crate::attachments::Staged::default(),
             att_chips: Vec::new(),
             slot_actions: Vec::new(),
@@ -1659,36 +1697,31 @@ impl App {
         });
     }
 
-    fn open_static_plugin_picker(&mut self) {
-        let items = self
-            .static_plugins
-            .iter()
-            .map(|plugin| PickerItem {
-                id: plugin.entry_id.clone(),
-                label: plugin.module_name.clone(),
-                meta: format!(
-                    "static · {} · {}",
-                    if plugin.enabled {
-                        "enabled"
-                    } else {
-                        "disabled"
-                    },
-                    plugin.fiber_phase.as_deref().unwrap_or("inactive"),
-                ),
-                provider: None,
-            })
-            .collect();
-        self.picker = Some(Picker {
-            kind: PickerKind::StaticPlugin,
+    fn open_plugin_tree(&mut self) {
+        let mut state = tui_tree_widget::TreeState::default();
+        // Open every provider branch by default; the selection starts on the
+        // first provider row. Identifiers are paths: [provider] for a branch
+        // and [provider, entryId] for one plugin leaf.
+        let mut first_provider: Option<String> = None;
+        for plugin in &self.static_plugins {
+            let provider = crate::app::plugin_provider(&plugin.module_name);
+            state.open(vec![provider.clone()]);
+            if first_provider.is_none() {
+                first_provider = Some(provider);
+            }
+        }
+        if let Some(provider) = first_provider {
+            state.select(vec![provider]);
+        }
+        self.plugin_tree = Some(PluginTree {
             title: self
                 .locale
                 .tr(
-                    " Host plugins · static · read only · esc close ",
-                    " Host 插件 · 静态 · 只读 · esc 关闭 ",
+                    " Host plugins · static · read only · ↑↓ ←→ navigate · esc close ",
+                    " Host 插件 · 静态 · 只读 · ↑↓ ←→ 导航 · esc 关闭 ",
                 )
                 .into(),
-            sel: 0,
-            items,
+            state,
         });
     }
 
@@ -2466,7 +2499,7 @@ impl App {
                     }
                     CtlEvent::StaticPlugins { plugins } => {
                         self.static_plugins = plugins;
-                        self.open_static_plugin_picker();
+                        self.open_plugin_tree();
                     }
                     CtlEvent::CordisPlugins { plugins } => {
                         self.cordis_plugins = plugins;
@@ -2827,6 +2860,8 @@ impl App {
             MouseEventKind::ScrollUp => {
                 if self.elicitation_ask.is_some() {
                     self.elicitation_scroll_by(-3);
+                } else if let Some(tree) = &mut self.plugin_tree {
+                    tree.state.scroll_up(3);
                 } else if self.view_overlay.is_some() {
                     self.view_scroll_by(-3);
                 } else {
@@ -2836,6 +2871,8 @@ impl App {
             MouseEventKind::ScrollDown => {
                 if self.elicitation_ask.is_some() {
                     self.elicitation_scroll_by(3);
+                } else if let Some(tree) = &mut self.plugin_tree {
+                    tree.state.scroll_down(3);
                 } else if self.view_overlay.is_some() {
                     self.view_scroll_by(3);
                 } else {
@@ -3577,6 +3614,12 @@ impl App {
             return;
         }
 
+        // --- /plugins tree popup (provider → plugin inventory)
+        if self.plugin_tree.is_some() {
+            self.handle_plugin_tree_key(key);
+            return;
+        }
+
         if self.agent_selection.is_some() {
             if key.modifiers == KeyModifiers::NONE {
                 match key.code {
@@ -4038,7 +4081,6 @@ impl App {
                             .push_notice(NoticeLevel::Info, format!("reasoning effort → {effort}"));
                     }
                     PickerKind::Auth => self.start_auth(&item.id, ctl),
-                    PickerKind::StaticPlugin => {}
                     PickerKind::CordisPlugin => {
                         let action = self
                             .cordis_plugins
@@ -4081,6 +4123,51 @@ impl App {
                     }
                     PickerKind::AgentHistory => self.select_agent_transcript(&item.id),
                 }
+            }
+            _ => {}
+        }
+    }
+
+    /// Keyboard driving of the `/plugins` tree popup. The tree widget owns
+    /// selection and viewport; ←/→ and enter fold/unfold a provider branch.
+    fn handle_plugin_tree_key(&mut self, key: KeyEvent) {
+        if key.modifiers != KeyModifiers::NONE {
+            return;
+        }
+        if key.code == KeyCode::Esc {
+            self.plugin_tree = None;
+            return;
+        }
+        let Some(tree) = &mut self.plugin_tree else {
+            return;
+        };
+        let page = self.plugin_tree_page_rows.max(1);
+        match key.code {
+            KeyCode::Up => {
+                tree.state.key_up();
+            }
+            KeyCode::Down => {
+                tree.state.key_down();
+            }
+            KeyCode::Left => {
+                tree.state.key_left();
+            }
+            KeyCode::Right | KeyCode::Enter => {
+                tree.state.toggle_selected();
+            }
+            KeyCode::PageUp => {
+                tree.state
+                    .select_relative(|i| i.map_or(0, |i| i.saturating_sub(page)));
+            }
+            KeyCode::PageDown => {
+                tree.state
+                    .select_relative(|i| i.map_or(0, |i| i.saturating_add(page)));
+            }
+            KeyCode::Home => {
+                tree.state.select_first();
+            }
+            KeyCode::End => {
+                tree.state.select_last();
             }
             _ => {}
         }
@@ -5388,7 +5475,7 @@ impl App {
 
 每轮会显示：流式思考与回答、工具调用与结果、注入上下文、Subagent 生命周期、
 token 用量（含缓存命中）以及轮次结束原因。";
-            self.transcript.push_markdown(text.to_string());
+            self.open_text_overlay("builtin.help", self.locale.tr("help", "帮助").to_string(), text.to_string());
             return;
         }
         let text = "\
@@ -5419,7 +5506,7 @@ token 用量（含缓存命中）以及轮次结束原因。";
 
 Per turn: streamed reasoning, answer, tool calls with results, injected
 context, subagent lifecycles, token usage (incl. cache hits), end reason.";
-        self.transcript.push_markdown(text.to_string());
+        self.open_text_overlay("builtin.help", self.locale.tr("help", "帮助").to_string(), text.to_string());
     }
 
     fn push_keys(&mut self) {
@@ -5537,7 +5624,28 @@ context, subagent lifecycles, token usage (incl. cache hits), end reason.";
                 u.output as f64 / (llm_millis as f64 / 1000.0)
             ));
         }
-        self.transcript.push_markdown(text);
+        self.open_text_overlay(
+            "builtin.session",
+            self.locale.tr("session", "会话").to_string(),
+            text,
+        );
+    }
+
+    /// Open one builtin info dialog (popup) from a markdown body. `/keys`,
+    /// `/help` and `/session` share this surface, so the facts never land in
+    /// the scrollback as transcript cells.
+    fn open_text_overlay(&mut self, id: &str, title: String, text: String) {
+        self.view_overlay = Some(ViewOverlay {
+            id: id.into(),
+            title,
+            nodes: vec![crate::slots::TuiNode::Markdown {
+                id: id.into(),
+                text,
+                streaming: false,
+            }],
+            scroll: 0,
+            notify_plugin: false,
+        });
     }
 
     /// Compact status fallback: the run state plus painter-owned ACP facts.

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -323,6 +323,7 @@ pub fn draw(f: &mut Frame, app: &mut App) {
         draw_attachment_preview(f, app, composer, area);
     }
     draw_model_picker(f, app, area);
+    draw_plugin_tree(f, app, area);
     draw_plugin_slider(f, app, area);
     draw_plugin_select(f, app, area);
     draw_view_overlay(f, app, area);
@@ -742,8 +743,16 @@ fn draw_view_overlay(f: &mut Frame, app: &mut App, screen: Rect) {
         .saturating_sub(4)
         .min((screen.width.saturating_mul(2) / 3).max(84))
         .max(24);
-    let inner_width = width.saturating_sub(2) as usize;
-    let lines = crate::slots::render_nodes(&view.nodes, &theme, inner_width);
+    // Popup bodies sit one indent level off the border (issue #49): wrap one
+    // level narrower, then prefix every rendered row with the indent so
+    // continuation lines stay aligned.
+    const POPUP_INDENT: u16 = 2;
+    let inner_width = width.saturating_sub(2 + POPUP_INDENT) as usize;
+    let mut lines = crate::slots::render_nodes(&view.nodes, &theme, inner_width);
+    let indent = " ".repeat(POPUP_INDENT as usize);
+    for line in &mut lines {
+        line.spans.insert(0, Span::raw(indent.clone()));
+    }
     let height = (lines.len() as u16 + 2)
         .min(screen.height.saturating_sub(4))
         .max(4);
@@ -773,6 +782,115 @@ fn draw_view_overlay(f: &mut Frame, app: &mut App, screen: Rect) {
         ))
         .style(Style::default().bg(theme.panel).fg(theme.fg));
     f.render_widget(Paragraph::new(lines).scroll((scroll, 0)).block(block), area);
+}
+
+/// `/plugins` inventory popup: a two-level provider → plugin tree rendered
+/// with tui-tree-widget (the maintained ratatui port of the widget named in
+/// issue #49). The widget owns the viewport and the selection; rows are
+/// rebuilt from `app.static_plugins` every frame so a palette switch
+/// recolors them immediately.
+fn draw_plugin_tree(f: &mut Frame, app: &mut App, screen: Rect) {
+    use std::collections::{BTreeMap, HashSet};
+    use tui_tree_widget::{Tree, TreeItem};
+
+    let Some(tree) = &mut app.plugin_tree else {
+        return;
+    };
+    let theme = app.theme;
+
+    // Group by provider, keeping loader order inside each provider. Leaf
+    // identifiers are entry ids (unique per loader), provider identifiers
+    // are scopes, so the widget's paths [provider] / [provider, entryId]
+    // stay stable across frames.
+    let mut groups: BTreeMap<String, Vec<&crate::bus::StaticPluginItem>> = BTreeMap::new();
+    for plugin in &app.static_plugins {
+        groups
+            .entry(crate::app::plugin_provider(&plugin.module_name))
+            .or_default()
+            .push(plugin);
+    }
+    let mut items = Vec::with_capacity(groups.len());
+    let mut widest = 0usize;
+    let mut leaf_rows = 0usize;
+    for (provider, plugins) in &groups {
+        let mut children = Vec::with_capacity(plugins.len());
+        let mut seen: HashSet<&str> = HashSet::with_capacity(plugins.len());
+        for plugin in plugins {
+            if !seen.insert(&plugin.entry_id) {
+                continue;
+            }
+            let short = crate::app::plugin_short_name(&plugin.module_name);
+            let meta = format!(
+                " · {} · {}",
+                if plugin.enabled {
+                    "enabled"
+                } else {
+                    "disabled"
+                },
+                plugin.fiber_phase.as_deref().unwrap_or("inactive"),
+            );
+            widest = widest.max(short.width() + meta.width());
+            leaf_rows += 1;
+            children.push(TreeItem::new_leaf(
+                plugin.entry_id.clone(),
+                Line::from(vec![
+                    Span::styled(short, Style::default().fg(theme.fg_secondary)),
+                    Span::styled(meta, Style::default().fg(theme.caption)),
+                ]),
+            ));
+        }
+        let label = format!("{provider} · {}", children.len());
+        widest = widest.max(label.width());
+        items.push(
+            TreeItem::new(
+                provider.clone(),
+                Line::styled(label, Style::default().fg(theme.brand)),
+                children,
+            )
+            .expect("provider identifiers are deduped by BTreeMap"),
+        );
+    }
+
+    // Popup geometry mirrors the picker: width follows the widest row (with
+    // room for the highlight symbol + node indent), height caps at the
+    // screen and the tree widget scrolls the overflow.
+    let total_rows = leaf_rows + groups.len();
+    let h = (total_rows as u16 + 2)
+        .min(screen.height.saturating_sub(2))
+        .max(4);
+    let cap = screen.width.saturating_sub(4).max(24);
+    let overflow = total_rows as u16 + 2 > h;
+    let w = if overflow {
+        ((widest as u16 + 8).max(58) + 1).min(cap)
+    } else {
+        (widest as u16 + 8).max(58).min(cap)
+    };
+    let x = screen.x + (screen.width - w) / 2;
+    let y = screen.y + (screen.height - h) / 3;
+    let area = Rect::new(x, y, w, h);
+    app.plugin_tree_page_rows = h.saturating_sub(2) as usize;
+
+    f.render_widget(Clear, area);
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .border_style(Style::default().fg(theme.brand))
+        .title(Span::styled(
+            tree.title.clone(),
+            Style::default().fg(theme.caption),
+        ))
+        .style(Style::default().bg(theme.panel));
+    let widget = Tree::new(&items)
+        .expect("plugin tree identifiers are deduped")
+        .block(block)
+        .highlight_symbol("▸ ")
+        .highlight_style(
+            Style::default()
+                .fg(theme.brand)
+                .bg(theme.chip_bg)
+                .add_modifier(Modifier::BOLD),
+        );
+    f.render_stateful_widget(widget, area, &mut tree.state);
 }
 
 /// Reserve a root-level right rail only while a plugin has content. Narrow
@@ -2648,7 +2766,6 @@ fn draw_model_picker(f: &mut Frame, app: &mut App, screen: Rect) {
         crate::app::PickerKind::Effort
         | crate::app::PickerKind::Session
         | crate::app::PickerKind::Auth
-        | crate::app::PickerKind::StaticPlugin
         | crate::app::PickerKind::CordisPlugin
         | crate::app::PickerKind::CordisApproval
         | crate::app::PickerKind::AgentHistory => false,

--- a/tests/unit/app__mode_tests.rs
+++ b/tests/unit/app__mode_tests.rs
@@ -253,10 +253,43 @@ fn static_plugin_inventory_is_read_only_and_matches_web_status_fields() {
         &ctl,
     );
 
-    let picker = app.picker.as_ref().expect("static plugin picker opens");
-    assert!(matches!(picker.kind, PickerKind::StaticPlugin));
-    assert_eq!(picker.items[0].label, "include");
-    assert_eq!(picker.items[0].meta, "static · enabled · active");
+    let tree = app.plugin_tree.as_ref().expect("plugin tree opens");
+    assert!(
+        tree.title.contains("静态") || tree.title.contains("static"),
+        "{}",
+        tree.title
+    );
+
+    // The inventory renders as a provider → plugin tree: the unscoped row
+    // lands under `core`, scoped rows under their npm scope, and the leaf
+    // keeps the enabled/phase meta of the old flat picker.
+    let (mut grouped, ctl2, _rx2) = test_app();
+    grouped.handle(
+        AppEvent::Ctl(CtlEvent::StaticPlugins {
+            plugins: vec![
+                StaticPluginItem {
+                    entry_id: "root/include".into(),
+                    module_name: "include".into(),
+                    enabled: true,
+                    fiber_phase: Some("active".into()),
+                },
+                StaticPluginItem {
+                    entry_id: "root/tool-bash".into(),
+                    module_name: "@deepseek-ai/dsh-tool-bash".into(),
+                    enabled: false,
+                    fiber_phase: None,
+                },
+            ],
+        }),
+        &ctl2,
+    );
+    let frame = crate::ui::dump_frame(&mut grouped, 100, 20);
+    assert!(frame.contains("core"), "provider bucket:\n{frame}");
+    assert!(frame.contains("@deepseek-ai"), "scoped provider:\n{frame}");
+    assert!(frame.contains("include"), "plugin leaf:\n{frame}");
+    assert!(frame.contains("dsh-tool-bash"), "scoped leaf:\n{frame}");
+    assert!(frame.contains("enabled"), "leaf meta:\n{frame}");
+    assert!(frame.contains("disabled"), "leaf meta:\n{frame}");
 }
 
 #[test]

--- a/tests/unit/app__right_slot_tests.rs
+++ b/tests/unit/app__right_slot_tests.rs
@@ -522,19 +522,21 @@ fn session_slash_shows_effort_when_set() {
 
     app.run_slash("session", "", &ctl);
 
-    let last = app.transcript.cells.last().expect("session cell");
-    let crate::transcript::CellKind::MarkdownNotice { text } = &last.kind else {
-        panic!("/session should be a markdown notice, got {:?}", last.kind);
+    let view = app.view_overlay.as_ref().expect("/session opens a popup");
+    assert_eq!(view.id, "builtin.session");
+    let crate::slots::TuiNode::Markdown { text, .. } = &view.nodes[0] else {
+        panic!("/session popup should carry markdown, got {:?}", view.nodes);
     };
     assert!(text.contains("## session"), "{text}");
     assert!(text.contains("- effort · max"), "{text}");
+    assert!(app.transcript.cells.is_empty(), "no transcript cell for /session");
 
     // Unset effort stays hidden.
     let (mut plain, ctl2, _rx2) = test_app();
     plain.run_slash("session", "", &ctl2);
-    let last = plain.transcript.cells.last().expect("session cell");
-    let crate::transcript::CellKind::MarkdownNotice { text } = &last.kind else {
-        panic!("/session should be a markdown notice, got {:?}", last.kind);
+    let view = plain.view_overlay.as_ref().expect("/session opens a popup");
+    let crate::slots::TuiNode::Markdown { text, .. } = &view.nodes[0] else {
+        panic!("/session popup should carry markdown, got {:?}", view.nodes);
     };
     assert!(!text.contains("- effort ·"), "{text}");
 }


### PR DESCRIPTION
Closes #49 — three UI improvements:

**① Popup bodies are indented one level**
`draw_view_overlay` now wraps markdown one level narrower and prefixes every rendered row with a two-space indent, so keys/plan-view/status and friends sit off the border with continuation lines aligned.

**② `/help` and `/session` open popup dialogs**
Both commands now share the same `ViewOverlay` surface as `/keys` (via a new `open_text_overlay` helper) instead of pushing markdown into the scrollback — the transcript stays untouched.

**③ `/plugins` shows a provider → plugin tree**
The flat static-plugin picker is replaced by a two-level tree using [`tui-tree-widget`](https://github.com/EdJoPaTo/tui-tree-widget) (the maintained ratatui port of the widget named in the issue; v0.24, compatible with ratatui 0.30):
- provider = npm scope (`@deepseek-ai`), unscoped rows land under `core`
- leaves keep the enabled/fiber-phase meta of the old picker
- every provider branch opens expanded; ↑/↓ navigate, ←/→ or Enter fold/unfold, PgUp/PgDn/Home/End and the mouse wheel scroll, Esc closes

**Also on this branch:** `devlocalinstall.sh` now builds and installs the aliased `martty` tarball (same shape as `dsh plugin --profile martty add martty@latest`), defaults the profile to `martty`, and drops a legacy `@openma/deepseek-harness-tui` bundle if a previous install left it (otherwise `dsh plugin add` would mount the TUI twice).

**Tests:** full Rust suite passes (476), status-view JS tests pass, live PTY smoke of the dialogs and the real-profile plugin tree verified. CHANGELOG updated.