### PR TITLE
fix(tui): pasted text keeps its newlines in the composer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ All notable changes to this project are documented here. The project follows
 
 ### Fixed
 
+- Pasting multi-line text into the composer keeps its line structure
+  instead of flattening every newline into a space; CRLF and CR-only
+  line endings (iTerm2 et al.) are normalized to plain rows too
+  (issue #54).
 - Scrolling the `/keys` popup or the chat transcript no longer leaves
   irregular black blocks on screen: orphan halves of wide (CJK) characters
   survived because the frame diff considered those cells unchanged; both

--- a/src/app.rs
+++ b/src/app.rs
@@ -2851,7 +2851,13 @@ impl App {
                     return;
                 }
                 self.slash_completion_dismissed = false;
-                self.input.insert_str(&text.replace('\n', " "));
+                // The composer is multi-line (soft wrap, ctrl+j), so pasted
+                // text keeps its line structure instead of being flattened
+                // to spaces (issue #54). `TextArea::insert_str` understands
+                // both `\n` and `\r\n`; normalize stray CR-only line
+                // endings some terminals (iTerm2 et al.) send.
+                let text = text.replace("\r\n", "\n").replace('\r', "\n");
+                self.input.insert_str(&text);
                 self.input_sel = None;
                 self.reconcile_attachments();
                 self.needs_redraw = true;

--- a/tests/unit/app__mode_tests.rs
+++ b/tests/unit/app__mode_tests.rs
@@ -1796,8 +1796,24 @@ fn ordinary_and_mixed_paste_payloads_are_not_treated_as_keys() {
         &ctl,
     );
 
-    assert_eq!(app.input.buf(), "hello world literal \u{1b}[99;5u");
+    // Pasted text keeps its line structure (issue #54); the CSI-u bytes
+    // are payload, never keys.
+    assert_eq!(app.input.buf(), "hello\nworld literal \u{1b}[99;5u");
     assert!(!app.quit);
+}
+
+#[test]
+fn paste_keeps_newlines_and_normalizes_cr_line_endings() {
+    let (mut app, ctl, _rx) = test_app();
+
+    app.handle(
+        AppEvent::Term(Event::Paste("a\r\nb\rc\nd".to_string())),
+        &ctl,
+    );
+
+    // CRLF and CR-only line endings (iTerm2 et al.) become plain LF rows.
+    assert_eq!(app.input.buf(), "a\nb\nc\nd");
+    assert_eq!(app.input.lines(), ["a", "b", "c", "d"]);
 }
 
 #[test]


### PR DESCRIPTION
## Problem

Fixes #54 — pasting multi-line text into the composer input loses the newlines (reported on macOS/iTerm2).

The `Event::Paste` handler flattened every `\n` into a space via `text.replace('\n', " ")` — a leftover from the initial single-line input era. The composer is multi-line today (soft wrap, ctrl+j hard newlines), so pasted line structure was silently destroyed. Additionally, CR-only line endings (iTerm2 et al.) were left as invisible control characters in the draft, which also read as "lost newlines".

## Fix

- `src/app.rs`: paste now keeps the line structure and normalizes CRLF / CR-only endings to plain LF rows:
  ```rust
  let text = text.replace("\r\n", "\n").replace('\r', "\n");
  self.input.insert_str(&text);
  ```
  `TextArea::insert_str` splits `\n`/`\r\n` natively. The send path needs no change — the whole multi-line draft goes into `session/prompt` as-is.
- The single-line elicitation form field keeps its intentional flattening.

## Tests

- Updated `ordinary_and_mixed_paste_payloads_are_not_treated_as_keys` — it had pinned the old flattening (`"hello\nworld"` → `"hello world"`); now expects the newlines preserved.
- New `paste_keeps_newlines_and_normalizes_cr_line_endings` — mixed `\r\n`/`\r`/`\n` endings become four plain rows.
- `cargo test --locked` (538+2+1+1) and `cargo check --locked --tests` pass.