### PR TITLE
fix(tui): synchronized frame updates; build: resolve devlocalinstall target from profile bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,23 @@ All notable changes to this project are documented here. The project follows
 - `Ctrl+U`, `Ctrl+K`, and the corresponding macOS line-kill shortcut now
   delete only to the current rendered line boundary instead of truncating the
   entire multiline composer draft.
+- The composer caret no longer flickers while the transcript scrolls (agent
+  streaming auto-follow, or scrolling yourself). The caret is now painted as
+  a buffer cell — a steady reversed block that rides the frame diff — and
+  the terminal's hardware cursor stays hidden for the whole session, instead
+  of being hidden for the entire frame write (long during scroll redraws)
+  and re-shown at frame end. Elicitation form fields use the same cell
+  caret; the old hardware-cursor position and the redundant `▏` insert mark
+  are gone. Frames still apply as one synchronized update (DECSET 2026).
+- Image thumbnails and the pixel pet no longer re-send their whole PNG to
+  the terminal on every move: each kitty image is transmitted once under its
+  image id, and viewport scrolls (thumbnails) or composer-height changes and
+  idle↔working toggles (pet) re-place it with a small `a=p` placement
+  command, dropping the previous placement only after the new one exists so
+  nothing blinks out mid-scroll. The pet's ~43KB sprite retransmit on every
+  long-draft wrap boundary is gone. All kitty writers now share one set of
+  protocol primitives, and the pet's screen anchor is recorded by the frame
+  draw itself instead of being recomputed in main.
 
 ## [0.2.24] - 2026-08-24
 

--- a/scripts/devlocalinstall.sh
+++ b/scripts/devlocalinstall.sh
@@ -7,45 +7,72 @@ cd "$(dirname "${BASH_SOURCE[0]}")/.."
 # primary dev profile). Must match the `dsh --profile <name>` you run.
 PROFILE="${1:-${DSH_TUI_PROFILE:-martty}}"
 
-# 1. Build the Rust binary and stage native artifacts into npm/
-./scripts/build-npm.sh
+# 1. The release binary to install; built on demand when missing.
+BIN="target/release/martty"
+if [[ ! -x "$BIN" ]]; then
+  echo "$BIN missing — building (cargo build --release --locked, lto is slow)…" >&2
+  cargo build --release --locked
+fi
 
-# 2. Produce the tarball under the name users install:
-#    `dsh plugin --profile martty add martty@latest` pulls the aliased
-#    `martty` package from npm, so the dev install must be the same shape:
-#    dist/martty-*.tgz. Mirrors CI (package-npm.yml):
-#    package-alias.mjs npm npm-martty martty && npm pack ./npm-martty
-rm -rf npm-martty
-node scripts/package-alias.mjs npm npm-martty martty
-npm pack ./npm-martty --pack-destination dist
-
-# 3. Pick the highest-version tarball in dist/. Version sort (sort -V),
-#    not mtime: a later-built older version must never regress the install.
-shopt -s nullglob
-tgz=(dist/martty-*.tgz)
-if (( ${#tgz[@]} == 0 )); then
-  echo "no tarball in dist/ — did the alias+pack step succeed?" >&2
+# 2. Locate the TUI package installed in the profile: the aliased `martty`
+#    package (current) or the legacy-named @openma/deepseek-harness-tui.
+#    `dsh --profile <name>` runs the package's bin/martty.js, which spawns
+#    vendor/<platform>-<arch>/martty — that vendored file is what we replace.
+PROFILE_DIR="$HOME/.dsh/profiles/$PROFILE"
+PKG_DIR=""
+for candidate in "$PROFILE_DIR/node_modules/martty" \
+                 "$PROFILE_DIR/node_modules/@openma/deepseek-harness-tui"; do
+  if [[ -d "$candidate/vendor" ]]; then
+    PKG_DIR="$candidate"
+    break
+  fi
+done
+if [[ -z "$PKG_DIR" ]]; then
+  echo "no TUI package with a vendor/ dir under $PROFILE_DIR/node_modules" >&2
+  echo "install once first: dsh plugin --profile $PROFILE add martty@latest" >&2
   exit 1
 fi
-LATEST="$(printf '%s\n' "${tgz[@]}" | sort -V | tail -n 1)"
-echo "using tarball: $LATEST"
 
-# 4. Install the freshly built plugin into the target profile.
-#    pnpm re-installs the tarball when its content changes (integrity check);
-#    clearing node_modules + lockfile below is a belt-and-braces force step.
-#    Deliberately NOT wiping the whole profile dir, so the user's
-#    cordis.patch.yml layer and any other installed plugins survive.
-PROFILE_DIR="$HOME/.dsh/profiles/$PROFILE"
-# Note: a missing profile dir is fine — `dsh plugin add` below creates it
-# (with the @deepseek-ai/dsh-base bundle), matching the user flow
-# `dsh plugin --profile martty add martty@latest` on a fresh machine.
-# Drop the legacy-named TUI bundle (@openma/deepseek-harness-tui) if a
-# previous install left it in the profile: `dsh plugin add` would otherwise
-# append `martty` alongside it and mount the TUI twice.
-if grep -q '@openma/deepseek-harness-tui' "$PROFILE_DIR/package.json"; then
-  dsh plugin --profile "$PROFILE" remove '@openma/deepseek-harness-tui'
+# 3. Mirror bin/martty.js's platform key: process.platform + '-' + process.arch.
+case "$(uname -s)" in
+  Linux) platform="linux" ;;
+  Darwin) platform="darwin" ;;
+  *) echo "unsupported OS: $(uname -s)" >&2; exit 1 ;;
+esac
+case "$(uname -m)" in
+  x86_64) arch="x64" ;;
+  aarch64 | arm64) arch="arm64" ;;
+  *) echo "unsupported arch: $(uname -m)" >&2; exit 1 ;;
+esac
+DEST="$PKG_DIR/vendor/$platform-$arch/martty"
+mkdir -p "$(dirname "$DEST")"
+
+# stat flag sets differ between GNU and BSD; birth time is what both report
+# for "created" (GNU prints '-' when the filesystem doesn't track it).
+if stat -c '%w' / >/dev/null 2>&1; then
+  stat_created() { stat -c '%w' "$1"; }
+  stat_modified() { stat -c '%y' "$1"; }
+else
+  stat_created() { stat -f '%SB' "$1"; }
+  stat_modified() { stat -f '%Sm' "$1"; }
 fi
-rm -rf "$PROFILE_DIR/node_modules" "$PROFILE_DIR/pnpm-lock.yaml"
-dsh plugin --profile "$PROFILE" add "$PWD/$LATEST"
 
-echo "installed $LATEST into profile $PROFILE — restart the TUI or run /refresh to pick it up"
+# 4. Replace the binary. Copy to a temp file and rename: cp onto a running
+#    TUI fails with ETXTBSY, while rename(2) just swaps the directory entry.
+#    -p keeps the source's build mtime on the installed file.
+OLD_CREATED="$(stat_created "$DEST")"
+OLD_MODIFIED="$(stat_modified "$DEST")"
+TMP="$DEST.tmp.$$"
+cp -p "$BIN" "$TMP"
+chmod 755 "$TMP"
+mv -f "$TMP" "$DEST"
+NEW_CREATED="$(stat_created "$DEST")"
+NEW_MODIFIED="$(stat_modified "$DEST")"
+
+if [[ -n "${MARTTY_BIN:-}${DSH_TUI_BIN:-}" ]]; then
+  echo "note: MARTTY_BIN/DSH_TUI_BIN is set — bin/martty.js prefers that override over this copy." >&2
+fi
+echo "installed $BIN -> $DEST (profile $PROFILE)"
+echo "old file: created $OLD_CREATED · modified $OLD_MODIFIED"
+echo "new file: created $NEW_CREATED · modified $NEW_MODIFIED"
+echo "restart the TUI or run /refresh to pick it up"

--- a/scripts/devlocalinstall.sh
+++ b/scripts/devlocalinstall.sh
@@ -7,48 +7,117 @@ cd "$(dirname "${BASH_SOURCE[0]}")/.."
 # primary dev profile). Must match the `dsh --profile <name>` you run.
 PROFILE="${1:-${DSH_TUI_PROFILE:-martty}}"
 
-# 1. The release binary to install; built on demand when missing.
+# 1. Build the release binary first so the installed copy always reflects
+#    the current source (cargo build --release --locked; lto is slow).
 BIN="target/release/martty"
-if [[ ! -x "$BIN" ]]; then
-  echo "$BIN missing — building (cargo build --release --locked, lto is slow)…" >&2
-  cargo build --release --locked
-fi
+echo "building $BIN (cargo build --release --locked, lto is slow)…" >&2
+cargo build --release --locked
 
-# 2. Locate the TUI package installed in the profile: the aliased `martty`
-#    package (current) or the legacy-named @openma/deepseek-harness-tui.
-#    `dsh --profile <name>` runs the package's bin/martty.js, which spawns
-#    vendor/<platform>-<arch>/martty — that vendored file is what we replace.
-PROFILE_DIR="$HOME/.dsh/profiles/$PROFILE"
-PKG_DIR=""
-for candidate in "$PROFILE_DIR/node_modules/martty" \
-                 "$PROFILE_DIR/node_modules/@openma/deepseek-harness-tui"; do
-  if [[ -d "$candidate/vendor" ]]; then
-    PKG_DIR="$candidate"
-    break
-  fi
-done
-if [[ -z "$PKG_DIR" ]]; then
-  echo "no TUI package with a vendor/ dir under $PROFILE_DIR/node_modules" >&2
-  echo "install once first: dsh plugin --profile $PROFILE add martty@latest" >&2
+# 2. Resolve exactly the binary `dsh --profile $PROFILE` runs — no hardcoded
+#    package names or home dirs:
+#      * the profile dir is $DSH_HOME/profiles/<name> (dsh defaults DSH_HOME
+#        to ~/.dsh)
+#      * the TUI package is the bundle in the profile's package.json
+#        `dsh.profile.bundles` whose `bin` maps martty/dsh-tui to a script
+#      * bin/martty.js spawns that package's vendor/<platform>-<arch>/martty,
+#        unless MARTTY_BIN/DSH_TUI_BIN points at an existing file (it wins)
+RESOLVED_FILE="$(mktemp)"
+trap 'rm -f "$RESOLVED_FILE"' EXIT
+DSH_TUI_INSTALL_PROFILE="$PROFILE" node --input-type=module > "$RESOLVED_FILE" <<'EOF'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+const profile = process.env.DSH_TUI_INSTALL_PROFILE
+const profileDir = path.join(
+  process.env.DSH_HOME || path.join(os.homedir(), '.dsh'),
+  'profiles',
+  profile,
+)
+const out = { profileDir, candidates: [] }
+
+// Legacy fallback names for profiles that install the TUI without declaring
+// it in dsh.profile.bundles.
+const LEGACY = ['martty', '@openma/deepseek-harness-tui']
+
+let bundles = null
+try {
+  bundles = JSON.parse(
+    fs.readFileSync(path.join(profileDir, 'package.json'), 'utf8'),
+  ).dsh?.profile?.bundles ?? null
+} catch {
+  // no profile manifest — fall through to the legacy names
+}
+
+const platformKey = `${process.platform}-${process.arch}`
+const exe = process.platform === 'win32' ? 'martty.exe' : 'martty'
+const names = [...new Set([...(bundles ?? []), ...LEGACY])]
+
+for (const name of names) {
+  const pkgDir = path.join(profileDir, 'node_modules', name)
+  let pkg
+  try {
+    pkg = JSON.parse(fs.readFileSync(path.join(pkgDir, 'package.json'), 'utf8'))
+  } catch {
+    continue // bundle not installed
+  }
+  const bin = pkg.bin
+  const binScript = typeof bin === 'string' ? bin : bin?.['martty'] ?? bin?.['dsh-tui']
+  if (typeof binScript !== 'string' || !binScript.length) continue
+  out.candidates.push({
+    name,
+    pkgDir,
+    binScript: path.join(pkgDir, binScript),
+    dest: path.join(pkgDir, 'vendor', platformKey, exe),
+  })
+}
+
+if (out.candidates.length === 0) {
+  out.error =
+    `no TUI package (bin martty/dsh-tui) under ${path.join(profileDir, 'node_modules')}; ` +
+    `install once first: dsh plugin --profile ${profile} add martty@latest`
+} else if (out.candidates.length === 1) {
+  out.pick = out.candidates[0]
+} else {
+  // Several bundles ship a martty bin (e.g. current + legacy alias): prefer
+  // the one that already staged a vendor binary for this platform.
+  const staged = out.candidates.filter((c) => fs.existsSync(c.dest))
+  out.pick = staged.length === 1 ? staged[0] : out.candidates[0]
+}
+
+// bin/martty.js precedence: MARTTY_BIN/DSH_TUI_BIN override the packaged copy
+// only when set to an existing file.
+const envBin = process.env.MARTTY_BIN || process.env.DSH_TUI_BIN
+if (typeof envBin === 'string' && envBin.length > 0) {
+  out.envBin = envBin
+  out.envOverrideActive = fs.existsSync(envBin)
+}
+
+process.stdout.write(JSON.stringify(out, null, 2))
+EOF
+
+field() { node -p "JSON.parse(require('fs').readFileSync(process.argv[1], 'utf8'))$1" "$RESOLVED_FILE"; }
+
+ERROR="$(field '.error || ""')"
+if [[ -n "$ERROR" ]]; then
+  echo "$ERROR" >&2
   exit 1
 fi
 
-# 3. Mirror bin/martty.js's platform key: process.platform + '-' + process.arch.
-case "$(uname -s)" in
-  Linux) platform="linux" ;;
-  Darwin) platform="darwin" ;;
-  *) echo "unsupported OS: $(uname -s)" >&2; exit 1 ;;
-esac
-case "$(uname -m)" in
-  x86_64) arch="x64" ;;
-  aarch64 | arm64) arch="arm64" ;;
-  *) echo "unsupported arch: $(uname -m)" >&2; exit 1 ;;
-esac
-DEST="$PKG_DIR/vendor/$platform-$arch/martty"
-mkdir -p "$(dirname "$DEST")"
+DEST="$(field '.pick.dest')"
+PKG_DIR="$(field '.pick.pkgDir')"
+BUNDLE="$(field '.pick.name')"
+if [[ "$(field '.envOverrideActive || false')" == "true" ]]; then
+  echo "dsh --profile $PROFILE does not use the packaged binary: MARTTY_BIN/DSH_TUI_BIN is set to" >&2
+  echo "  $(field '.envBin')" >&2
+  echo "unset MARTTY_BIN DSH_TUI_BIN (or point them at $BIN) and rerun." >&2
+  exit 1
+fi
 
-# stat flag sets differ between GNU and BSD; birth time is what both report
-# for "created" (GNU prints '-' when the filesystem doesn't track it).
+# 3. Replace the binary. Copy to a temp file and rename: cp onto a running
+#    TUI fails with ETXTBSY, while rename(2) just swaps the directory entry.
+#    -p keeps the source's build mtime on the installed file.
+mkdir -p "$(dirname "$DEST")"
 if stat -c '%w' / >/dev/null 2>&1; then
   stat_created() { stat -c '%w' "$1"; }
   stat_modified() { stat -c '%y' "$1"; }
@@ -56,23 +125,31 @@ else
   stat_created() { stat -f '%SB' "$1"; }
   stat_modified() { stat -f '%Sm' "$1"; }
 fi
-
-# 4. Replace the binary. Copy to a temp file and rename: cp onto a running
-#    TUI fails with ETXTBSY, while rename(2) just swaps the directory entry.
-#    -p keeps the source's build mtime on the installed file.
-OLD_CREATED="$(stat_created "$DEST")"
-OLD_MODIFIED="$(stat_modified "$DEST")"
+# sha256 availability differs between GNU coreutils (sha256sum) and BSD/macOS (shasum).
+if command -v sha256sum >/dev/null 2>&1; then
+  sha256() { sha256sum "$1" | awk '{print $1}'; }
+else
+  sha256() { shasum -a 256 "$1" | awk '{print $1}'; }
+fi
+if [[ -e "$DEST" ]]; then
+  OLD_CREATED="$(stat_created "$DEST")"
+  OLD_MODIFIED="$(stat_modified "$DEST")"
+  OLD_SHA256="$(sha256 "$DEST")"
+else
+  OLD_CREATED="(absent)"
+  OLD_MODIFIED="(absent)"
+  OLD_SHA256="(absent)"
+fi
 TMP="$DEST.tmp.$$"
 cp -p "$BIN" "$TMP"
 chmod 755 "$TMP"
 mv -f "$TMP" "$DEST"
 NEW_CREATED="$(stat_created "$DEST")"
 NEW_MODIFIED="$(stat_modified "$DEST")"
+NEW_SHA256="$(sha256 "$DEST")"
 
-if [[ -n "${MARTTY_BIN:-}${DSH_TUI_BIN:-}" ]]; then
-  echo "note: MARTTY_BIN/DSH_TUI_BIN is set — bin/martty.js prefers that override over this copy." >&2
-fi
-echo "installed $BIN -> $DEST (profile $PROFILE)"
-echo "old file: created $OLD_CREATED · modified $OLD_MODIFIED"
-echo "new file: created $NEW_CREATED · modified $NEW_MODIFIED"
+echo "installed $BIN -> $DEST"
+echo "profile: $PROFILE ($(field '.profileDir')) · bundle: $BUNDLE"
+echo "old martty: sha256 $OLD_SHA256 · created $OLD_CREATED · modified $OLD_MODIFIED"
+echo "new martty: sha256 $NEW_SHA256 · created $NEW_CREATED · modified $NEW_MODIFIED"
 echo "restart the TUI or run /refresh to pick it up"

--- a/src/app.rs
+++ b/src/app.rs
@@ -984,6 +984,10 @@ pub struct App {
     /// True when the terminal speaks the kitty graphics protocol: image
     /// thumbnails and the background layer emit real pixels (set by `main`).
     pub pet_pixels: bool,
+    /// The pet sprite the frame just drew around: cell box + working flag.
+    /// Filled by `ui::draw` (the layout math lives there — one source of
+    /// truth), reconciled against the terminal by `main` after the frame.
+    pub pet_want: Option<(ratatui::layout::Rect, bool)>,
     /// Current git branch of the workspace, shown after the project path in
     /// the composer cap when git is available and the terminal is wide
     /// enough. Seeded at startup, then re-checked on a throttled tick and
@@ -1379,6 +1383,7 @@ impl App {
             show_banner: true,
             pet_visible: false,
             pet_pixels: false,
+            pet_want: None,
             git_branch: None,
             git_check_at: Instant::now(),
             run_started: None,

--- a/src/input/composer.rs
+++ b/src/input/composer.rs
@@ -588,7 +588,7 @@ impl ComposerEditor {
     /// relative to the *start of the text* (row 0), not the viewport.
     /// Requires the widget to have been rendered (or edited) at least
     /// once so its screen map matches the current area.
-    pub fn screen_cursor(&self) -> (usize, usize) {
+    fn screen_cursor(&self) -> (usize, usize) {
         let sc = self.textarea.screen_cursor();
         (sc.row, sc.col)
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -427,36 +427,23 @@ fn main() -> Result<()> {
         loop {
             if app.needs_redraw {
                 // One atomic frame. Synchronized updates (DECSET 2026) make
-                // supporting terminals apply the whole frame without tearing;
-                // the pre-draw Hide keeps the hardware cursor from teleporting
-                // across the buffer diff while it is applied (ratatui re-shows
-                // it at the input position at frame end). On terminals without
-                // 2026 both sequences are ignored and the Hide still prevents
-                // the visible cursor jumps.
+                // supporting terminals apply the whole frame without tearing.
+                // The caret itself is painted as buffer cells (ui::paint_caret)
+                // and the hardware cursor stays hidden for the whole session
+                // (enter_tui), so no frame-time Hide/Show is needed — the old
+                // per-frame Hide kept the cursor off for the entire diff
+                // write, which read as flicker in the input well whenever a
+                // scroll redraw rewrote the transcript pane.
                 std::io::stdout().sync_update(|out| -> Result<()> {
-                    execute!(out, Hide)?;
                     terminal.draw(|f| ui::draw(f, &mut app))?;
                     app.needs_redraw = false;
-                    // Reconcile the pixel pet (frame + state) with what was drawn.
+                    // Reconcile the kitty pixel layers against the freshly
+                    // drawn frame: backdrop, pet (anchor recorded by
+                    // ui::draw) and the visible image thumbnails.
                     let size = terminal.size()?;
                     let area = ratatui::layout::Rect::new(0, 0, size.width, size.height);
                     let _ = backdrop.sync(out, app.active_background(), area);
-                    let working = !matches!(app.state, RunState::Idle);
-                    // Same anchor math as ui::draw: the pet sits inside the
-                    // composer box, above navigation and stats docks when shown.
-                    let dock_h =
-                        ui::composer_dock_height(&app, area.height, app.active_subagent.is_some());
-                    let navigation_h = ui::navigation_dock_height(&app, area.height);
-                    let pet_area = ratatui::layout::Rect::new(
-                        0,
-                        0,
-                        size.width,
-                        size.height.saturating_sub(dock_h + navigation_h),
-                    );
-                    let want = ui::pet_rect(pet_area, &app).map(|r| (r, working));
-                    let _ = pet.sync(out, want);
-                    // Sync image thumbnails (chat + composer attachment strip)
-                    // against the freshly drawn viewport.
+                    let _ = pet.sync(out, app.pet_want);
                     let shots: Vec<pet::ThumbShot> = app
                         .chat_view
                         .images
@@ -536,9 +523,12 @@ fn main() -> Result<()> {
 fn enter_tui() -> Result<()> {
     enable_raw_mode()?;
     let mut stdout = std::io::stdout();
+    // Hide once up front: the caret is drawn as buffer cells, and the first
+    // frame's diff must not paint with a visible hardware cursor.
     execute!(
         stdout,
         EnterAlternateScreen,
+        Hide,
         EnableMouseCapture,
         EnableBracketedPaste
     )?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,14 +32,17 @@ use std::sync::mpsc;
 use std::time::Duration;
 
 use anyhow::{bail, Context, Result};
+use crossterm::cursor::{Hide, Show};
 use crossterm::event::{
     DisableBracketedPaste, DisableMouseCapture, EnableBracketedPaste, EnableMouseCapture,
     KeyboardEnhancementFlags, PopKeyboardEnhancementFlags, PushKeyboardEnhancementFlags,
 };
 use crossterm::execute;
 use crossterm::terminal::{
-    disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen,
+    disable_raw_mode, enable_raw_mode, EnterAlternateScreen, EndSynchronizedUpdate,
+    LeaveAlternateScreen,
 };
+use crossterm::SynchronizedUpdate;
 
 use crate::app::{App, RunState};
 use crate::bus::{AppEvent, Cmd};
@@ -423,40 +426,51 @@ fn main() -> Result<()> {
         let mut last_tick = std::time::Instant::now();
         loop {
             if app.needs_redraw {
-                terminal.draw(|f| ui::draw(f, &mut app))?;
-                app.needs_redraw = false;
-                // Reconcile the pixel pet (frame + state) with what was drawn.
-                let size = terminal.size()?;
-                let area = ratatui::layout::Rect::new(0, 0, size.width, size.height);
-                let _ = backdrop.sync(&mut std::io::stdout(), app.active_background(), area);
-                let working = !matches!(app.state, RunState::Idle);
-                // Same anchor math as ui::draw: the pet sits inside the
-                // composer box, above navigation and stats docks when shown.
-                let dock_h =
-                    ui::composer_dock_height(&app, area.height, app.active_subagent.is_some());
-                let navigation_h = ui::navigation_dock_height(&app, area.height);
-                let pet_area = ratatui::layout::Rect::new(
-                    0,
-                    0,
-                    size.width,
-                    size.height.saturating_sub(dock_h + navigation_h),
-                );
-                let want = ui::pet_rect(pet_area, &app).map(|r| (r, working));
-                let _ = pet.sync(&mut std::io::stdout(), want);
-                // Sync image thumbnails (chat + composer attachment strip)
-                // against the freshly drawn viewport.
-                let shots: Vec<pet::ThumbShot> = app
-                    .chat_view
-                    .images
-                    .iter()
-                    .chain(app.att_thumbs.iter())
-                    .map(|t| pet::ThumbShot {
-                        id: t.id,
-                        rect: t.rect,
-                        data: t.data.as_ref(),
-                    })
-                    .collect();
-                let _ = thumbnails.sync(&mut std::io::stdout(), &shots);
+                // One atomic frame. Synchronized updates (DECSET 2026) make
+                // supporting terminals apply the whole frame without tearing;
+                // the pre-draw Hide keeps the hardware cursor from teleporting
+                // across the buffer diff while it is applied (ratatui re-shows
+                // it at the input position at frame end). On terminals without
+                // 2026 both sequences are ignored and the Hide still prevents
+                // the visible cursor jumps.
+                std::io::stdout().sync_update(|out| -> Result<()> {
+                    execute!(out, Hide)?;
+                    terminal.draw(|f| ui::draw(f, &mut app))?;
+                    app.needs_redraw = false;
+                    // Reconcile the pixel pet (frame + state) with what was drawn.
+                    let size = terminal.size()?;
+                    let area = ratatui::layout::Rect::new(0, 0, size.width, size.height);
+                    let _ = backdrop.sync(out, app.active_background(), area);
+                    let working = !matches!(app.state, RunState::Idle);
+                    // Same anchor math as ui::draw: the pet sits inside the
+                    // composer box, above navigation and stats docks when shown.
+                    let dock_h =
+                        ui::composer_dock_height(&app, area.height, app.active_subagent.is_some());
+                    let navigation_h = ui::navigation_dock_height(&app, area.height);
+                    let pet_area = ratatui::layout::Rect::new(
+                        0,
+                        0,
+                        size.width,
+                        size.height.saturating_sub(dock_h + navigation_h),
+                    );
+                    let want = ui::pet_rect(pet_area, &app).map(|r| (r, working));
+                    let _ = pet.sync(out, want);
+                    // Sync image thumbnails (chat + composer attachment strip)
+                    // against the freshly drawn viewport.
+                    let shots: Vec<pet::ThumbShot> = app
+                        .chat_view
+                        .images
+                        .iter()
+                        .chain(app.att_thumbs.iter())
+                        .map(|t| pet::ThumbShot {
+                            id: t.id,
+                            rect: t.rect,
+                            data: t.data.as_ref(),
+                        })
+                        .collect();
+                    let _ = thumbnails.sync(out, &shots);
+                    Ok(())
+                })??;
             }
             match bus_rx.recv_timeout(Duration::from_millis(50)) {
                 Ok(ev) => {
@@ -572,6 +586,8 @@ fn restore_terminal() {
     let _ = execute!(stdout, PopKeyboardEnhancementFlags);
     let _ = execute!(
         stdout,
+        Show,
+        EndSynchronizedUpdate,
         DisableBracketedPaste,
         DisableMouseCapture,
         LeaveAlternateScreen

--- a/src/pet.rs
+++ b/src/pet.rs
@@ -50,59 +50,75 @@ pub fn kitty_supported() -> bool {
     })
 }
 
-/// What's on screen: the sprite's cell box and whether he's working.
-type Shown = (Rect, bool);
+/// The two sprite states: (kitty image id, PNG), indexed by `working`.
+const SPRITES: [(u32, &[u8]); 2] = [(ID_IDLE, LIANG_IDLE_PNG), (ID_WORKING, LIANG_WORKING_PNG)];
 
-/// Reconciles the desired sprite with what the terminal displays.
+/// What the terminal currently displays for one placement: the cell box and
+/// the kitty placement id showing it. The PNG itself is transmitted once
+/// under its image id — moves and state toggles only re-place it.
+#[derive(Clone, Copy)]
+struct Placed {
+    rect: Rect,
+    placement: u32,
+}
+
+/// Reconciles the desired sprite with what the terminal displays. Each
+/// sprite PNG is transmitted once; moving (the composer growing with a long
+/// draft) and idle↔working toggles only re-place it, a few bytes each.
 pub struct Pet {
     enabled: bool,
-    shown: Option<Shown>,
+    transmitted: [bool; SPRITES.len()],
+    shown: Option<(usize, Placed)>,
 }
 
 impl Pet {
     pub fn new(enabled: bool) -> Self {
         Pet {
             enabled,
+            transmitted: [false; SPRITES.len()],
             shown: None,
         }
     }
 
     /// Make the terminal match `want` (cell box + working flag, or None to
     /// hide). Idempotent and zero-cost when nothing changed.
-    pub fn sync(&mut self, out: &mut impl Write, want: Option<Shown>) -> io::Result<()> {
-        if !self.enabled || self.shown == want {
+    pub fn sync(&mut self, out: &mut impl Write, want: Option<(Rect, bool)>) -> io::Result<()> {
+        if !self.enabled {
             return Ok(());
         }
-        if let Some((_, was_working)) = self.shown.take() {
-            let id = if was_working { ID_WORKING } else { ID_IDLE };
-            write!(out, "\x1b_Ga=d,d=I,i={id},q=2\x1b\\")?;
+        let desired = want.map(|(rect, working)| (usize::from(working), rect));
+        if self.shown.as_ref().map(|(image, placed)| (*image, placed.rect)) == desired {
+            return Ok(());
         }
-        if let Some((cell, working)) = want {
-            let (id, png) = if working {
-                (ID_WORKING, LIANG_WORKING_PNG)
-            } else {
-                (ID_IDLE, LIANG_IDLE_PNG)
-            };
-            // DECSC · jump to the cell · transmit-and-display · DECRC.
-            write!(out, "\x1b7\x1b[{};{}H", cell.y + 1, cell.x + 1)?;
-            let data = base64(png);
-            let chunks: Vec<&[u8]> = data.as_bytes().chunks(CHUNK).collect();
-            for (i, chunk) in chunks.iter().enumerate() {
-                let more = u8::from(i + 1 != chunks.len());
-                if i == 0 {
-                    write!(
-                        out,
-                        "\x1b_Ga=T,f=100,i={id},c={},r={},C=1,z=0,q=2,m={more};",
-                        cell.width, cell.height
-                    )?;
-                } else {
-                    write!(out, "\x1b_Gm={more};")?;
-                }
-                out.write_all(chunk)?;
-                write!(out, "\x1b\\")?;
+        if let Some((image, rect)) = desired {
+            if !self.transmitted[image] {
+                let (id, png) = SPRITES[image];
+                transmit_kitty(out, id, png)?;
+                self.transmitted[image] = true;
             }
-            write!(out, "\x1b8")?;
-            self.shown = Some((cell, working));
+            // Place the (possibly just transmitted) sprite at the new cell
+            // before dropping the old placement, so the pet never blinks
+            // out between frames.
+            let next = match self.shown {
+                Some((old_image, placed)) if old_image == image => {
+                    placed.placement.wrapping_add(1).max(1)
+                }
+                _ => 1,
+            };
+            place_kitty(out, SPRITES[image].0, next, rect, 0)?;
+            if let Some((old_image, old)) =
+                self.shown.replace((image, Placed { rect, placement: next }))
+            {
+                delete_placement_kitty(out, SPRITES[old_image].0, old.placement)?;
+            }
+        } else if self.shown.take().is_some() {
+            // Hide: drop both sprites' data and placements (deleting an id
+            // that was never transmitted is a harmless no-op) and forget
+            // the transmission state, so a re-show retransmits.
+            for (id, _) in SPRITES {
+                delete_kitty(out, id)?;
+            }
+            self.transmitted = [false; SPRITES.len()];
         }
         out.flush()
     }
@@ -127,10 +143,14 @@ pub struct ThumbShot<'a> {
 }
 
 /// Keeps kitty-graphics thumbnail placements in sync with the visible chat
-/// viewport: emit when new/moved, delete when scrolled away.
+/// viewport: emit when new, re-place when scrolled, delete when scrolled
+/// away. Placement moves are a few bytes (`a=p` re-uses the transmitted
+/// image); a full retransmit only ever happens on first sight. Scrolling the
+/// transcript used to delete and re-send the entire PNG on every step, which
+/// stalled the frame write and blinked the composer caret.
 #[derive(Default)]
 pub struct Thumbnails {
-    shown: std::collections::HashMap<u32, Rect>,
+    shown: std::collections::HashMap<u32, Placed>,
 }
 
 impl Thumbnails {
@@ -143,12 +163,39 @@ impl Thumbnails {
         let mut ids = HashSet::new();
         for shot in visible {
             ids.insert(shot.id);
-            if self.shown.get(&shot.id) != Some(&shot.rect) {
-                if self.shown.remove(&shot.id).is_some() {
-                    delete_kitty(out, shot.id)?;
+            match self.shown.get(&shot.id).copied() {
+                Some(shown) if shown.rect == shot.rect => {}
+                Some(shown) => {
+                    // Moved (viewport scrolled): place the already
+                    // transmitted image at the new cell, then drop the old
+                    // placement — place first, so the thumbnail never
+                    // blinks out between frames.
+                    let next = shown.placement.wrapping_add(1).max(1);
+                    place_kitty(out, shot.id, next, shot.rect, 0)?;
+                    delete_placement_kitty(out, shot.id, shown.placement)?;
+                    self.shown.insert(
+                        shot.id,
+                        Placed {
+                            rect: shot.rect,
+                            placement: next,
+                        },
+                    );
                 }
-                emit_kitty(out, shot.id, shot.data, shot.rect, 0)?;
-                self.shown.insert(shot.id, shot.rect);
+                None => {
+                    // First sight: transmit the PNG under the image id and
+                    // create placement 1. Transmit (a=t) and placement
+                    // (a=p) stay separate so every placement is one we
+                    // track and can delete by id.
+                    transmit_kitty(out, shot.id, shot.data)?;
+                    place_kitty(out, shot.id, 1, shot.rect, 0)?;
+                    self.shown.insert(
+                        shot.id,
+                        Placed {
+                            rect: shot.rect,
+                            placement: 1,
+                        },
+                    );
+                }
             }
         }
         let gone: Vec<u32> = self
@@ -165,31 +212,45 @@ impl Thumbnails {
     }
 }
 
-fn emit_kitty(
-    out: &mut impl Write,
-    id: u32,
-    data: &[u8],
-    cell: Rect,
-    z_index: i32,
-) -> io::Result<()> {
-    write!(out, "\x1b7\x1b[{};{}H", cell.y + 1, cell.x + 1)?;
+/// Upload the PNG under `id` without displaying it.
+fn transmit_kitty(out: &mut impl Write, id: u32, data: &[u8]) -> io::Result<()> {
     let b64 = base64(data);
     let chunks: Vec<&[u8]> = b64.as_bytes().chunks(CHUNK).collect();
     for (i, chunk) in chunks.iter().enumerate() {
         let more = u8::from(i + 1 != chunks.len());
         if i == 0 {
-            write!(
-                out,
-                "\x1b_Ga=T,f=100,i={id},c={},r={},C=1,z={z_index},q=2,m={more};",
-                cell.width, cell.height,
-            )?;
+            write!(out, "\x1b_Ga=t,f=100,i={id},q=2,m={more};")?;
         } else {
             write!(out, "\x1b_Gm={more};")?;
         }
         out.write_all(chunk)?;
         write!(out, "\x1b\\")?;
     }
-    write!(out, "\x1b8")
+    Ok(())
+}
+
+/// Create one placement of an already-transmitted image at `cell`.
+fn place_kitty(
+    out: &mut impl Write,
+    id: u32,
+    placement: u32,
+    cell: Rect,
+    z: i32,
+) -> io::Result<()> {
+    // DECSC · jump to the cell · place · DECRC.
+    write!(
+        out,
+        "\x1b7\x1b[{};{}H\x1b_Ga=p,i={id},p={placement},c={},r={},C=1,z={z},q=2\x1b\\\x1b8",
+        cell.y + 1,
+        cell.x + 1,
+        cell.width,
+        cell.height
+    )
+}
+
+/// Drop one placement (the image data stays transmitted and re-placeable).
+fn delete_placement_kitty(out: &mut impl Write, id: u32, placement: u32) -> io::Result<()> {
+    write!(out, "\x1b_Ga=d,d=p,i={id},p={placement},q=2\x1b\\")
 }
 
 const BACKDROP_ID: u32 = 4210;
@@ -240,7 +301,8 @@ impl Backdrop {
             };
             let placement = backdrop_rect(&background, dimensions, rect);
             let data = prepare_background(data, &background, rect)?;
-            emit_kitty(out, BACKDROP_ID, &data, placement, -1)?;
+            transmit_kitty(out, BACKDROP_ID, &data)?;
+            place_kitty(out, BACKDROP_ID, 1, placement, -1)?;
             self.shown = Some((background, rect));
         }
         out.flush()

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -57,7 +57,7 @@ fn resolved_composer_height(area: Rect, app: &App) -> u16 {
 /// Height of the composer stats dock row: 1 when it fits and the stats slot is
 /// mounted, even before it has data; else 0. Shared by the frame layout and
 /// the kitty pixel sync so the pet anchors to the box bottom in both places.
-pub fn composer_dock_height(app: &App, main_height: u16, child_view: bool) -> u16 {
+fn composer_dock_height(app: &App, main_height: u16, child_view: bool) -> u16 {
     if !child_view
         && main_height >= 20 + navigation_dock_height(app, main_height)
         && app
@@ -73,7 +73,7 @@ pub fn composer_dock_height(app: &App, main_height: u16, child_view: bool) -> u1
 /// One compact session-navigation row inside the composer, immediately above
 /// its meta row. A Client Plugin snapshot wins; the native Agent rail is only
 /// the no-Client-tree fallback.
-pub fn navigation_dock_height(app: &App, main_height: u16) -> u16 {
+fn navigation_dock_height(app: &App, main_height: u16) -> u16 {
     if main_height >= 8
         && (slot_has_nodes(app, "conversation.navigation.dock") || !app.subagents.is_empty())
     {
@@ -122,7 +122,7 @@ fn input_dock_body_height(app: &App, main_width: u16, main_height: u16, child_vi
 /// of the rounded border), matching the sprite's 192:208 aspect in 1:2
 /// cells. None hides it (`/liang` off, or the terminal is too cramped to
 /// give up columns).
-pub fn pet_rect(area: Rect, app: &App) -> Option<Rect> {
+fn pet_rect(area: Rect, app: &App) -> Option<Rect> {
     if !app.pet_visible || area.width < 60 || area.height < 10 {
         return None;
     }
@@ -140,6 +140,7 @@ pub fn draw(f: &mut Frame, app: &mut App) {
     let area = f.area();
     let theme = app.theme;
     app.slot_actions.clear();
+    app.pet_want = None;
     f.render_widget(
         Block::default().style(
             Style::default()
@@ -263,7 +264,9 @@ pub fn draw(f: &mut Frame, app: &mut App) {
     }
     // The pet floats inside the box's bottom-right; composer text keeps
     // clear of it. Anchor to the box's bottom — when the stats dock sits
-    // below the box, the pet rides up with it instead of overlapping.
+    // below the box, the pet rides up with it instead of overlapping. The
+    // anchor is recorded for main()'s kitty reconciler (single source of
+    // truth for the pet's place — no duplicated dock math there).
     let pet = if child_view {
         None
     } else {
@@ -275,6 +278,10 @@ pub fn draw(f: &mut Frame, app: &mut App) {
         );
         pet_rect(pet_area, app)
     };
+    if app.pet_pixels {
+        let working = !matches!(app.state, RunState::Idle);
+        app.pet_want = pet.map(|rect| (rect, working));
+    }
     let pet_pad = if pet.is_some() { PET_PAD } else { 0 };
     if child_view {
         draw_child_navigation(f, app, composer);
@@ -2374,6 +2381,28 @@ fn draw_attachment_preview(f: &mut Frame, app: &mut App, composer: Rect, screen:
     }
 }
 
+/// The caret rendered as buffer cells instead of the terminal's hardware
+/// cursor: a steady reversed block that moves atomically with the frame
+/// diff. The hardware cursor had to be hidden for the whole diff write and
+/// re-shown at frame end, so any scroll-heavy redraw (streaming auto-follow,
+/// user scrolling) held it off long enough to blink the input caret; as
+/// buffer cells it can never flicker or teleport, and the terminal cursor
+/// stays hidden for the whole session. Wide graphemes cover both cells.
+fn paint_caret(f: &mut Frame, x: u16, y: u16) {
+    let buf = f.buffer_mut();
+    let style = Style::default().add_modifier(Modifier::REVERSED);
+    let Some(cell) = buf.cell_mut((x, y)) else {
+        return;
+    };
+    let wide = UnicodeWidthStr::width(cell.symbol()) > 1;
+    cell.set_style(style);
+    if wide {
+        if let Some(cell) = buf.cell_mut((x + 1, y)) {
+            cell.set_style(style);
+        }
+    }
+}
+
 /// The input well. Long prompts wrap across the (now taller) well, and the
 /// cursor follows the wrap; `/` and `!` prefixes recolor the whole line.
 /// Inline `[image n]` tokens render as chips (no icon — the token itself is
@@ -2381,8 +2410,8 @@ fn draw_attachment_preview(f: &mut Frame, app: &mut App, composer: Rect, screen:
 ///
 /// The draft itself is a `ratatui-textarea` widget rendered in the columns
 /// right of the prompt; the wrap layout mirror (`ComposerEditor::layout`)
-/// drives chip restyling, the drag-selection highlight, and the terminal
-/// cursor, and `ComposerEditor::update_scroll_top` keeps the mirrored
+/// drives chip restyling, the drag-selection highlight, and the caret cell,
+/// and `ComposerEditor::update_scroll_top` keeps the mirrored
 /// scroll offset in lockstep with the widget's own viewport.
 fn draw_input(f: &mut Frame, app: &mut App, area: Rect) {
     let theme = app.theme;
@@ -2429,7 +2458,7 @@ fn draw_input(f: &mut Frame, app: &mut App, area: Rect) {
             area,
         );
         if composer_owns_cursor {
-            f.set_cursor_position((area.x + pw as u16, area.y));
+            paint_caret(f, area.x + pw as u16, area.y);
         }
         return;
     }
@@ -2455,11 +2484,20 @@ fn draw_input(f: &mut Frame, app: &mut App, area: Rect) {
     }
 
     // The widget renders into the columns right of the prompt; its wrap
-    // width is exactly `avail`.
+    // width is exactly `avail`. The caret is the widget's own reversed
+    // cursor cell: it rides the frame diff like any other cell, so scroll
+    // redraws can never blink it (the old hardware cursor was hidden for
+    // the whole diff write). While an overlay owns input, the composer
+    // shows no caret at all.
     let text_area = Rect::new(area.x + pw as u16, area.y, area.width - pw as u16, area.height);
     {
         let ta = app.input.textarea_mut();
         ta.set_style(style);
+        ta.set_cursor_style(if composer_owns_cursor {
+            Style::default().add_modifier(Modifier::REVERSED)
+        } else {
+            Style::default()
+        });
         f.render_widget(&*ta, text_area);
     }
 
@@ -2545,15 +2583,6 @@ fn draw_input(f: &mut Frame, app: &mut App, area: Rect) {
     }
     app.att_chips = chip_rects;
 
-    // Terminal cursor on the widget's screen position, clamped into the
-    // well. `update_scroll_top` after it: the mirrored scroll offset used
-    // above is the one the widget just rendered with.
-    if composer_owns_cursor {
-        let (crow, ccol) = app.input.screen_cursor();
-        let cy = area.y + (crow.saturating_sub(top)).min(h.saturating_sub(1)) as u16;
-        let cx = text_area.x + ccol as u16;
-        f.set_cursor_position((cx.min(text_area.right().saturating_sub(1)), cy));
-    }
     app.input.update_scroll_top(area.height);
     // `input_top` is the app-side mirror mouse hit-testing reads between
     // frames; keep it in lockstep with the editor's own scroll mirror.
@@ -2989,10 +3018,7 @@ fn draw_elicitation_form(f: &mut Frame, app: &mut App, screen: Rect) {
                             .width();
                     bottom.push(Line::from(vec![
                         Span::styled("      ❯ ", Style::default().fg(theme.brand)),
-                        Span::styled(
-                            format!("{}▏", state.input.buf),
-                            Style::default().fg(theme.fg),
-                        ),
+                        Span::styled(state.input.buf.clone(), Style::default().fg(theme.fg)),
                     ]));
                     field_cursor = Some((cursor_row, cursor_col));
                 }
@@ -3030,10 +3056,7 @@ fn draw_elicitation_form(f: &mut Frame, app: &mut App, screen: Rect) {
                     .width();
             bottom.push(Line::from(vec![
                 Span::styled("❯ ", Style::default().fg(theme.brand)),
-                Span::styled(
-                    format!("{}▏", state.input.buf),
-                    Style::default().fg(theme.fg),
-                ),
+                Span::styled(state.input.buf.clone(), Style::default().fg(theme.fg)),
             ]));
             field_cursor = Some((cursor_row, cursor_col));
         }
@@ -3113,13 +3136,14 @@ fn draw_elicitation_form(f: &mut Frame, app: &mut App, screen: Rect) {
     );
     f.render_widget(Paragraph::new(bottom), bottom_area);
     if let Some((row, col)) = field_cursor.filter(|(row, _)| *row < bottom_h) {
-        f.set_cursor_position((
+        paint_caret(
+            f,
             bottom_area
                 .x
                 .saturating_add(col as u16)
                 .min(bottom_area.right().saturating_sub(1)),
             bottom_area.y.saturating_add(row as u16),
-        ));
+        );
     }
 }
 

--- a/tests/unit/pet__tests.rs
+++ b/tests/unit/pet__tests.rs
@@ -50,14 +50,15 @@ fn sync_shows_switches_state_and_hides() {
     let mut pet = Pet::new(true);
     let cell = Rect::new(90, 30, 7, 4);
 
-    // Idle: one-shot transmit-and-display under the idle id.
+    // Idle: transmit the idle PNG once, then place it.
     let mut out = Vec::new();
     pet.sync(&mut out, Some((cell, false))).unwrap();
     let s = String::from_utf8(out).unwrap();
     assert!(s.contains("\x1b[31;91H"), "cursor jumps to the cell");
+    assert!(s.contains("a=t,f=100,i=4207"), "idle transmitted: {s:.60}");
     assert!(
-        s.contains("a=T,f=100,i=4207,c=7,r=4,C=1,z=0,q=2,m=1;"),
-        "idle sprite: {s:.90}"
+        s.contains("a=p,i=4207,p=1,c=7,r=4,"),
+        "idle placed: {s:.80}"
     );
 
     // Same state again: no bytes at all.
@@ -65,21 +66,39 @@ fn sync_shows_switches_state_and_hides() {
     pet.sync(&mut out, Some((cell, false))).unwrap();
     assert!(out.is_empty(), "idempotent when unchanged");
 
-    // A turn starts: idle sprite deleted, working sprite displayed.
+    // The composer grows with a long draft: re-place only, no retransmit.
+    let moved = Rect::new(90, 29, 7, 4);
     let mut out = Vec::new();
-    pet.sync(&mut out, Some((cell, true))).unwrap();
+    pet.sync(&mut out, Some((moved, false))).unwrap();
     let s = String::from_utf8(out).unwrap();
-    assert!(s.contains("a=d,d=I,i=4207"), "idle deleted: {s:.90}");
-    assert!(s.contains("a=T,f=100,i=4208,"), "working shown: {s:.90}");
+    assert!(!s.contains("a=t"), "a move must not retransmit: {s}");
+    assert!(s.contains("a=p,i=4207,p=2,"), "new placement: {s}");
+    assert!(s.contains("a=d,d=p,i=4207,p=1"), "old placement dropped: {s}");
 
-    // Hide (`/liang` off): delete only.
+    // A turn starts: the working sprite is transmitted once and placed; the
+    // idle image keeps its data — only its placement is dropped.
+    let mut out = Vec::new();
+    pet.sync(&mut out, Some((moved, true))).unwrap();
+    let s = String::from_utf8(out).unwrap();
+    assert!(s.contains("a=t,f=100,i=4208"), "working transmitted: {s:.60}");
+    assert!(s.contains("a=p,i=4208,p=1,"), "working placed: {s:.80}");
+    assert!(s.contains("a=d,d=p,i=4207,p=2"), "idle placement dropped: {s}");
+    assert!(!s.contains("a=d,d=I"), "image data is kept: {s}");
+
+    // Hide (`/liang` off): both sprites deleted, transmission state reset.
     let mut out = Vec::new();
     pet.sync(&mut out, None).unwrap();
     let s = String::from_utf8(out).unwrap();
     assert!(
-        s.contains("a=d,d=I,i=4208") && !s.contains("a=T"),
+        s.contains("a=d,d=I,i=4207") && s.contains("a=d,d=I,i=4208") && !s.contains("a=t"),
         "hidden: {s}"
     );
+
+    // Re-show after a hide: the sprite is transmitted again.
+    let mut out = Vec::new();
+    pet.sync(&mut out, Some((cell, false))).unwrap();
+    let s = String::from_utf8(out).unwrap();
+    assert!(s.contains("a=t,f=100,i=4207"), "retransmit after hide: {s:.60}");
 }
 
 #[test]
@@ -89,6 +108,51 @@ fn disabled_pet_stays_silent() {
     pet.sync(&mut out, Some((Rect::new(0, 0, 7, 4), true)))
         .unwrap();
     assert!(out.is_empty());
+}
+
+#[test]
+fn thumbnails_scroll_by_replacement_without_retransmit() {
+    let shot = |rect: Rect| ThumbShot {
+        id: 7,
+        rect,
+        data: LIANG_IDLE_PNG,
+    };
+    let mut thumbs = Thumbnails::new();
+
+    // First sight: transmit the PNG once, then place it as placement 1.
+    let mut out = Vec::new();
+    thumbs
+        .sync(&mut out, &[shot(Rect::new(0, 0, 8, 3))])
+        .unwrap();
+    assert_eq!(image_dims(&transmitted_png(out.clone())), Some((192, 208)));
+    let s = String::from_utf8(out).unwrap();
+    assert!(s.contains("a=t,f=100,i=7,"), "transmit once: {s:.60}");
+    assert!(s.contains("a=p,i=7,p=1,c=8,r=3,"), "initial place: {s:.80}");
+
+    // Same viewport: no bytes at all.
+    let mut out = Vec::new();
+    thumbs
+        .sync(&mut out, &[shot(Rect::new(0, 0, 8, 3))])
+        .unwrap();
+    assert!(out.is_empty(), "idempotent when unchanged");
+
+    // Viewport scrolls: the already-transmitted image is re-placed (a few
+    // bytes) — never deleted and re-sent — and the old placement is dropped
+    // after the new one exists, so the thumbnail never blinks out.
+    let mut out = Vec::new();
+    thumbs
+        .sync(&mut out, &[shot(Rect::new(0, 1, 8, 3))])
+        .unwrap();
+    let s = String::from_utf8(out).unwrap();
+    assert!(!s.contains("a=t"), "a move must not retransmit: {s}");
+    assert!(s.contains("a=p,i=7,p=2,c=8,r=3,"), "new placement: {s}");
+    assert!(s.contains("a=d,d=p,i=7,p=1"), "old placement dropped: {s}");
+
+    // Scrolled away entirely: the image and its placements are deleted.
+    let mut out = Vec::new();
+    thumbs.sync(&mut out, &[]).unwrap();
+    let s = String::from_utf8(out).unwrap();
+    assert!(s.contains("a=d,d=I,i=7"), "scrolled away: {s}");
 }
 
 #[test]

--- a/tests/unit/ui__tests.rs
+++ b/tests/unit/ui__tests.rs
@@ -1107,6 +1107,61 @@ fn long_input_wraps_in_the_well() {
     assert!(wrapped >= 2, "input should wrap across well rows:\n{frame}");
 }
 
+/// The caret is a buffer cell (a steady reversed block), so it moves
+/// atomically with the frame diff and can never be blinked off by a
+/// scroll-heavy redraw. Returns the reversed cells of one drawn frame.
+fn caret_cells(app: &mut App, width: u16, height: u16) -> Vec<(u16, u16)> {
+    use ratatui::backend::TestBackend;
+    use ratatui::Terminal;
+    let backend = TestBackend::new(width, height);
+    let mut terminal = Terminal::new(backend).expect("test terminal");
+    terminal.draw(|f| draw(f, app)).expect("draw frame");
+    let buf = terminal.backend().buffer();
+    let mut cells = Vec::new();
+    for y in 0..height {
+        for x in 0..width {
+            if buf[(x, y)].modifier.contains(Modifier::REVERSED) {
+                cells.push((x, y));
+            }
+        }
+    }
+    cells
+}
+
+#[test]
+fn empty_composer_paints_the_caret_on_the_placeholder() {
+    let mut app = test_app();
+    app.show_banner = false;
+    let cells = caret_cells(&mut app, 80, 20);
+    assert_eq!(cells, vec![(3, 16)], "caret right of the ❯ prompt");
+}
+
+#[test]
+fn composer_caret_follows_the_cursor_end_and_mid_draft() {
+    let mut app = test_app();
+    app.show_banner = false;
+    app.input.set("hello".into());
+    app.input.set_cursor_char(5);
+    // One past the draft: a reversed blank cell, never a hardware cursor.
+    assert_eq!(caret_cells(&mut app, 80, 20), vec![(8, 16)]);
+    app.input.set_cursor_char(2);
+    assert_eq!(caret_cells(&mut app, 80, 20), vec![(5, 16)]);
+}
+
+#[test]
+fn composer_caret_sits_on_wide_graphemes() {
+    let mut app = test_app();
+    app.show_banner = false;
+    app.input.set("中".into());
+    app.input.set_cursor_char(0);
+    // The reversed style rides the grapheme's start cell — terminals paint
+    // the full two-column glyph with it, so the block caret covers 中.
+    assert_eq!(caret_cells(&mut app, 80, 20), vec![(3, 16)]);
+    // Cursor after the wide char: the caret is the blank cell past it.
+    app.input.set_cursor_char(1);
+    assert_eq!(caret_cells(&mut app, 80, 20), vec![(5, 16)]);
+}
+
 #[test]
 fn multiline_input_breaks_on_newlines() {
     let mut app = test_app();
@@ -1512,6 +1567,34 @@ fn pet_rides_above_the_stats_dock() {
     app.slot_snapshots.remove("conversation.composer.dock");
     let without_dock = Rect::new(main.x, main.y, main.width, main.height);
     assert_eq!(pet_rect(without_dock, &app), Some(Rect::new(92, 21, 7, 4)));
+}
+
+#[test]
+fn draw_records_the_pet_anchor_for_the_kitty_reconciler() {
+    let mut app = test_app();
+    app.show_banner = false;
+    app.pet_visible = true;
+    app.pet_pixels = true;
+    // One draw: the anchor is recorded with the idle flag; main() reconciles
+    // the kitty placement against exactly this value.
+    let _ = dump_frame(&mut app, 100, 34);
+    let (rect, working) = app.pet_want.expect("pet anchor recorded");
+    assert_eq!(
+        Some(rect),
+        pet_rect(Rect::new(0, 0, 100, 34), &app),
+        "anchor matches the pet geometry at this size"
+    );
+    assert!(!working, "idle app draws the idle sprite");
+
+    app.state = RunState::Running;
+    let _ = dump_frame(&mut app, 100, 34);
+    assert!(app.pet_want.expect("pet anchor").1, "working flag follows");
+
+    // Char-whale fallback (no kitty protocol): nothing recorded, the kitty
+    // reconciler stays silent.
+    app.pet_pixels = false;
+    let _ = dump_frame(&mut app, 100, 34);
+    assert_eq!(app.pet_want, None, "no kitty pixels, no anchor");
 }
 
 #[test]
@@ -2144,9 +2227,9 @@ fn elicitation_text_field_owns_the_terminal_cursor_instead_of_the_composer() {
     let answer_row = (0..30)
         .find(|y| {
             (0..100)
-                .map(|x| buffer[(x, *y)].symbol())
+                .map(|x| buffer[(x as u16, *y)].symbol())
                 .collect::<String>()
-                .contains("overlay answer▏")
+                .contains("overlay answer")
         })
         .expect("elicitation text field");
     let answer_line = (0..100)
@@ -2154,12 +2237,36 @@ fn elicitation_text_field_owns_the_terminal_cursor_instead_of_the_composer() {
         .collect::<String>();
     let answer_byte = answer_line.find("overlay answer").expect("answer text");
     let answer_start = answer_line[..answer_byte].width() as u16;
-    let cursor = terminal
-        .get_cursor_position()
-        .expect("terminal cursor position");
-
-    assert_eq!(cursor.y, answer_row);
-    assert_eq!(cursor.x, answer_start + "overlay answer".width() as u16);
+    // The caret is a buffer cell: a reversed block one past the field text
+    // (the cursor sits at the end of "overlay answer").
+    let caret_x = answer_start + "overlay answer".width() as u16;
+    assert!(
+        buffer[(caret_x, answer_row)]
+            .modifier
+            .contains(ratatui::style::Modifier::REVERSED),
+        "elicitation field paints its own caret cell"
+    );
+    // The composer draft keeps no caret while the overlay owns input.
+    let composer_row = (0..30)
+        .find(|y| {
+            (0..100)
+                .map(|x| buffer[(x as u16, *y)].symbol())
+                .collect::<String>()
+                .contains("composer draft")
+        })
+        .expect("composer draft visible behind the overlay");
+    let draft_line = (0..100)
+        .map(|x| buffer[(x, composer_row)].symbol())
+        .collect::<String>();
+    let draft_byte = draft_line.find("composer draft").expect("draft text");
+    let draft_start = draft_line[..draft_byte].width() as u16;
+    let draft_end = draft_start + "composer draft".width() as u16;
+    assert!(
+        !(0..100).any(|x| {
+            x >= draft_start && x <= draft_end && buffer[(x, composer_row)].modifier.contains(ratatui::style::Modifier::REVERSED)
+        }),
+        "composer shows no caret while elicitation owns input"
+    );
 }
 
 fn box_line(line: &str) -> &str {


### PR DESCRIPTION
Cherry-picked from fork `main` (3 commits, applies cleanly on current upstream `main`).

## fix(tui): draw frames as one synchronized update

Wrap each redraw in crossterm `sync_update` (DECSET 2026): supporting terminals apply the whole frame atomically; the pre-draw `Hide` keeps the hardware cursor from teleporting across the buffer diff (ratatui re-shows it at the input position at frame end). Pixel-pet, backdrop and thumbnail syncs move inside the same atomic region. `restore_terminal` now also emits `Show` + `EndSynchronizedUpdate` so a panic mid-frame cannot leave the terminal with a hidden cursor or stuck in 2026 mode.

## build: resolve devlocalinstall target from the profile bundle

Always rebuild the release binary so the installed copy reflects current source, and locate the exact binary `dsh --profile` runs: read the profile package.json `dsh.profile.bundles` (legacy `martty`/`@openma` names as fallback), prefer the bundle that already staged a vendor binary, and honor `MARTTY_BIN`/`DSH_TUI_BIN` only when it points at an existing file. Report sha256 of old/new copies; keep the cp-then-rename install to avoid ETXTBSY on a running TUI.

## Verification

- `cargo check --locked --tests` passes
- No-TTY visual check unaffected (`cargo run -- --dump-frame 100x34`)