### PR TITLE
release: v0.2.27

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -523,7 +523,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-harness-tui"
-version = "0.2.27-beta.0"
+version = "0.2.27"
 dependencies = [
  "agent-client-protocol",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deepseek-harness-tui"
-version = "0.2.27-beta.0"
+version = "0.2.27"
 edition = "2021"
 description = "Terminal-native ACP client UI with a Cordis client plugin tree"
 license = "MIT"

--- a/npm/package-lock.json
+++ b/npm/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@openma/deepseek-harness-tui",
-  "version": "0.2.27-beta.0",
+  "version": "0.2.27",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openma/deepseek-harness-tui",
-      "version": "0.2.27-beta.0",
+      "version": "0.2.27",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/cordis": "^4.0.1",

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openma/deepseek-harness-tui",
-  "version": "0.2.27-beta.0",
+  "version": "0.2.27",
   "description": "Terminal-native ACP client UI; Cordis client tree, any ACP agent",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary

- promote the validated `v0.2.27-beta.0` build to stable `v0.2.27`
- publish the current `main`, including the macOS composer line-kill fix

## Validation

- `cargo test --locked`: 475 unit tests and all integration tests passed
- release tag/version checks passed
- beta cross-platform publish workflow passed: https://github.com/openma-ai/Martty/actions/runs/32938191800

Closes #51