### PR TITLE
fix(tui): park the hidden hardware cursor on the caret cell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ All notable changes to this project are documented here. The project follows
 
 ### Fixed
 
+- IME candidate/composition popups (e.g. the first Chinese character typed
+  into an empty composer) now anchor at the input caret again: the hidden
+  hardware cursor is repositioned onto the painted caret cell after every
+  frame instead of being left wherever the last diff write happened
+  (issue #66).
 - Scrolling the `/keys` popup or the chat transcript no longer leaves
   irregular black blocks on screen: orphan halves of wide (CJK) characters
   survived because the frame diff considered those cells unchanged; both

--- a/src/app.rs
+++ b/src/app.rs
@@ -969,6 +969,13 @@ pub struct App {
     /// First text row shown inside the well (the viewport scroll from
     /// `ui::draw_input`).
     pub(crate) input_top: usize,
+    /// Absolute screen cell of the soft caret from the latest frame (the
+    /// reversed block `ui::draw` paints in the composer well or the
+    /// elicitation field). `main` repositions the *hidden* hardware cursor
+    /// onto this cell after every draw, so IME candidate popups anchor at
+    /// the caret instead of wherever the frame diff left the cursor;
+    /// `None` when no caret was painted this frame.
+    pub caret_cell: Option<(u16, u16)>,
     /// Ordered char-index range selected in the composer: drag-select and
     /// copy highlight, `None` when no input selection is shown.
     pub(crate) input_sel: Option<InputSel>,
@@ -1376,6 +1383,7 @@ impl App {
             composer_wrap_width: 80,
             input_area: ratatui::layout::Rect::default(),
             input_top: 0,
+            caret_cell: None,
             input_sel: None,
             input_selecting: false,
             state: RunState::Idle,

--- a/src/input/composer.rs
+++ b/src/input/composer.rs
@@ -589,7 +589,7 @@ impl ComposerEditor {
     /// relative to the *start of the text* (row 0), not the viewport.
     /// Requires the widget to have been rendered (or edited) at least
     /// once so its screen map matches the current area.
-    fn screen_cursor(&self) -> (usize, usize) {
+    pub fn screen_cursor(&self) -> (usize, usize) {
         let sc = self.textarea.screen_cursor();
         (sc.row, sc.col)
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,7 +32,7 @@ use std::sync::mpsc;
 use std::time::Duration;
 
 use anyhow::{bail, Context, Result};
-use crossterm::cursor::{Hide, Show};
+use crossterm::cursor::{Hide, MoveTo, Show};
 use crossterm::event::{
     DisableBracketedPaste, DisableMouseCapture, EnableBracketedPaste, EnableMouseCapture,
     KeyboardEnhancementFlags, PopKeyboardEnhancementFlags, PushKeyboardEnhancementFlags,
@@ -441,7 +441,11 @@ fn main() -> Result<()> {
                 // (enter_tui), so no frame-time Hide/Show is needed — the old
                 // per-frame Hide kept the cursor off for the entire diff
                 // write, which read as flicker in the input well whenever a
-                // scroll redraw rewrote the transcript pane.
+                // scroll redraw rewrote the transcript pane. The hidden
+                // hardware cursor is still *repositioned* onto the caret cell
+                // after every draw: terminals anchor IME candidate popups at
+                // the cursor, and the frame diff would otherwise leave it
+                // wherever the last cell write happened.
                 std::io::stdout().sync_update(|out| -> Result<()> {
                     terminal.draw(|f| ui::draw(f, &mut app))?;
                     app.needs_redraw = false;
@@ -464,6 +468,13 @@ fn main() -> Result<()> {
                         })
                         .collect();
                     let _ = thumbnails.sync(out, &shots);
+                    // Park the (hidden) hardware cursor on the caret cell so
+                    // IME composition/candidate popups anchor at the caret.
+                    // Last on purpose: the kitty writers above move the
+                    // cursor around while placing images.
+                    if let Some((col, row)) = app.caret_cell {
+                        let _ = execute!(out, MoveTo(col, row));
+                    }
                     Ok(())
                 })??;
             }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -141,6 +141,7 @@ pub fn draw(f: &mut Frame, app: &mut App) {
     let theme = app.theme;
     app.slot_actions.clear();
     app.pet_want = None;
+    app.caret_cell = None;
     f.render_widget(
         Block::default().style(
             Style::default()
@@ -2477,6 +2478,7 @@ fn draw_input(f: &mut Frame, app: &mut App, area: Rect) {
         );
         if composer_owns_cursor {
             paint_caret(f, area.x + pw as u16, area.y);
+            app.caret_cell = Some((area.x + pw as u16, area.y));
         }
         return;
     }
@@ -2605,6 +2607,21 @@ fn draw_input(f: &mut Frame, app: &mut App, area: Rect) {
     // `input_top` is the app-side mirror mouse hit-testing reads between
     // frames; keep it in lockstep with the editor's own scroll mirror.
     app.input_top = app.input.scroll_top;
+    // Track the painted caret cell so `main` can park the hidden hardware
+    // cursor on it after the frame (IME popups anchor there; the frame diff
+    // leaves the cursor wherever its last cell write happened). The widget's
+    // own screen cursor is authoritative — it is the cell the reversed
+    // caret style landed on.
+    if composer_owns_cursor {
+        let (row, col) = app.input.screen_cursor();
+        let top = app.input.scroll_top;
+        if row >= top && row - top < area.height as usize {
+            app.caret_cell = Some((
+                text_area.x.saturating_add(col as u16),
+                text_area.y.saturating_add((row - top) as u16),
+            ));
+        }
+    }
 }
 
 /// Rows of menu items shown at once; the window follows the selection
@@ -3154,14 +3171,15 @@ fn draw_elicitation_form(f: &mut Frame, app: &mut App, screen: Rect) {
     );
     f.render_widget(Paragraph::new(bottom), bottom_area);
     if let Some((row, col)) = field_cursor.filter(|(row, _)| *row < bottom_h) {
-        paint_caret(
-            f,
+        let caret = (
             bottom_area
                 .x
                 .saturating_add(col as u16)
                 .min(bottom_area.right().saturating_sub(1)),
             bottom_area.y.saturating_add(row as u16),
         );
+        paint_caret(f, caret.0, caret.1);
+        app.caret_cell = Some(caret);
     }
 }
 

--- a/tests/unit/ui__tests.rs
+++ b/tests/unit/ui__tests.rs
@@ -1162,6 +1162,66 @@ fn composer_caret_sits_on_wide_graphemes() {
     assert_eq!(caret_cells(&mut app, 80, 20), vec![(5, 16)]);
 }
 
+/// The hardware-cursor park target (`app.caret_cell`) must always equal the
+/// cell the frame painted the soft caret on: `main` parks the hidden
+/// hardware cursor there after every draw so IME candidate popups anchor at
+/// the caret (issue #66).
+#[test]
+fn caret_cell_tracks_the_painted_caret_in_the_composer() {
+    let mut app = test_app();
+    app.show_banner = false;
+    // Empty well: caret right of the ❯ prompt.
+    assert_eq!(caret_cells(&mut app, 80, 20), vec![(3, 16)]);
+    assert_eq!(app.caret_cell, Some((3, 16)));
+    // Draft end and mid-draft.
+    app.input.set("hello".into());
+    app.input.set_cursor_char(5);
+    assert_eq!(caret_cells(&mut app, 80, 20), vec![(8, 16)]);
+    assert_eq!(app.caret_cell, Some((8, 16)));
+    app.input.set_cursor_char(2);
+    assert_eq!(caret_cells(&mut app, 80, 20), vec![(5, 16)]);
+    assert_eq!(app.caret_cell, Some((5, 16)));
+}
+
+#[test]
+fn caret_cell_follows_wrapped_rows_and_hides_with_the_caret() {
+    let mut app = test_app();
+    app.show_banner = false;
+    // The well is 76 cells wide at 80x20; 77 chars wrap to a second row.
+    app.input.set("a".repeat(77));
+    app.input.set_cursor_char(77);
+    assert_eq!(caret_cells(&mut app, 80, 20), vec![(4, 17)]);
+    assert_eq!(app.caret_cell, Some((4, 17)));
+    // While elicitation owns input the composer paints no caret and no
+    // park target — the field's own caret takes over: the frame's only
+    // reversed cell is the field caret and the park target rides it, never
+    // the composer well row (y=16 at 80x20).
+    let mut app = test_app();
+    app.show_banner = false;
+    app.input.set("draft".into());
+    app.elicitation_ask = Some(crate::app::ElicitationAskOverlay {
+        form: crate::elicitation::ElicitationFormState::new(crate::elicitation::ElicitationForm {
+            message: "m".into(),
+            fields: vec![crate::elicitation::ElicitationField {
+                name: "f".into(),
+                custom_name: None,
+                title: "t".into(),
+                description: None,
+                required: true,
+                kind: crate::elicitation::ElicitationFieldKind::Text { default: None },
+            }],
+        }),
+        scroll: 0,
+        reply: None,
+    });
+    let cells = caret_cells(&mut app, 80, 20);
+    assert_eq!(app.caret_cell, cells.first().copied(), "park rides the field caret");
+    assert!(
+        cells.iter().all(|(_, y)| *y != 16),
+        "composer well shows no caret while elicitation owns input"
+    );
+}
+
 #[test]
 fn multiline_input_breaks_on_newlines() {
     let mut app = test_app();
@@ -2245,6 +2305,11 @@ fn elicitation_text_field_owns_the_terminal_cursor_instead_of_the_composer() {
             .modifier
             .contains(ratatui::style::Modifier::REVERSED),
         "elicitation field paints its own caret cell"
+    );
+    assert_eq!(
+        app.caret_cell,
+        Some((caret_x, answer_row)),
+        "hardware cursor parks on the elicitation field caret"
     );
     // The composer draft keeps no caret while the overlay owns input.
     let composer_row = (0..30)


### PR DESCRIPTION
## Problem

Fixes #66 — the hardware cursor no longer follows the caret, so IME candidate/composition popups (e.g. the first Chinese character typed into an empty composer) anchor at an arbitrary position.

The soft-cursor rework (d1b5d70) replaced the per-frame `set_cursor_position` calls with buffer-cell carets, but the hardware cursor — hidden for the whole session — was never repositioned afterwards. Terminals anchor IME popups at the cursor cell, so the candidate box appeared wherever the last frame diff write happened to leave the cursor.

## Fix

- `app.caret_cell` records the painted soft-caret cell every frame (empty well, wrapped draft via the textarea's own `screen_cursor()` + scroll mirror, elicitation field).
- After each synchronized frame — and after the kitty image writers that move the cursor around — `main` parks the still-hidden hardware cursor on that cell with `MoveTo`.
- The caret remains a steady reversed buffer cell: no flicker regression, and the cursor stays hidden for the whole session.

## Tests

- `caret_cell_tracks_the_painted_caret_in_the_composer` — empty well, draft end, mid-draft.
- `caret_cell_follows_wrapped_rows_and_hides_with_the_caret` — wrap to a second row; elicitation overlay takes the park target over and the composer well shows none.
- Extended `elicitation_text_field_owns_the_terminal_cursor_instead_of_the_composer` to assert the park target.
- `cargo test --locked` (539+2+1+1) and `cargo check --locked --tests` pass.

> Note: the candidate popup's final placement depends on the terminal anchoring IME to the (hidden) cursor cell — kitty/wezterm/ghostty do. If any terminal still misplaces it, a follow-up can temporarily Show the cursor over the caret.