### PR TITLE
fix(tui): rewrite chat and view-overlay scroll surfaces every frame

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ All notable changes to this project are documented here. The project follows
 
 ### Fixed
 
+- Scrolling the `/keys` popup or the chat transcript no longer leaves
+  irregular black blocks on screen: orphan halves of wide (CJK) characters
+  survived because the frame diff considered those cells unchanged; both
+  scroll surfaces are now marked `CellDiffOption::AlwaysUpdate` so every
+  drawn frame rewrites them (issue #38).
 - Esc no longer freezes the TUI when the agent runtime closes its stdout but
   keeps running: the frame reader no longer holds the child lock across a
   blocking wait, so the hard interrupt can always SIGKILL it.

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -738,6 +738,20 @@ fn wrap_line(s: &str, cells: usize) -> Vec<String> {
     out
 }
 
+/// Mark every cell in `area` [`CellDiffOption::AlwaysUpdate`] so the frame
+/// diff rewrites them unconditionally (issue #38). Scrolling CJK content can
+/// leave orphan halves of wide chars on the real screen while both ratatui
+/// buffers agree the cell is unchanged, so the diff skips it and the leftover
+/// half-glyph stays as a black block. Forcing a full rewrite of the scroll
+/// surfaces costs a few KB of output per drawn frame and clears the stale
+/// cells regardless of terminal-specific wide-char erase behavior.
+fn force_full_rewrite(f: &mut Frame, area: Rect) {
+    let buf = f.buffer_mut();
+    for pos in area.positions() {
+        buf[pos].set_diff_option(ratatui::buffer::CellDiffOption::AlwaysUpdate);
+    }
+}
+
 fn draw_view_overlay(f: &mut Frame, app: &mut App, screen: Rect) {
     let theme = app.theme;
     let Some(view) = app.view_overlay.as_mut() else {
@@ -789,6 +803,7 @@ fn draw_view_overlay(f: &mut Frame, app: &mut App, screen: Rect) {
         ))
         .style(Style::default().bg(theme.panel).fg(theme.fg));
     f.render_widget(Paragraph::new(lines).scroll((scroll, 0)).block(block), area);
+    force_full_rewrite(f, area);
 }
 
 /// `/plugins` inventory popup: a two-level provider → plugin tree rendered
@@ -2027,6 +2042,9 @@ fn draw_chat(f: &mut Frame, app: &mut App, area: Rect) {
 
     f.render_widget(Paragraph::new(visible), inner);
     draw_selection_overlay(f, app, inner, start);
+    // Last: the selection overlay above also writes these cells, so the
+    // full-rewrite marker must run after it (issue #38).
+    force_full_rewrite(f, inner);
 }
 
 /// Paint the in-app mouse selection as reversed cells — the live highlight
@@ -3375,3 +3393,7 @@ mod tests;
 #[cfg(test)]
 #[path = "../tests/unit/ui__rpc_probe.rs"]
 mod rpc_probe;
+
+#[cfg(test)]
+#[path = "../tests/unit/ui_diff_option__tests.rs"]
+mod diff_option_tests;

--- a/tests/unit/ui_diff_option__tests.rs
+++ b/tests/unit/ui_diff_option__tests.rs
@@ -1,0 +1,133 @@
+use super::*;
+use crate::runtime::RuntimeConfig;
+use ratatui::backend::TestBackend;
+use ratatui::buffer::{Buffer, CellDiffOption};
+use ratatui::Terminal;
+use std::sync::mpsc;
+
+/// Unique session root per call — keeps the modes cache from leaking
+/// between tests and runs.
+fn fresh_root() -> String {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static N: AtomicU64 = AtomicU64::new(0);
+    let dir = std::env::temp_dir().join(format!(
+        "dsh-tui-ui-diff-{}-{}",
+        std::process::id(),
+        N.fetch_add(1, Ordering::Relaxed),
+    ));
+    let _ = std::fs::create_dir_all(&dir);
+    dir.to_string_lossy().into_owned()
+}
+
+fn test_app() -> App {
+    let cfg = RuntimeConfig {
+        bin: "dsh-runtime".into(),
+        cordis: "cordis".into(),
+        workspace: "/tmp".into(),
+        session_root: fresh_root(),
+        provider: "deepseek".into(),
+        model: "deepseek-chat".into(),
+        max_tokens: None,
+        base_url: None,
+        api_key: None,
+    };
+    let (tx, _rx) = mpsc::channel();
+    App::new(Theme::dark(), cfg, "dsh-test".into(), true, false, tx)
+}
+
+/// Issue #38: scrolled CJK content leaves orphan halves of wide chars on the
+/// real screen while both ratatui buffers agree the cell is unchanged, so the
+/// diff skips it. The scroll surfaces mark every cell `AlwaysUpdate` to
+/// bypass that equality check. The marks are read off the freshly rendered
+/// buffer inside the draw closure: the backend's copy only reflects cells
+/// that travelled through the diff, which wide-char trailing cells never do.
+fn assert_always_update(buf: &Buffer, area: Rect, what: &str) {
+    for pos in area.positions() {
+        assert_eq!(
+            buf[pos].diff_option,
+            CellDiffOption::AlwaysUpdate,
+            "{what} cell {pos:?} must bypass the diff equality check (issue #38)"
+        );
+    }
+}
+
+#[test]
+fn chat_cells_force_a_full_rewrite_every_frame() {
+    let mut app = test_app();
+    app.show_banner = false;
+    let backend = TestBackend::new(80, 20);
+    let mut terminal = Terminal::new(backend).expect("test terminal");
+    terminal
+        .draw(|f| {
+            draw(f, &mut app);
+            // draw_chat publishes the exact rect it painted for mouse
+            // hit-testing.
+            let area = app.chat_view.area;
+            assert!(area.width > 0 && area.height > 0, "chat area must be drawn");
+            assert_always_update(f.buffer_mut(), area, "chat");
+        })
+        .expect("draw frame");
+}
+
+#[test]
+fn view_overlay_body_forces_a_full_rewrite() {
+    use crate::app::ViewOverlay;
+    let mut app = test_app();
+    app.show_banner = false;
+    app.view_overlay = Some(ViewOverlay {
+        id: "keys".into(),
+        title: "Keys".into(),
+        nodes: vec![crate::slots::TuiNode::Markdown {
+            id: "content".into(),
+            text: (0..40)
+                .map(|i| format!("- 第 {i} 行 · 快捷键说明 · wide char テスト"))
+                .collect::<Vec<_>>()
+                .join("\n"),
+            streaming: false,
+        }],
+        scroll: 0,
+        notify_plugin: false,
+    });
+    let backend = TestBackend::new(100, 30);
+    let mut terminal = Terminal::new(backend).expect("test terminal");
+    terminal.draw(|f| draw(f, &mut app)).expect("draw frame");
+    // The issue-#38 gesture: scroll the popup, redraw, and the body must
+    // still be marked for a full rewrite.
+    app.view_overlay.as_mut().expect("overlay").scroll = 5;
+    terminal
+        .draw(|f| {
+            draw(f, &mut app);
+            let area = overlay_area(f.buffer_mut());
+            assert_always_update(f.buffer_mut(), area, "overlay");
+        })
+        .expect("redraw frame");
+}
+
+/// Locate the overlay by its title row (the only row carrying "esc close")
+/// and its rounded corners — the area formula is content-dependent, so the
+/// test reads the painted border back.
+fn overlay_area(buf: &Buffer) -> Rect {
+    let (width, height) = (buf.area.width, buf.area.height);
+    let mut border = None;
+    for y in 0..height {
+        let mut row = String::new();
+        for x in 0..width {
+            row.push_str(buf[(x, y)].symbol());
+        }
+        if row.contains("esc close") {
+            let left = (0..width)
+                .find(|&x| buf[(x, y)].symbol() == "╭")
+                .expect("overlay top-left corner");
+            let right = (0..width)
+                .rfind(|&x| buf[(x, y)].symbol() == "╮")
+                .expect("overlay top-right corner");
+            border = Some((y, left, right));
+            break;
+        }
+    }
+    let (top, left, right) = border.expect("overlay title row");
+    let bottom = (top + 1..height)
+        .find(|&y| buf[(left, y)].symbol() == "╰" && buf[(right, y)].symbol() == "╯")
+        .expect("overlay bottom border");
+    Rect::new(left, top, right - left + 1, bottom - top + 1)
+}


### PR DESCRIPTION
## Summary

Scrolling the `/keys` popup (view overlay) or the chat transcript with CJK content left irregular black blocks on screen.

## Root cause

When a wide (double-width) character is replaced by narrower content, some terminals keep the orphan trailing half on screen. Ratatui's frame diff compares the current and previous *buffers* — which agree the cell is unchanged — and skips the rewrite, so the stale half-glyph stays. Ratatui 0.30's built-in mitigation only force-rewrites trailing cells when the previous wide char had a non-Reset background or visible-on-blank modifiers, which does not cover the chat pane (no bg) and still leaks on the overlay in practice.

## Fix

Mark every cell of the two scroll surfaces `CellDiffOption::AlwaysUpdate` after rendering (`draw_chat`, `draw_view_overlay`), so the frame diff bypasses the equality check and rewrites them unconditionally. `CellDiffOption` is public API in ratatui 0.30.2 — no fork or upgrade needed. The marks do not change rendered content; the cost is a few KB of extra terminal output per drawn frame (frames are `needs_redraw`-gated and wrapped in DECSET 2026 synchronized updates).

## Verification

- `cargo test --locked` — all 541 tests pass, including 2 new regression tests (`chat_cells_force_a_full_rewrite_every_frame`, `view_overlay_body_forces_a_full_rewrite`)
- `cargo check --locked --tests` — clean
- `cargo run -- --dump-frame 100x34` — byte-identical before/after

Closes #38