### PR TITLE
perf: cache transcript cell bodies; re-render only changed cells

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,15 +2,31 @@
 
 Read [docs/architecture.md](docs/architecture.md) and [docs/plugins.md](docs/plugins.md) before changing UI, the runner, or plugin loading. The migration sequence and phase 1 demo live in [docs/migration.md](docs/migration.md).
 
+## Commands & verification
+
+- Rust is the CI gate: `cargo test --locked` and `cargo check --locked --tests`. `make rust-test` / `make rust-build` wrap cargo in `scripts/cargo-guard.sh` (cache-size + disk guards, `DSH_TUI_RUST_CACHE_MAX_GIB`). No clippy/fmt gate exists.
+- Linker OOM: on small-RAM machines `cc`/`ld` can get killed (signal 9) linking the test binary. Retry with `RUSTFLAGS="-C link-arg=-fuse-ld=mold" cargo test` (mold is much lighter). `release` uses `lto = true` and is slow — verify with debug builds.
+- JS tests have no root `package.json`. Suites are `scripts/*.test.mjs` (`node --test`) run from the npm package: `npm test --prefix npm`; a single file is `node --test scripts/<name>.test.mjs`.
+- Rust unit tests live in `tests/unit/*__tests.rs` but are wired in by a `#[cfg(test)] #[path = "../tests/unit/…"] mod tests;` include at the bottom of the owning `src/*.rs` file — add that include for new test files.
+- No-TTY visual check: `cargo run -- --dump-frame 100x34` renders the canned demo frame as text; useful to diff transcript/markdown output before and after a rendering change.
+- Demos: `martty --demo` stays on built-in `default` theme; `martty --demo-skin` is the gallery (`ember`) path. `make tui-test` drives a dsh profile against the debug bin; `make real-agent-e2e` consumes model tokens — opt-in.
+
+## Release & versioning
+
+- The version lives in three files that must match the `v*` tag: `Cargo.toml`, `npm/package.json`, and `npm-martty/package.json` (`scripts/check-release-tag.mjs` enforces tag == npm version == Cargo version).
+- Add user-visible changes to `CHANGELOG.md` under `[Unreleased]` (Keep-a-Changelog style).
+- CI (`package-npm.yml`, PRs + tags): Rust tests/check, `npm test --prefix npm`, `test:profile-install-matrix`; release builds additionally run static-ELF and old-glibc smoke checks.
+
+## Protocol & plugin constraints
+
 - The ACP client is a Cordis plugin providing `ctx.acpClient`. It is either the client composition root or an `insert` in another client tree. It attaches to an ACP agent by spawn (`dsh-acp` / `dsh --profile acp` / other) or `config.stream`. It does not import a harness.
 - Do not sync plugin ids, `inject`, or fibers. Server plugins surface through ACP; client plugins stay on the client tree. Both sides negotiate protocol 0 through `initialize` `_meta.dsh.cordis`; only then may they use `_dsh/cordis/*` Extension Requests/Notifications. TUI painter methods are the `_dsh/cordis/tui/*` child domain. This is serialized capability projection, not plugin-tree sync.
-- The primary profile path has two processes: the dsh Host tree mounts Base + the ACP plugin, then its runner starts a separate TUI Client process. ACP uses that Client process's stdin/stdout. The Client process receives the user TTY on fd 3/4 and maps it to the Rust painter; those descriptors never carry Host↔Client ACP. Standalone `dsh-tui` may instead spawn any ACP agent on standard pipes.
+- The primary profile path has two processes: the dsh Host tree mounts Base + the ACP plugin, then its runner starts a separate TUI Client process. ACP uses that Client process's stdin/stdout. The Client process receives the user TTY on fd 3/4 and maps it to the Rust painter; those descriptors never carry Host↔Client ACP. Standalone `martty` may instead spawn any ACP agent on standard pipes (`dsh-tui` remains a compatibility alias).
 - Third-party packs are sibling `insert` rows plus `inject = ['tuiTheme']`. Do not nest them with `ctx.plugin` inside the runner.
 - TUI npm may depend on `@deepseek-ai/cordis` only among `@deepseek-ai/*`; do not depend directly on `dsh-*`. It deliberately carries `@openma/deepseek-harness-acp` as a runtime dependency and exports its own Creator overlay. The TUI bundle mounts both Host plugins on the Base tree; neither enters the separate Client tree.
 - The `tui-theme` service catalog starts with builtin `default`. Palette packs are sibling `insert` rows that `register` into the catalog (like agent presets). `/theme` and `tuiTheme.activate` switch which pack covers. `--demo-skin` is the only shipped path that selects gallery `ember`.
-- The first shell slot proof is `chrome.right`: plugins inject `tuiSlots` and
-  contribute validated `TuiNode` trees. Conversation timeline slots remain later work.
+- The first shell slot proof is `chrome.right`: plugins inject `tuiSlots` and contribute validated `TuiNode` trees. Conversation timeline slots remain later work.
 - Do not give plugins the TTY, kitty, raw mode, or global terminal size.
 - Transcript paint comes from ACP `session/update`. Do not drive chrome or palette from `session/update`. Do not put TUI chrome in ACP `_meta`.
-- ACP auth follows Backchat: read `initialize.authMethods`, submit in-app forms through `authenticate` `_meta`, run Terminal Auth (`_meta["terminal-auth"]`) on the TTY, then `authenticate` to re-check. `/login` stays the agent's slash when advertised. `dsh-tui --demo` stays on built-in `default`. Phase 1 demo is `--demo-skin` (`ember`).
+- ACP auth follows Backchat: read `initialize.authMethods`, submit in-app forms through `authenticate` `_meta`, run Terminal Auth (`_meta["terminal-auth"]`) on the TTY, then `authenticate` to re-check. `/login` stays the agent's slash when advertised. Phase 1 demo is `--demo-skin` (`ember`).
 - Token names, kinds, and slot names are append-only; field meaning changes bump `protocol`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ All notable changes to this project are documented here. The project follows
 
 ### Changed
 
+- Transcript rendering now caches each cell's body lines and re-renders only
+  the cells that actually changed (streaming deltas, tool results, width,
+  theme or expansion drift). Spinner ticks and unchanged frames no longer
+  re-parse the whole scrollback: measured ~12.6x faster idle frames and
+  ~4.3x faster streaming frames on a seven-message markdown transcript,
+  with the gap growing as the conversation grows.
 - `/help` and `/session` now open the same popup dialog as `/keys` instead
   of pushing markdown into the scrollback; the transcript stays untouched
   (issue #49).

--- a/src/app.rs
+++ b/src/app.rs
@@ -1461,7 +1461,7 @@ impl App {
             .unwrap_or(&self.transcript)
     }
 
-    fn displayed_transcript_mut(&mut self) -> &mut Transcript {
+    pub fn displayed_transcript_mut(&mut self) -> &mut Transcript {
         if let Some(index) = self
             .active_subagent
             .as_deref()

--- a/src/markdown.rs
+++ b/src/markdown.rs
@@ -40,14 +40,16 @@ pub fn render(text: &str, theme: &Theme, width: usize) -> Vec<Line<'static>> {
     let mut out: Vec<Line<'static>> = Vec::new();
     let mut in_code = false;
     let mut prev_table_row = false;
-    for line in &parsed.lines {
+    for line in parsed.lines {
         // Flatten the line-level base style (blockquote, code block, …) into
         // each span so wrapping can move spans freely without losing it.
+        // Consumed by value: tui-markdown owns the spans, so the text moves
+        // out instead of being cloned per span per frame.
         let segs: Vec<Seg> = line
             .spans
-            .iter()
+            .into_iter()
             .map(|s| Seg {
-                text: s.content.to_string(),
+                text: s.content.into_owned(),
                 style: line.style.patch(s.style),
             })
             .collect();
@@ -316,7 +318,7 @@ fn table_row_separator(row: &Line, theme: &Theme) -> Line<'static> {
 
 /// Split off the leading blockquote (`>` runs) or list (`- ` / `- [x] ` /
 /// `1. `) marker so wrapped continuations can hang under the body text.
-fn split_prefix(segs: Vec<Seg>) -> (Vec<Seg>, Vec<Seg>) {
+fn split_prefix(mut segs: Vec<Seg>) -> (Vec<Seg>, Vec<Seg>) {
     // Blockquotes: tui-markdown prefixes every quote line with one `>` span
     // per nesting level plus a separating space.
     let mut n = 0;
@@ -332,7 +334,8 @@ fn split_prefix(segs: Vec<Seg>) -> (Vec<Seg>, Vec<Seg>) {
         }
     }
     if saw_gt {
-        return (segs[..n].to_vec(), segs[n..].to_vec());
+        let body = segs.split_off(n);
+        return (segs, body);
     }
 
     // Lists: the marker lives at the start of the first span, possibly after
@@ -545,27 +548,22 @@ fn wrap_pre(segs: Vec<Seg>, width: usize) -> Vec<Line<'static>> {
 /// tui-markdown renders every link as `label (destination)`; for autolinks
 /// and bare-URL links the label *is* the destination, doubling the URL. Drop
 /// the redundant ` (url)` tail when label and destination are identical.
-fn collapse_autolinks(segs: Vec<Seg>) -> Vec<Seg> {
+fn collapse_autolinks(mut segs: Vec<Seg>) -> Vec<Seg> {
     let is_link = |s: &Seg| s.style.add_modifier.contains(Modifier::UNDERLINED);
-    let mut out: Vec<Seg> = Vec::with_capacity(segs.len());
     let mut i = 0;
-    while i < segs.len() {
-        if i + 3 < segs.len()
-            && segs[i + 1].text == " ("
+    while i + 3 < segs.len() {
+        let redundant = segs[i + 1].text == " ("
             && segs[i + 3].text == ")"
             && segs[i].text == segs[i + 2].text
             && !segs[i].text.is_empty()
             && is_link(&segs[i])
-            && is_link(&segs[i + 2])
-        {
-            out.push(segs[i].clone());
-            i += 4;
-            continue;
+            && is_link(&segs[i + 2]);
+        if redundant {
+            segs.drain(i + 1..i + 4);
         }
-        out.push(segs[i].clone());
         i += 1;
     }
-    out
+    segs
 }
 
 /// Truncate a line to `width` columns, appending an ellipsis when content was

--- a/src/transcript.rs
+++ b/src/transcript.rs
@@ -99,6 +99,28 @@ pub struct Cell {
     pub kind: CellKind,
     pub expanded: bool,
     pub hidden: bool,
+    /// Content version, bumped by every mutation (streaming deltas, tool
+    /// results, …) so the body render cache can detect staleness.
+    version: u64,
+    /// Cached body render for the wrap/markdown-heavy kinds. Headers stay
+    /// outside the cache: they depend on the per-frame spinner and are cheap.
+    render: Option<CellRender>,
+}
+
+/// Cached body lines of one cell plus the layout inputs they were built for.
+/// Body lines never depend on the spinner, so a spinning UI reuses them.
+struct CellRender {
+    version: u64,
+    width: u16,
+    theme: Theme,
+    expanded: bool,
+    thumbs: bool,
+    /// Lines below the cell header, in paint order, fully styled.
+    body: Vec<Line<'static>>,
+    /// Kind-specific count needed by the per-frame header: Tool cells carry
+    /// the wrapped result line count (the `▸` chrome), Reasoning cells the
+    /// wrapped body line count (`· N lines`). 0 when unused.
+    meta: usize,
 }
 
 impl Cell {
@@ -107,7 +129,203 @@ impl Cell {
             kind,
             expanded: false,
             hidden: false,
+            version: 0,
+            render: None,
         }
+    }
+
+    fn bump(&mut self) {
+        self.version = self.version.wrapping_add(1);
+    }
+
+    /// Return the cached body render, rebuilding it when the cell content
+    /// version or any layout input (width/theme/expanded/thumbs) drifted.
+    /// `expanded` is the *effective* value including the transcript-wide
+    /// `expand_all`; it decides Tool/Shell/Reasoning body layout.
+    fn ensure_render(&mut self, theme: &Theme, width: u16, expanded: bool, thumbs: bool) -> &CellRender {
+        let stale = match &self.render {
+            Some(r) => {
+                r.version != self.version
+                    || r.width != width
+                    || r.theme != *theme
+                    || r.expanded != expanded
+                    || r.thumbs != thumbs
+            }
+            None => true,
+        };
+        if stale {
+            let (body, meta) = build_body(&self.kind, theme, width as usize, expanded, thumbs);
+            self.render = Some(CellRender {
+                version: self.version,
+                width,
+                theme: *theme,
+                expanded,
+                thumbs,
+                body,
+                meta,
+            });
+        }
+        self.render.as_ref().expect("body render built")
+    }
+}
+
+/// Build the cacheable body lines for one cell: everything painted below the
+/// per-frame header. Returns the lines and the kind-specific header count.
+/// Only the expensive kinds route through here; User/Image/Injected/Plan/
+/// Notice cells render fresh (their work is bounded and small).
+fn build_body(
+    kind: &CellKind,
+    theme: &Theme,
+    width: usize,
+    expanded: bool,
+    _thumbs: bool,
+) -> (Vec<Line<'static>>, usize) {
+    match kind {
+        CellKind::Reasoning { text, .. } => {
+            let body = text.trim();
+            if body.is_empty() {
+                return (Vec::new(), 0);
+            }
+            let body_style = Style::default()
+                .fg(theme.fg_tertiary)
+                .add_modifier(Modifier::ITALIC);
+            let lines: Vec<Line> = wrap(body, width.saturating_sub(2))
+                .into_iter()
+                .map(|l| {
+                    Line::from(vec![Span::raw("  "), Span::styled(l, body_style)])
+                })
+                .collect();
+            let meta = lines.len();
+            (lines, meta)
+        }
+        CellKind::Assistant { text, .. } => {
+            if text.trim().is_empty() {
+                return (Vec::new(), 0);
+            }
+            (crate::markdown::render(text, theme, width), 0)
+        }
+        CellKind::Tool {
+            request, result, ok, error, ..
+        } => {
+            let body = result.trim_end();
+            let all: Vec<String> = if body.is_empty() {
+                Vec::new()
+            } else {
+                body.lines()
+                    .flat_map(|raw| wrap(raw, width.saturating_sub(2)))
+                    .collect()
+            };
+            let total = all.len();
+            let mut lines: Vec<Line> = Vec::new();
+            let request = if ok.is_none() { request.trim() } else { "" };
+            if !request.is_empty() {
+                let label = "request  ";
+                let request_width = width.saturating_sub(2 + label.width());
+                for (index, line) in
+                    wrap(request, request_width.max(1)).into_iter().take(TOOL_VIEWPORT).enumerate()
+                {
+                    lines.push(Line::from(vec![
+                        Span::styled("│ ".to_string(), Style::default().fg(theme.border)),
+                        Span::styled(
+                            if index == 0 { label } else { "         " }.to_string(),
+                            Style::default().fg(theme.caption),
+                        ),
+                        Span::styled(line, Style::default().fg(theme.fg_tertiary)),
+                    ]));
+                }
+            }
+            if let Some(err) = error {
+                for l in wrap(err, width.saturating_sub(2)) {
+                    lines.push(Line::from(vec![
+                        Span::styled("│ ".to_string(), Style::default().fg(theme.err)),
+                        Span::styled(l, Style::default().fg(theme.err)),
+                    ]));
+                }
+            }
+            if !body.is_empty() {
+                let bar_color = match ok {
+                    Some(false) => theme.err,
+                    _ => theme.border,
+                };
+                if expanded || total <= TOOL_VIEWPORT {
+                    for l in all {
+                        lines.push(Line::from(vec![
+                            Span::styled("│ ".to_string(), Style::default().fg(bar_color)),
+                            Span::styled(l, Style::default().fg(theme.fg_tertiary)),
+                        ]));
+                    }
+                } else {
+                    let offset = total - TOOL_VIEWPORT;
+                    for l in all.into_iter().skip(offset) {
+                        lines.push(Line::from(vec![
+                            Span::styled("│ ".to_string(), Style::default().fg(bar_color)),
+                            Span::styled(l, Style::default().fg(theme.fg_tertiary)),
+                        ]));
+                    }
+                    lines.push(Line::from(vec![
+                        Span::styled("│ ".to_string(), Style::default().fg(bar_color)),
+                        Span::styled(
+                            format!("last {}/{} lines · click to expand", TOOL_VIEWPORT, total),
+                            Style::default().fg(theme.caption),
+                        ),
+                    ]));
+                }
+            }
+            (lines, total)
+        }
+        CellKind::Shell { output, .. } => {
+            let mut lines: Vec<Line> = Vec::new();
+            if let Some((code, text)) = output {
+                let body_w = width.saturating_sub(2);
+                let card_row = |txt: &str, fg: ratatui::style::Color| -> Line<'static> {
+                    let pad = body_w.saturating_sub(unicode_width::UnicodeWidthStr::width(txt));
+                    Line::from(vec![
+                        Span::styled(
+                            "▎ ".to_string(),
+                            Style::default().fg(theme.hint).bg(theme.code_bg),
+                        ),
+                        Span::styled(
+                            format!("{txt}{}", " ".repeat(pad)),
+                            Style::default().fg(fg).bg(theme.code_bg),
+                        ),
+                    ])
+                };
+                let all: Vec<String> = text
+                    .trim_end()
+                    .lines()
+                    .flat_map(|raw| wrap(raw, body_w))
+                    .collect();
+                let total = all.len();
+                let shown = if expanded || total <= COLLAPSED_SHELL_LINES {
+                    all
+                } else {
+                    all.into_iter().take(COLLAPSED_SHELL_LINES).collect()
+                };
+                let shown_len = shown.len();
+                for l in shown {
+                    lines.push(card_row(&l, theme.fg_secondary));
+                }
+                if total > shown_len {
+                    lines.push(card_row(
+                        &format!("… +{} lines (ctrl+o expands)", total - shown_len),
+                        theme.caption,
+                    ));
+                }
+                if let Some(c) = code {
+                    if *c != 0 {
+                        lines.push(card_row(&format!("exit {c}"), theme.err));
+                    }
+                }
+            }
+            (lines, 0)
+        }
+        CellKind::MarkdownNotice { text } => {
+            if text.trim().is_empty() {
+                return (Vec::new(), 0);
+            }
+            (crate::markdown::render(text, theme, width), 0)
+        }
+        _ => (Vec::new(), 0),
     }
 }
 
@@ -284,6 +502,7 @@ impl Transcript {
             if let CellKind::Shell { output: slot, .. } = &mut cell.kind {
                 *slot = Some((code, output));
             }
+            cell.bump();
         }
     }
 
@@ -300,7 +519,7 @@ impl Transcript {
     pub fn cancel_open_work(&mut self) {
         self.settle_open_tools("cancelled");
         for cell in &mut self.cells {
-            match &mut cell.kind {
+            let mutated = match &mut cell.kind {
                 CellKind::Reasoning {
                     done,
                     started,
@@ -309,14 +528,20 @@ impl Transcript {
                 } if !*done => {
                     *done = true;
                     *seconds = Some(started.elapsed().as_secs_f32());
+                    true
                 }
                 CellKind::Assistant { done, .. } if !*done => {
                     *done = true;
+                    true
                 }
                 CellKind::Shell { output, .. } if output.is_none() => {
                     *output = Some((None, "cancelled".into()));
+                    true
                 }
-                _ => {}
+                _ => false,
+            };
+            if mutated {
+                cell.bump();
             }
         }
         self.open_assistant.clear();
@@ -329,20 +554,20 @@ impl Transcript {
     /// `failed` event: the adapter's last reported status remains unchanged.
     fn settle_open_tools(&mut self, reason: &str) {
         for idx in self.tools.values().copied().collect::<Vec<_>>() {
-            if let Some(Cell {
-                kind: CellKind::Tool {
+            if let Some(cell) = self.cells.get_mut(idx) {
+                if let CellKind::Tool {
                     ok, result, error, ..
-                },
-                ..
-            }) = self.cells.get_mut(idx)
-            {
-                if ok.is_none() {
-                    *ok = Some(false);
-                    *error = Some(reason.into());
-                    if result.is_empty() {
-                        *result = reason.into();
+                } = &mut cell.kind
+                {
+                    if ok.is_none() {
+                        *ok = Some(false);
+                        *error = Some(reason.into());
+                        if result.is_empty() {
+                            *result = reason.into();
+                        }
                     }
                 }
+                cell.bump();
             }
         }
         self.tools.clear();
@@ -358,6 +583,7 @@ impl Transcript {
                         // Leave the empty husk; render skips empty finished cells.
                     }
                 }
+                cell.bump();
             }
         }
         if let Some(idx) = self.open_reasoning.remove(session) {
@@ -372,6 +598,7 @@ impl Transcript {
                     *done = true;
                     *seconds = Some(started.elapsed().as_secs_f32());
                 }
+                cell.bump();
             }
         }
     }
@@ -452,6 +679,7 @@ impl Transcript {
                             *done = true;
                             *seconds = Some(started.elapsed().as_secs_f32());
                         }
+                        cell.bump();
                     }
                 }
                 let idx = match self.open_assistant.get(&session) {
@@ -473,6 +701,7 @@ impl Transcript {
                     if let CellKind::Assistant { text: buf, .. } = &mut cell.kind {
                         buf.push_str(&text);
                     }
+                    cell.bump();
                 }
             }
             UiEvent::ReasoningDelta { session, text } => {
@@ -497,6 +726,7 @@ impl Transcript {
                     if let CellKind::Reasoning { text: buf, .. } = &mut cell.kind {
                         buf.push_str(&text);
                     }
+                    cell.bump();
                 }
             }
             UiEvent::ToolCallPreparing { session } => {
@@ -530,6 +760,7 @@ impl Transcript {
                                 *done = true;
                                 *m = model;
                             }
+                            cell.bump();
                         }
                     }
                     None => {
@@ -554,20 +785,19 @@ impl Transcript {
                 self.close_open(&session);
                 let title = tool_title(&name, &arguments);
                 if let Some(&idx) = self.tools.get(&call_id) {
-                    if let Some(Cell {
-                        kind:
-                            CellKind::Tool {
-                                name: current_name,
-                                title: current_title,
-                                request,
-                                ..
-                            },
-                        ..
-                    }) = self.cells.get_mut(idx)
-                    {
-                        *current_name = name;
-                        *current_title = title;
-                        *request = arguments;
+                    if let Some(cell) = self.cells.get_mut(idx) {
+                        if let CellKind::Tool {
+                            name: current_name,
+                            title: current_title,
+                            request,
+                            ..
+                        } = &mut cell.kind
+                        {
+                            *current_name = name;
+                            *current_title = title;
+                            *request = arguments;
+                        }
+                        cell.bump();
                     }
                     return;
                 }
@@ -613,6 +843,7 @@ impl Transcript {
                                 *ok = Some(!is_error);
                                 *e = error;
                             }
+                            cell.bump();
                         }
                     }
                     None => {
@@ -655,12 +886,11 @@ impl Transcript {
             }
             UiEvent::Plan { summary, .. } => {
                 if let Some(idx) = self.plan_cell {
-                    if let Some(Cell {
-                        kind: CellKind::Plan { summary: current },
-                        ..
-                    }) = self.cells.get_mut(idx)
-                    {
-                        *current = summary.clone();
+                    if let Some(cell) = self.cells.get_mut(idx) {
+                        if let CellKind::Plan { summary: current } = &mut cell.kind {
+                            *current = summary.clone();
+                        }
+                        cell.bump();
                     } else {
                         self.plan_cell = None;
                     }
@@ -727,7 +957,7 @@ impl Transcript {
 
     /// Render every cell to wrapped, styled lines for `width` columns.
     #[allow(dead_code)] // kept for tests; the UI uses `layout` for ownership
-    pub fn lines(&self, theme: &Theme, width: u16, spinner: char) -> Vec<Line<'static>> {
+    pub fn lines(&mut self, theme: &Theme, width: u16, spinner: char) -> Vec<Line<'static>> {
         self.layout(theme, width, spinner, false).lines
     }
 
@@ -736,21 +966,35 @@ impl Transcript {
     /// lines claim ownership). `thumbs` reserves blank
     /// lines for kitty-graphics image thumbnails and reports their placements.
     pub fn layout(
-        &self,
+        &mut self,
         theme: &Theme,
         width: u16,
         spinner: char,
         thumbs: bool,
     ) -> TranscriptLayout {
         let width = width.max(8) as usize;
+        let expand_all = self.expand_all;
         let mut out: Vec<Line> = Vec::new();
         let mut owners: Vec<Option<usize>> = Vec::new();
         let mut images: Vec<ImageShot> = Vec::new();
-        for (ci, cell) in self.cells.iter().enumerate() {
+        for (ci, cell) in self.cells.iter_mut().enumerate() {
             if cell.hidden {
                 continue;
             }
-            let expanded = cell.expanded || self.expand_all;
+            let expanded = cell.expanded || expand_all;
+            // Wrap/markdown-heavy kinds paint their body lines from the
+            // per-cell render cache (see `Cell::ensure_render`); headers stay
+            // live so the spinner keeps turning without re-wrapping bodies.
+            if matches!(
+                &cell.kind,
+                CellKind::Reasoning { .. }
+                    | CellKind::Assistant { .. }
+                    | CellKind::Tool { .. }
+                    | CellKind::Shell { .. }
+                    | CellKind::MarkdownNotice { .. }
+            ) {
+                cell.ensure_render(theme, width as u16, expanded, thumbs);
+            }
             match &cell.kind {
                 CellKind::User { text, queued } => {
                     emit(&mut out, &mut owners, Line::default(), None);
@@ -860,27 +1104,19 @@ impl Transcript {
                     }
                 }
                 CellKind::Reasoning {
-                    text,
                     done,
                     started,
                     seconds,
                     agent,
+                    ..
                 } => {
+                    let render = cell.render.as_ref().expect("body cache");
                     emit(&mut out, &mut owners, Line::default(), None);
                     let head_style = Style::default().fg(theme.caption);
-                    let body_style = Style::default()
-                        .fg(theme.fg_tertiary)
-                        .add_modifier(Modifier::ITALIC);
                     // A reasoning stream can open with an empty/whitespace
                     // delta. The heading is enough for that frame; an empty
                     // body must not make its height jump from one row to two.
-                    let body = text.trim();
-                    let lines = if body.is_empty() {
-                        Vec::new()
-                    } else {
-                        wrap(body, width.saturating_sub(2))
-                    };
-                    let n = lines.len();
+                    let n = render.meta;
                     if *done {
                         let dur = seconds.map(|s| format!(" · {s:.1}s")).unwrap_or_default();
                         let agent = agent_prefix(agent);
@@ -894,13 +1130,8 @@ impl Transcript {
                             None,
                         );
                         if expanded {
-                            for l in lines {
-                                emit(
-                                    &mut out,
-                                    &mut owners,
-                                    Line::from(vec![Span::raw("  "), Span::styled(l, body_style)]),
-                                    None,
-                                );
+                            for l in &render.body {
+                                emit(&mut out, &mut owners, l.clone(), None);
                             }
                         }
                     } else {
@@ -917,23 +1148,13 @@ impl Transcript {
                             )),
                             None,
                         );
-                        let tail: Vec<_> = if expanded {
-                            lines
+                        let skip = if expanded {
+                            0
                         } else {
-                            lines
-                                .into_iter()
-                                .rev()
-                                .take(COLLAPSED_REASONING_PREVIEW)
-                                .rev()
-                                .collect()
+                            render.body.len().saturating_sub(COLLAPSED_REASONING_PREVIEW)
                         };
-                        for l in tail {
-                            emit(
-                                &mut out,
-                                &mut owners,
-                                Line::from(vec![Span::raw("  "), Span::styled(l, body_style)]),
-                                None,
-                            );
+                        for l in &render.body[skip..] {
+                            emit(&mut out, &mut owners, l.clone(), None);
                         }
                     }
                 }
@@ -955,39 +1176,31 @@ impl Transcript {
                             None,
                         );
                     }
-                    let mut lines = crate::markdown::render(text, theme, width);
-                    if !done {
+                    let render = cell.render.as_ref().expect("body cache");
+                    for l in &render.body {
+                        emit(&mut out, &mut owners, l.clone(), None);
+                    }
+                    if !done && !render.body.is_empty() {
                         // streaming cursor
-                        if let Some(last) = lines.last_mut() {
+                        if let Some(last) = out.last_mut() {
                             last.spans.push(Span::styled(
                                 "▍".to_string(),
                                 Style::default().fg(theme.brand),
                             ));
                         }
                     }
-                    for l in lines {
-                        emit(&mut out, &mut owners, l, None);
-                    }
                 }
                 CellKind::Tool {
                     name,
                     title,
                     request,
-                    result,
                     ok,
-                    error,
                     agent,
+                    ..
                 } => {
+                    let render = cell.render.as_ref().expect("body cache");
                     emit(&mut out, &mut owners, Line::default(), None);
-                    let body = result.trim_end();
-                    let all: Vec<String> = if body.is_empty() {
-                        Vec::new()
-                    } else {
-                        body.lines()
-                            .flat_map(|raw| wrap(raw, width.saturating_sub(2)))
-                            .collect()
-                    };
-                    let total = all.len();
+                    let total = render.meta;
                     let has_more = total > TOOL_VIEWPORT;
                     let (glyph, gstyle) = match ok {
                         None => (spinner, Style::default().fg(theme.brand)),
@@ -1025,101 +1238,8 @@ impl Transcript {
                     }
                     emit(&mut out, &mut owners, Line::from(spans), Some(ci));
 
-                    if !request.is_empty() {
-                        let label = "request  ";
-                        let request_width = width.saturating_sub(2 + label.width());
-                        let request_lines = wrap(request, request_width.max(1));
-                        for (index, line) in
-                            request_lines.into_iter().take(TOOL_VIEWPORT).enumerate()
-                        {
-                            emit(
-                                &mut out,
-                                &mut owners,
-                                Line::from(vec![
-                                    Span::styled(
-                                        "│ ".to_string(),
-                                        Style::default().fg(theme.border),
-                                    ),
-                                    Span::styled(
-                                        if index == 0 { label } else { "         " }.to_string(),
-                                        Style::default().fg(theme.caption),
-                                    ),
-                                    Span::styled(line, Style::default().fg(theme.fg_tertiary)),
-                                ]),
-                                Some(ci),
-                            );
-                        }
-                    }
-
-                    if let Some(err) = error {
-                        for l in wrap(err, width.saturating_sub(2)) {
-                            emit(
-                                &mut out,
-                                &mut owners,
-                                Line::from(vec![
-                                    Span::styled("│ ".to_string(), Style::default().fg(theme.err)),
-                                    Span::styled(l, Style::default().fg(theme.err)),
-                                ]),
-                                Some(ci),
-                            );
-                        }
-                    }
-
-                    if !body.is_empty() {
-                        let bar_color = match ok {
-                            Some(false) => theme.err,
-                            _ => theme.border,
-                        };
-                        if expanded || total <= TOOL_VIEWPORT {
-                            for l in all {
-                                emit(
-                                    &mut out,
-                                    &mut owners,
-                                    Line::from(vec![
-                                        Span::styled(
-                                            "│ ".to_string(),
-                                            Style::default().fg(bar_color),
-                                        ),
-                                        Span::styled(l, Style::default().fg(theme.fg_tertiary)),
-                                    ]),
-                                    Some(ci),
-                                );
-                            }
-                        } else {
-                            let offset = total - TOOL_VIEWPORT;
-                            for l in &all[offset..offset + TOOL_VIEWPORT] {
-                                emit(
-                                    &mut out,
-                                    &mut owners,
-                                    Line::from(vec![
-                                        Span::styled(
-                                            "│ ".to_string(),
-                                            Style::default().fg(bar_color),
-                                        ),
-                                        Span::styled(
-                                            l.clone(),
-                                            Style::default().fg(theme.fg_tertiary),
-                                        ),
-                                    ]),
-                                    Some(ci),
-                                );
-                            }
-                            emit(
-                                &mut out,
-                                &mut owners,
-                                Line::from(vec![
-                                    Span::styled("│ ".to_string(), Style::default().fg(bar_color)),
-                                    Span::styled(
-                                        format!(
-                                            "last {}/{} lines · click to expand",
-                                            TOOL_VIEWPORT, total
-                                        ),
-                                        Style::default().fg(theme.caption),
-                                    ),
-                                ]),
-                                Some(ci),
-                            );
-                        }
+                    for l in &render.body {
+                        emit(&mut out, &mut owners, l.clone(), Some(ci));
                     }
                 }
                 CellKind::Shell { command, output } => {
@@ -1150,63 +1270,9 @@ impl Transcript {
                         ]),
                         None,
                     );
-                    if let Some((code, text)) = output {
-                        let body_w = width.saturating_sub(2);
-                        let card_row = |txt: &str, fg: ratatui::style::Color| -> Line<'static> {
-                            let pad =
-                                body_w.saturating_sub(unicode_width::UnicodeWidthStr::width(txt));
-                            Line::from(vec![
-                                Span::styled(
-                                    "▎ ".to_string(),
-                                    Style::default().fg(theme.hint).bg(theme.code_bg),
-                                ),
-                                Span::styled(
-                                    format!("{txt}{}", " ".repeat(pad)),
-                                    Style::default().fg(fg).bg(theme.code_bg),
-                                ),
-                            ])
-                        };
-                        let all: Vec<String> = text
-                            .trim_end()
-                            .lines()
-                            .flat_map(|raw| wrap(raw, body_w))
-                            .collect();
-                        let total = all.len();
-                        let shown = if expanded || total <= COLLAPSED_SHELL_LINES {
-                            all
-                        } else {
-                            all.into_iter().take(COLLAPSED_SHELL_LINES).collect()
-                        };
-                        let shown_len = shown.len();
-                        for l in shown {
-                            emit(
-                                &mut out,
-                                &mut owners,
-                                card_row(&l, theme.fg_secondary),
-                                None,
-                            );
-                        }
-                        if total > shown_len {
-                            emit(
-                                &mut out,
-                                &mut owners,
-                                card_row(
-                                    &format!("… +{} lines (ctrl+o expands)", total - shown_len),
-                                    theme.caption,
-                                ),
-                                None,
-                            );
-                        }
-                        if let Some(c) = code {
-                            if *c != 0 {
-                                emit(
-                                    &mut out,
-                                    &mut owners,
-                                    card_row(&format!("exit {c}"), theme.err),
-                                    None,
-                                );
-                            }
-                        }
+                    let render = cell.render.as_ref().expect("body cache");
+                    for l in &render.body {
+                        emit(&mut out, &mut owners, l.clone(), None);
                     }
                 }
                 CellKind::Injected { source, preview } => {
@@ -1269,8 +1335,9 @@ impl Transcript {
                         continue;
                     }
                     emit(&mut out, &mut owners, Line::default(), None);
-                    for l in crate::markdown::render(text, theme, width) {
-                        emit(&mut out, &mut owners, l, None);
+                    let render = cell.render.as_ref().expect("body cache");
+                    for l in &render.body {
+                        emit(&mut out, &mut owners, l.clone(), None);
                     }
                 }
             }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1931,9 +1931,10 @@ fn draw_chat(f: &mut Frame, app: &mut App, area: Rect) {
         Vec::new()
     };
     let thumbs = crate::pet::kitty_supported();
+    let spinner = app.spinner();
     let layout = app
-        .displayed_transcript()
-        .layout(&theme, inner.width, app.spinner(), thumbs);
+        .displayed_transcript_mut()
+        .layout(&theme, inner.width, spinner, thumbs);
     if app.show_banner && lines.len() < inner.height as usize {
         let remaining = inner.height as usize - lines.len();
         let top = remaining / 2;

--- a/tests/unit/transcript__tests.rs
+++ b/tests/unit/transcript__tests.rs
@@ -59,7 +59,7 @@ fn streaming_assistant_keeps_its_cursor_without_a_fallback_loading_icon() {
         text: "starting subagents".into(),
     });
 
-    let rendered = |spinner| {
+    let mut rendered = |spinner| {
         tr.lines(&Theme::dark(), 80, spinner)
             .iter()
             .flat_map(|line| line.spans.iter().map(|span| span.content.as_ref()))


### PR DESCRIPTION
## Problem

`draw_chat` calls `transcript.layout()` on every frame — every event batch, every keystroke, and every 100ms spinner tick while streaming. `layout()` rebuilt the entire transcript from scratch each time:

- every assistant cell re-ran the full markdown pipeline (pulldown-cmark parse → tui-markdown render → two-tone split → wrap)
- every tool result re-wrapped its whole body even while collapsed (just to compute the `+N lines` hint)
- every reasoning cell re-wrapped its full text

Cost grew linearly with conversation size and was paid ~10x/second during streaming, even though only the last cell changes.

## Change

**Per-cell body render cache** (`src/transcript.rs`): cells carry a content `version` bumped at every mutation site (`TextDelta`, `ReasoningDelta`, `AssistantFinal`, `ToolCall`, `ToolResult`, `Plan`, shell/notice helpers, cancel/settle paths). `layout()` now rebuilds only spinner-dependent headers live and clones body lines from a per-cell cache keyed by `(version, width, theme, expanded, thumbs)`. `Theme` is `Copy+Eq`, so key comparison is trivial. Streaming still re-renders the one cell being streamed — the algorithmic floor for markdown.

**Allocation reduction** (`src/markdown.rs`): consume `parsed.lines` by value and move span text out instead of cloning per span; `collapse_autolinks` compacts in place with `drain`; `split_prefix` uses `split_off` instead of double `to_vec`.

User/Image/Injected/Plan/Notice cells stay uncached (bounded, cheap work).

## Verification

- `cargo test`: 518 unit + 4 integration tests green
- `--dump-frame 100x34` output **byte-identical** before/after (no visual regression)
- Temp benchmarks on a 7×7.4KB markdown transcript (debug build, width 76; removed after measuring):

| Scenario | Before | After | Improvement |
|---|---|---|---|
| Idle frame (spinner tick, nothing changed) | 20.4 ms | 1.62 ms | **12.6×** |
| Streaming frame (6 done cells + 1 streaming) | 20.7 ms | 4.78 ms | **4.3×** |
| `markdown::render` single call (22 KB) | 3.09 ms | 2.84 ms | 8% |

Before-side costs grow linearly with history (~100ms+/frame at 40 messages); after-side idle frames stay roughly flat and streaming frames scale only with the message being streamed.

## Notes

- CHANGELOG entry added under `[Unreleased] → Changed`.
- AGENTS.md also gains the build/test/release conventions established in recent work (cargo-guard usage, mold linker fallback for small-RAM OOM, `npm test --prefix npm`, `#[path]` unit-test wiring, three-file version lock) and updates stale `dsh-tui` naming to `martty`.