### PR TITLE
fix(tui): interrupt deadlock, spawn crash, elicitation panic, selection delete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@ All notable changes to this project are documented here. The project follows
 
 ## [Unreleased]
 
+### Fixed
+
+- Esc no longer freezes the TUI when the agent runtime closes its stdout but
+  keeps running: the frame reader no longer holds the child lock across a
+  blocking wait, so the hard interrupt can always SIGKILL it.
+- A failed agent spawn (e.g. a missing `--agent` binary) no longer crashes
+  the client process with an uncaught exception; the transport sees EOF and
+  pending requests fail instead of hanging, and a later apply retries the
+  spawn instead of reusing the dead child.
+- Pressing space on an agent elicitation multi-select field with zero
+  options no longer panics the TUI.
+- Backspace/Delete with an active composer selection (shift+arrows, vim
+  `x`/`X`) now delete the whole selection instead of a single character.
+- `terminal/wait_for_exit` no longer hangs forever when the exit
+  notification fires between the status check and the await (lost wakeup).
+- Esc pressed with no in-flight turn no longer poisons the next prompt
+  (whose result would be swallowed and misreported as interrupted).
+- `--dump-frame` no longer swallows the following CLI flag when its
+  optional `[WxH]` argument is omitted.
+- Scrolling in the same event burst as jump-to-top no longer teleports the
+  viewport from the top of the scrollback to just above the tail.
+- Sending an image prompt on a transport without image support now reports
+  an error and returns to idle instead of wedging in the Starting state
+  with a queue that never drains.
+- User message bubbles no longer overflow the chat pane by two cells, which
+  clipped the last visible character of every wrapped CJK line.
+
 ### Added
 
 - `/plugins` now renders the static Host plugin inventory as a two-level

--- a/npm/lib/acp-client.js
+++ b/npm/lib/acp-client.js
@@ -80,12 +80,31 @@ export function apply(ctx, config = {}) {
     provide(ctx, liveAgent)
     return
   }
+  // Replacing the agent: the previous child must not outlive its spec.
+  if (liveAgent !== null && liveAgent.child.exitCode === null) {
+    try {
+      liveAgent.child.kill('SIGTERM')
+    } catch {
+      // already gone
+    }
+  }
+  liveAgent = null
   const child = spawn(agent.command, agent.args ?? [], {
     stdio: ['pipe', 'pipe', 'inherit'],
     env: { ...process.env, ...(agent.env ?? {}) },
   })
   child.stdin.on('error', () => {})
   child.stdout.on('error', () => {})
+  child.on('error', (err) => {
+    // A failed spawn (ENOENT, EACCES) emits 'error' on the child; without a
+    // listener it is an uncaught exception. Surface EOF to the transport
+    // instead so pending requests fail instead of hanging, and drop the
+    // cached handle so the next apply() retries the spawn.
+    console.error(`acp-client: failed to spawn agent ${agent.command}: ${err.message}`)
+    if (liveAgent?.child === child) liveAgent = null
+    child.stdin.destroy()
+    child.stdout.destroy()
+  })
   const service = {
     kind: 'spawn',
     command: agent.command,

--- a/scripts/acp-client.test.mjs
+++ b/scripts/acp-client.test.mjs
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
-import { resolveAgent } from '../npm/lib/acp-client.js'
+import { apply, resolveAgent } from '../npm/lib/acp-client.js'
 import { parseClientArgv, painterArgs } from '../npm/lib/boot.js'
 
 test('resolveAgent defaults to dsh-acp and honors command/args', () => {
@@ -47,4 +47,15 @@ test('parseClientArgv strips agent flags for the painter', () => {
     '--agent-arg',
     'acp',
   ])
+})
+
+test('apply with a nonexistent agent command does not crash with an uncaught exception', async () => {
+  const ctx = {}
+  apply(ctx, { agent: { command: 'martty-definitely-missing-agent' } })
+  assert.equal(ctx.acpClient.kind, 'spawn')
+  // The child emits 'error' (ENOENT) asynchronously; without a listener Node
+  // would kill the whole process before this assertion runs.
+  await new Promise((resolve) => setTimeout(resolve, 200))
+  assert.ok(ctx.acpClient.stdin.destroyed, 'stdin destroyed after failed spawn')
+  assert.ok(ctx.acpClient.stdout.destroyed, 'stdout destroyed after failed spawn')
 })

--- a/src/acp.rs
+++ b/src/acp.rs
@@ -1655,8 +1655,15 @@ where
                             }
                         }
                         Cmd::Interrupt { .. } => {
-                            abort_turn(&cx, &session_id, &bus);
-                            turn_aborted = true;
+                            // Only a live turn can be aborted. Setting the
+                            // flag with no inflight prompt would poison the
+                            // *next* prompt's finish (its result would be
+                            // swallowed and the turn misreported as
+                            // interrupted).
+                            if inflight.is_some() {
+                                abort_turn(&cx, &session_id, &bus);
+                                turn_aborted = true;
+                            }
                         }
                         Cmd::SelectModel { model, effort, .. } => {
                             let Some(sid) = session_id.clone() else {

--- a/src/acp_term.rs
+++ b/src/acp_term.rs
@@ -108,10 +108,17 @@ impl TerminalBroker {
             return TerminalExitStatus::new();
         };
         loop {
+            // Register interest *before* re-checking the status:
+            // notify_waiters() stores no permit, so a notification fired
+            // between the check and the await would otherwise be lost and
+            // wait() would sleep forever with the exit status already set.
+            let notified = rec.notify.notified();
+            tokio::pin!(notified);
+            notified.as_mut().enable();
             if let Some(status) = rec.exit.lock().unwrap_or_else(|e| e.into_inner()).clone() {
                 return status;
             }
-            rec.notify.notified().await;
+            notified.await;
         }
     }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -3386,7 +3386,18 @@ impl App {
     }
 
     pub fn scroll_by(&mut self, delta: i64) {
-        let cur = self.scroll_up as i64;
+        // usize::MAX is the JumpTop sentinel — resolve it against the last
+        // rendered frame before arithmetic (MAX as i64 wraps to -1, so a
+        // wheel flick in the same event burst as JumpTop would teleport the
+        // viewport from the top of scrollback to just above the tail).
+        let cur = if self.scroll_up == usize::MAX {
+            self.chat_view
+                .lines
+                .len()
+                .saturating_sub(self.chat_view.area.height as usize) as i64
+        } else {
+            self.scroll_up as i64
+        };
         // The renderer clamps the relative gesture to the actual content.
         self.scroll_up = (cur + delta).max(0) as usize;
         // Apply this gesture relative to the frame the user actually saw.
@@ -6571,3 +6582,7 @@ mod palette_tests;
 #[cfg(test)]
 #[path = "../tests/unit/app__right_slot_tests.rs"]
 mod right_slot_tests;
+
+#[cfg(test)]
+#[path = "../tests/unit/app__scroll_tests.rs"]
+mod scroll_tests;

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -183,15 +183,21 @@ fn controller_loop(
                         &mut attached_initialized,
                         &session_id,
                         &blocks,
+                        None,
                     );
                 } else {
-                    let _ = bus.send(AppEvent::Ctl(CtlEvent::TuiOpFailed(
+                    // A fresh image prompt never reached the agent: Error —
+                    // not TuiOpFailed — so the app leaves the pending
+                    // Starting state and drains its queue.
+                    let _ = bus.send(AppEvent::Ctl(CtlEvent::Error(
                         "image attachments are unavailable on the legacy demo transport".into(),
                     )));
                 }
             }
             Cmd::SteerImages {
-                session_id, blocks, ..
+                session_id,
+                blocks,
+                message_id,
             } => {
                 if demo {
                     let text = blocks
@@ -213,11 +219,18 @@ fn controller_loop(
                         &mut attached_initialized,
                         &session_id,
                         &blocks,
+                        Some(message_id),
                     );
                 } else {
+                    // A steer rides the active turn: warn, then release the
+                    // app's steer bookkeeping so it does not leak.
                     let _ = bus.send(AppEvent::Ctl(CtlEvent::TuiOpFailed(
                         "image attachments are unavailable on the legacy demo transport".into(),
                     )));
+                    let _ = bus.send(AppEvent::Ctl(CtlEvent::SteerSettled {
+                        message_id,
+                        deferred: false,
+                    }));
                 }
             }
             Cmd::Interrupt { session_id } => {
@@ -623,6 +636,7 @@ fn handle_prompt_images_attached(
     initialized: &mut bool,
     session_id: &str,
     parts: &[crate::bus::PromptBlock],
+    steer_message_id: Option<u64>,
 ) {
     let Some(rt) = ensure_attached_ready(cfg, bus, runtime, initialized) else {
         return;
@@ -641,24 +655,39 @@ fn handle_prompt_images_attached(
                     "mediaType": img.media_type,
                     "name": img.name,
                 });
-                match rt.request("tui/attach-image", Some(attach), Duration::from_secs(120)) {
+                let failure = match rt.request("tui/attach-image", Some(attach), Duration::from_secs(120))
+                {
                     Ok(result) => match result.get("attachment").cloned() {
-                        Some(a) => blocks.push(json!({ "type": "image", "attachment": a })),
-                        None => {
-                            let _ = bus.send(AppEvent::Ctl(CtlEvent::TuiOpFailed(format!(
-                                "tui/attach-image returned no attachment for {}",
-                                img.name
-                            ))));
-                            return;
+                        Some(a) => {
+                            blocks.push(json!({ "type": "image", "attachment": a }));
+                            None
                         }
-                    },
-                    Err(err) => {
-                        let _ = bus.send(AppEvent::Ctl(CtlEvent::TuiOpFailed(format!(
-                            "tui/attach-image failed for {}: {err:#}",
+                        None => Some(format!(
+                            "tui/attach-image returned no attachment for {}",
                             img.name
-                        ))));
-                        return;
+                        )),
+                    },
+                    Err(err) => Some(format!("tui/attach-image failed for {}: {err:#}", img.name)),
+                };
+                if let Some(desc) = failure {
+                    match steer_message_id {
+                        // A steer rides the active turn: warn and release
+                        // the app's steer bookkeeping.
+                        Some(message_id) => {
+                            let _ = bus.send(AppEvent::Ctl(CtlEvent::TuiOpFailed(desc)));
+                            let _ = bus.send(AppEvent::Ctl(CtlEvent::SteerSettled {
+                                message_id,
+                                deferred: false,
+                            }));
+                        }
+                        // A fresh image prompt never launched: Error resets
+                        // the app's pending Starting state and drains its
+                        // queue.
+                        None => {
+                            let _ = bus.send(AppEvent::Ctl(CtlEvent::Error(desc)));
+                        }
                     }
+                    return;
                 }
             }
         }

--- a/src/elicitation.rs
+++ b/src/elicitation.rs
@@ -442,7 +442,11 @@ impl ElicitationFormState {
                 let state = &mut self.fields[self.index];
                 match state.field.kind {
                     ElicitationFieldKind::Multi { .. } => {
-                        state.selected[state.cursor] = !state.selected[state.cursor];
+                        // An agent may legally send a multi-select with zero
+                        // options; there is nothing to toggle then.
+                        if let Some(selected) = state.selected.get_mut(state.cursor) {
+                            *selected = !*selected;
+                        }
                     }
                     ElicitationFieldKind::Boolean { .. } => {
                         state.selected.fill(false);

--- a/src/input/composer.rs
+++ b/src/input/composer.rs
@@ -301,14 +301,15 @@ impl ComposerEditor {
         self.hist_pos = None;
     }
 
+    // delete_char/delete_next_char delete an active selection first (the
+    // widget's native behavior); cancelling it here would reduce the edit to
+    // a single char.
     pub fn backspace(&mut self) {
-        self.textarea_mut().cancel_selection();
         self.textarea_mut().delete_char();
         self.hist_pos = None;
     }
 
     pub fn delete_forward(&mut self) {
-        self.textarea_mut().cancel_selection();
         self.textarea_mut().delete_next_char();
         self.hist_pos = None;
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -128,7 +128,7 @@ fn parse_args_from(args: impl IntoIterator<Item = String>) -> Result<Args> {
         check_runtime: false,
         dump_frame: None,
     };
-    let mut it = args.into_iter();
+    let mut it = args.into_iter().peekable();
     while let Some(arg) = it.next() {
         let mut take = |name: &str| -> Result<String> {
             it.next().with_context(|| format!("{name} needs a value"))
@@ -154,12 +154,20 @@ fn parse_args_from(args: impl IntoIterator<Item = String>) -> Result<Args> {
             "--attach-tcp" => args_out.attach_tcp = Some(take("--attach-tcp")?),
             "--check-runtime" => args_out.check_runtime = true,
             "--dump-frame" => {
-                let dims = it.next().unwrap_or_else(|| "100x34".into());
-                let (w, h) = dims
-                    .split_once('x')
-                    .and_then(|(w, h)| Some((w.parse().ok()?, h.parse().ok()?)))
-                    .unwrap_or((100, 34));
-                args_out.dump_frame = Some((w, h));
+                // [WxH] is optional: only consume the next token when it
+                // actually parses as dimensions — it may be another flag.
+                let parse_dims = |s: &str| -> Option<(u16, u16)> {
+                    let (w, h) = s.split_once('x')?;
+                    Some((w.parse().ok()?, h.parse().ok()?))
+                };
+                let dims = match it.peek().and_then(|s| parse_dims(s)) {
+                    Some(dims) => {
+                        it.next();
+                        dims
+                    }
+                    None => (100, 34),
+                };
+                args_out.dump_frame = Some(dims);
             }
             "-V" | "--version" => {
                 println!("martty {}", env!("CARGO_PKG_VERSION"));

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -150,12 +150,24 @@ impl RuntimeProcess {
                         message: "harness runtime closed".into(),
                     }));
                 }
-                let code = child_slot
-                    .lock()
-                    .unwrap()
-                    .as_mut()
-                    .and_then(|c| c.wait().ok())
-                    .and_then(|s| s.code());
+                // Poll with try_wait instead of a blocking wait: the lock
+                // must stay acquirable so kill() can SIGKILL a runtime that
+                // closed stdout but keeps running.
+                let code = loop {
+                    {
+                        let mut guard = child_slot.lock().unwrap();
+                        match guard.as_mut() {
+                            // kill() already reaped the child.
+                            None => break None,
+                            Some(child) => match child.try_wait() {
+                                Ok(Some(status)) => break status.code(),
+                                Ok(None) => {}
+                                Err(_) => break None,
+                            },
+                        }
+                    }
+                    std::thread::sleep(Duration::from_millis(20));
+                };
                 let _ = bus.send(AppEvent::RuntimeExited(code));
             })
             .expect("spawn frame reader");
@@ -310,3 +322,7 @@ fn route_message(
         _ => {}
     }
 }
+
+#[cfg(test)]
+#[path = "../tests/unit/proto__tests.rs"]
+mod tests;

--- a/src/transcript.rs
+++ b/src/transcript.rs
@@ -999,7 +999,10 @@ impl Transcript {
                 CellKind::User { text, queued } => {
                     emit(&mut out, &mut owners, Line::default(), None);
                     // Web UI fidelity: the user bubble uses --dsw-specific-bubble.
-                    for (i, l) in wrap(text, width.saturating_sub(2)).into_iter().enumerate() {
+                    // Budget = width - 4: the "❯ "/"  " prefix takes 2 cells
+                    // and the " {l} " padding takes 2 more, so a wider wrap
+                    // budget would clip the last text cells of full lines.
+                    for (i, l) in wrap(text, width.saturating_sub(4)).into_iter().enumerate() {
                         let mut spans = vec![
                             Span::styled(
                                 if i == 0 { "❯ " } else { "  " }.to_string(),

--- a/tests/unit/acp_term__tests.rs
+++ b/tests/unit/acp_term__tests.rs
@@ -27,3 +27,47 @@ async fn kill_then_wait_settles() {
     assert!(status.exit_code.is_none() || status.exit_code != Some(0) || status.signal.is_some());
     broker.release(&id);
 }
+
+#[tokio::test]
+async fn wait_after_the_exit_notification_already_fired_returns() {
+    // notify_waiters() stores no permit: a wait() started around/after the
+    // waiter thread's notification must still settle (registration happens
+    // before the status re-check).
+    let broker = TerminalBroker::new(std::env::temp_dir());
+    let id = broker
+        .create("/bin/true", &[], None, &[], None)
+        .expect("spawn true");
+    // Give the waiter thread time to reap and fire notify_waiters() with no
+    // listeners registered.
+    tokio::time::sleep(Duration::from_millis(300)).await;
+    let status = tokio::time::timeout(Duration::from_secs(3), broker.wait(&id))
+        .await
+        .expect("wait must not hang once exit was already recorded");
+    assert_eq!(status.exit_code, Some(0));
+    broker.release(&id);
+}
+
+#[tokio::test]
+async fn concurrent_waiters_all_settle() {
+    let broker = std::sync::Arc::new(TerminalBroker::new(std::env::temp_dir()));
+    let id = broker
+        .create("/bin/true", &[], None, &[], None)
+        .expect("spawn true");
+    let mut handles = Vec::new();
+    for _ in 0..4 {
+        handles.push(tokio::spawn({
+            let broker = broker.clone();
+            let id = id.clone();
+            async move { broker.wait(&id).await }
+        }));
+    }
+    for handle in handles {
+        let status = tokio::time::timeout(Duration::from_secs(3), handle)
+            .await
+            .expect("waiter must settle")
+            .expect("join");
+        assert_eq!(status.exit_code, Some(0));
+    }
+    broker.release(&id);
+}
+

--- a/tests/unit/app__scroll_tests.rs
+++ b/tests/unit/app__scroll_tests.rs
@@ -1,0 +1,51 @@
+use super::*;
+use std::sync::mpsc::Receiver;
+
+fn test_app() -> (App, Receiver<AppEvent>) {
+    let cfg = RuntimeConfig {
+        bin: "demo".into(),
+        cordis: "demo".into(),
+        workspace: "/tmp".into(),
+        session_root: std::env::temp_dir()
+            .join(format!("dsh-tui-scroll-{}", std::process::id()))
+            .to_string_lossy()
+            .into_owned(),
+        provider: "deepseek-official".into(),
+        model: "deepseek-v4-flash".into(),
+        max_tokens: None,
+        base_url: None,
+        api_key: None,
+    };
+    let (tx, rx) = std::sync::mpsc::channel::<AppEvent>();
+    let app = App::new(Theme::dark(), cfg, "s1".into(), true, false, tx);
+    (app, rx)
+}
+
+#[test]
+fn scroll_by_after_jump_top_resolves_the_sentinel_against_the_last_frame() {
+    let (mut app, _rx) = test_app();
+    // Last rendered frame: 200 lines in a 20-row pane → max_scroll = 180.
+    app.chat_view.area = ratatui::layout::Rect::new(0, 0, 80, 20);
+    app.chat_view.lines = (0..200).map(|i| format!("line {i}")).collect();
+
+    // JumpTop leaves the usize::MAX sentinel until the next draw; a wheel
+    // flick arriving in the same event burst must stay relative to the top
+    // (MAX as i64 would wrap to -1 and teleport the viewport to the tail).
+    app.scroll_up = usize::MAX;
+    app.scroll_by(3);
+    assert_eq!(app.scroll_up, 183, "wheel-up from the top clamps at the top");
+
+    app.scroll_up = usize::MAX;
+    app.scroll_by(-3);
+    assert_eq!(app.scroll_up, 177, "wheel-down from the top moves 3 lines");
+}
+
+#[test]
+fn scroll_by_without_the_sentinel_is_untouched() {
+    let (mut app, _rx) = test_app();
+    app.scroll_up = 10;
+    app.scroll_by(5);
+    assert_eq!(app.scroll_up, 15);
+    app.scroll_by(-100);
+    assert_eq!(app.scroll_up, 0, "clamps at the streaming tail");
+}

--- a/tests/unit/controller__tests.rs
+++ b/tests/unit/controller__tests.rs
@@ -97,3 +97,95 @@ pub(crate) fn test_interruptible_controller() -> (Controller, Receiver<Cmd>) {
         cmd_rx,
     )
 }
+
+fn image_block() -> crate::bus::PromptBlock {
+    crate::bus::PromptBlock::Image(crate::bus::ImagePart {
+        data: "AA==".into(),
+        media_type: "image/png".into(),
+        name: "x.png".into(),
+        path: "clipboard".into(),
+    })
+}
+
+fn loop_cfg() -> RuntimeConfig {
+    RuntimeConfig {
+        bin: "demo".into(),
+        cordis: "demo".into(),
+        workspace: "/tmp".into(),
+        session_root: std::env::temp_dir()
+            .join(format!("dsh-tui-ctl-{}", std::process::id()))
+            .to_string_lossy()
+            .into_owned(),
+        provider: "deepseek-official".into(),
+        model: "deepseek-v4-flash".into(),
+        max_tokens: None,
+        base_url: None,
+        api_key: None,
+    }
+}
+
+fn collect_events(rx: &Receiver<AppEvent>, n: usize) -> Vec<AppEvent> {
+    let mut out = Vec::new();
+    let deadline = std::time::Instant::now() + Duration::from_secs(3);
+    while out.len() < n && std::time::Instant::now() < deadline {
+        match rx.recv_timeout(Duration::from_millis(200)) {
+            Ok(ev) => out.push(ev),
+            Err(mpsc::RecvTimeoutError::Timeout) => {}
+            Err(mpsc::RecvTimeoutError::Disconnected) => break,
+        }
+    }
+    out
+}
+
+#[test]
+fn legacy_image_prompt_fails_with_error_so_the_app_leaves_starting() {
+    // Regression: TuiOpFailed only pushes a notice — a fresh image prompt
+    // that never launches must be an Error so the app clears prompt_pending
+    // and drains its queue instead of wedging in Starting.
+    let (bus, rx) = mpsc::channel::<AppEvent>();
+    let ctl = Controller::start(loop_cfg(), false, None, bus);
+    ctl.send(Cmd::PromptImages {
+        session_id: "s1".into(),
+        blocks: vec![image_block()],
+    });
+    let events = collect_events(&rx, 1);
+    assert!(
+        events.iter().any(|ev| matches!(
+            ev,
+            AppEvent::Ctl(CtlEvent::Error(e)) if e.contains("unavailable")
+        )),
+        "expected CtlEvent::Error among {} event(s)",
+        events.len()
+    );
+}
+
+#[test]
+fn legacy_image_steer_warns_and_settles_the_steer_bookkeeping() {
+    let (bus, rx) = mpsc::channel::<AppEvent>();
+    let ctl = Controller::start(loop_cfg(), false, None, bus);
+    ctl.send(Cmd::SteerImages {
+        session_id: "s1".into(),
+        message_id: 7,
+        blocks: vec![image_block()],
+    });
+    let events = collect_events(&rx, 2);
+    assert!(
+        events.iter().any(|ev| matches!(
+            ev,
+            AppEvent::Ctl(CtlEvent::TuiOpFailed(e)) if e.contains("unavailable")
+        )),
+        "expected TuiOpFailed among {} event(s)",
+        events.len()
+    );
+    assert!(
+        events.iter().any(|ev| matches!(
+            ev,
+            AppEvent::Ctl(CtlEvent::SteerSettled {
+                message_id: 7,
+                deferred: false
+            })
+        )),
+        "expected SteerSettled among {} event(s)",
+        events.len()
+    );
+}

--- a/tests/unit/elicitation__tests.rs
+++ b/tests/unit/elicitation__tests.rs
@@ -193,3 +193,40 @@ fn other_choice_collects_inline_text_and_returns_both_schema_properties() {
         ])))
     );
 }
+
+#[test]
+fn space_on_an_optionless_multi_select_is_a_noop_not_a_panic() {
+    // ACP allows a multi-select property with an empty enum; Space toggles
+    // selected[cursor], which must not index a zero-length vector.
+    let mut form = ElicitationFormState::new(ElicitationForm {
+        message: "Pick things".into(),
+        fields: vec![ElicitationField {
+            name: "choices".into(),
+            custom_name: None,
+            title: "Choices".into(),
+            description: None,
+            required: false,
+            kind: ElicitationFieldKind::Multi {
+                options: vec![],
+                default: vec![],
+                min: 0,
+                max: None,
+            },
+        }],
+    });
+
+    assert_eq!(form.fields[0].selected.len(), 0);
+    assert_eq!(
+        form.handle_key(KeyEvent::new(KeyCode::Char(' '), KeyModifiers::NONE)),
+        None,
+        "space with zero options must not panic"
+    );
+    let reply = form.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+    assert_eq!(
+        reply,
+        Some(ElicitationReply::Accepted(BTreeMap::from([(
+            "choices".into(),
+            ElicitationValue::StringArray(vec![])
+        )])))
+    );
+}

--- a/tests/unit/input__composer__tests.rs
+++ b/tests/unit/input__composer__tests.rs
@@ -305,8 +305,8 @@ fn shift_select_extends_and_plain_moves_cancel() {
     e.backspace();
     assert_eq!(
         e.buf(),
-        "hello world",
-        "backspace cancels the selection, then deletes before the cursor (at the selection head)"
+        "llo world",
+        "backspace with an active selection deletes the selection"
     );
     assert_eq!(e.selection_text(), None);
 }
@@ -356,4 +356,18 @@ fn kill_line_on_the_last_line_keeps_its_newline_friends() {
     e.set_cursor_char(2);
     e.kill_line();
     assert_eq!(e.buf(), "a\n", "last content line dies, newline stays");
+}
+
+#[test]
+fn delete_forward_with_a_selection_deletes_the_selection() {
+    let mut e = ComposerEditor::new();
+    e.insert_str("hello world");
+    e.set_cursor_char(0);
+    e.select_right();
+    e.select_right();
+    e.select_right();
+    assert_eq!(e.selection_text().as_deref(), Some("hel"));
+    e.delete_forward();
+    assert_eq!(e.buf(), "lo world", "delete removes the active selection");
+    assert_eq!(e.selection_text(), None);
 }

--- a/tests/unit/main__cli_args_tests.rs
+++ b/tests/unit/main__cli_args_tests.rs
@@ -95,3 +95,26 @@ fn demo_skin_script_candidates_prefer_source_then_vendor_layout() {
         .any(|p| p.components().any(|c| c.as_os_str() == "vendor")
             || p.to_string_lossy().contains("..")));
 }
+
+#[test]
+fn dump_frame_defaults_and_explicit_dims() {
+    let args = parse_args_from(["--dump-frame".into()]).unwrap();
+    assert_eq!(args.dump_frame, Some((100, 34)));
+    let args = parse_args_from(["--dump-frame".into(), "80x24".into()]).unwrap();
+    assert_eq!(args.dump_frame, Some((80, 24)));
+}
+
+#[test]
+fn dump_frame_does_not_swallow_the_next_flag() {
+    // `--dump-frame --theme light`: --theme is a flag, not dimensions.
+    let args = parse_args_from([
+        "--dump-frame".into(),
+        "--theme".into(),
+        "light".into(),
+        "--demo".into(),
+    ])
+    .unwrap();
+    assert_eq!(args.dump_frame, Some((100, 34)));
+    assert_eq!(args.theme, "light");
+    assert!(args.demo);
+}

--- a/tests/unit/proto__tests.rs
+++ b/tests/unit/proto__tests.rs
@@ -1,0 +1,29 @@
+use super::*;
+
+#[cfg(unix)]
+#[test]
+fn kill_does_not_deadlock_when_stdout_closed_but_process_keeps_running() {
+    // Regression: the reader thread must not hold the child lock across a
+    // blocking wait() at stdout EOF — kill() needs that lock to SIGKILL a
+    // wedged runtime, and the UI thread calls kill() on Esc.
+    use std::os::unix::fs::PermissionsExt;
+    let script = std::env::temp_dir().join(format!("martty-proto-wedge-{}", std::process::id()));
+    std::fs::write(&script, "#!/bin/sh\nexec 1>&-\nsleep 30\n").expect("write stub runtime");
+    std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755)).expect("chmod");
+
+    let (bus, _rx) = mpsc::channel();
+    let proc = RuntimeProcess::spawn(script.to_str().unwrap(), &[], "/tmp", bus)
+        .expect("spawn stub runtime");
+    // Let the reader thread hit the EOF path before killing.
+    std::thread::sleep(Duration::from_millis(300));
+
+    let (tx, rx) = mpsc::channel();
+    let killer = std::thread::spawn(move || {
+        proc.kill();
+        let _ = tx.send(());
+    });
+    rx.recv_timeout(Duration::from_secs(5))
+        .expect("kill() deadlocked on the child lock held by the reader's wait()");
+    killer.join().expect("killer thread");
+    let _ = std::fs::remove_file(&script);
+}

--- a/tests/unit/transcript__tests.rs
+++ b/tests/unit/transcript__tests.rs
@@ -216,6 +216,24 @@ fn wrap_handles_cjk() {
 }
 
 #[test]
+fn user_bubble_stays_within_the_pane_width() {
+    // The bubble line is "❯ " (2 cells) + " {l} " (text + 2 cells); the wrap
+    // budget must pay for all 4 chrome cells or packed CJK lines clip.
+    let mut tr = t("s");
+    tr.push_user("深度求索深度求索深度求索深度求索深度求索".into(), false);
+    let theme = Theme::dark();
+    for width in [20u16, 40, 80] {
+        for (i, line) in tr.lines(&theme, width, '⠋').iter().enumerate() {
+            assert!(
+                line_width(line) <= width as usize,
+                "line {i} at pane width {width} paints {} cells: {line:?}",
+                line_width(line),
+            );
+        }
+    }
+}
+
+#[test]
 fn wrap_expands_tabs_and_never_exceeds_width() {
     use unicode_width::UnicodeWidthStr;
     let cases = [


### PR DESCRIPTION
## Summary

Review-driven stability fixes across the Rust painter and the npm client — 10 bugs, each with a regression test.

**Crashes / freezes**
- `proto`: the frame reader no longer holds the child lock across a blocking `wait()` at stdout EOF, so Esc can always SIGKILL a wedged runtime (previously `kill()` deadlocked and froze the whole TUI)
- `acp-client` (npm): a failed agent spawn (e.g. missing `--agent` binary) was an uncaught exception that killed the client process; now the transport sees EOF, pending requests fail, the dead handle is dropped so a later `apply()` retries, and replacing the agent spec kills the previous child instead of leaking it
- `elicitation`: pressing space on an agent-supplied multi-select with zero options panicked on an empty index

**Stuck / poisoned state**
- `acp-term`: `terminal/wait_for_exit` lost-wakeup race — `notify_waiters()` stores no permit, so a notification between the status check and the await hung the agent's turn forever; interest is now registered before the re-check
- `acp`: `Interrupt` with no in-flight turn set a stale `turn_aborted` flag that swallowed the *next* prompt's result and misreported it as interrupted
- `controller`: a failed image prompt (legacy transport / attach RPC failure) sent `TuiOpFailed`, which only shows a notice — the app wedged in `Starting` with a queue that never drains; fresh prompts now report `Error` (reset + drain), failed steers additionally send `SteerSettled` so the app's bookkeeping doesn't leak

**Interaction correctness**
- `composer`: backspace/delete with an active selection deleted one char — the wrapper's `cancel_selection()` defeated the widget's native `delete_selection`
- `main`: `--dump-frame` unconditionally ate the next CLI token (`--dump-frame --theme light` broke); it now only consumes a token that parses as `WxH`
- `app`: `JumpTop` + wheel flick in the same event burst computed `usize::MAX as i64 == -1` and teleported the viewport from the top of scrollback to just above the tail
- `transcript`: the user bubble wrap budget ignored the 4 chrome cells (`❯ ` + padding), so every wrapped CJK user line lost its last visible character

## Test plan

- `cargo test --locked`: **535 passed** (12 new Rust regression tests, incl. a kill-deadlock guard with a wedged stub runtime, acp-term wakeup-race tests, controller image-failure event tests)
- `npm test --prefix npm`: **204 passed** (new: failed spawn does not crash the client)
- `cargo run -- --dump-frame 60x20`: renders as before
- CHANGELOG updated under `[Unreleased]`