### PR TITLE
fix(tui): table borders keep their color in aliased palettes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ All notable changes to this project are documented here. The project follows
   hardware cursor is repositioned onto the painted caret cell after every
   frame instead of being left wherever the last diff write happened
   (issue #66).
+- Table frames no longer show gaps in the vertical borders when a palette
+  aliases `border` onto a body gray (Ayu: border == fg_secondary): the
+  two-tone body pass no longer repaints box-drawing characters, so the
+  hand-drawn `├─┼─┤` junction rows between table rows match the frame
+  (issue #68).
 - Scrolling the `/keys` popup or the chat transcript no longer leaves
   irregular black blocks on screen: orphan halves of wide (CJK) characters
   survived because the frame diff considered those cells unchanged; both

--- a/src/markdown.rs
+++ b/src/markdown.rs
@@ -428,7 +428,13 @@ fn task_list_glyphs(prefix: Vec<Seg>, theme: &Theme) -> Vec<Seg> {
 fn two_tone(segs: Vec<Seg>, theme: &Theme) -> Vec<Seg> {
     let mut out = Vec::new();
     for seg in segs {
-        if is_body_style(seg.style, theme) {
+        // Box-drawing characters are structural borders, never body text:
+        // keep their own style. Palettes that alias `border` to a body gray
+        // (Ayu: border == fg_secondary == #686868) would otherwise pass them
+        // through the body check and repaint the table frame bright while
+        // the hand-drawn junction rows stay border-colored, leaving gaps in
+        // the vertical borders (issue #68).
+        if is_body_style(seg.style, theme) && !is_box_drawing(&seg.text) {
             for (run, is_cjk) in split_script(&seg.text) {
                 let fg = if is_cjk {
                     seg.style.fg.unwrap_or(theme.fg_secondary)
@@ -445,6 +451,20 @@ fn two_tone(segs: Vec<Seg>, theme: &Theme) -> Vec<Seg> {
         }
     }
     out
+}
+
+/// True when the whole run is box-drawing characters (table/code frames).
+fn is_box_drawing(s: &str) -> bool {
+    s.chars().all(|c| {
+        matches!(
+            c,
+            '─' | '━' | '│' | '┃' | '┌' | '┐' | '└' | '┘' | '├' | '┤' | '┬'
+                | '┴' | '┼' | '╭' | '╮' | '╰' | '╯' | '═' | '║' | '╔' | '╗'
+                | '╚' | '╝' | '╠' | '╣' | '╦' | '╩' | '╬' | '╒' | '╓' | '╕'
+                | '╖' | '╘' | '╙' | '╛' | '╜' | '╞' | '╟' | '╡' | '╢' | '╤'
+                | '╥' | '╧' | '╨' | '╪' | '╫'
+        )
+    })
 }
 
 /// "Plain body" styles: no background, body-gray or tertiary foreground, and

--- a/tests/unit/markdown__tests.rs
+++ b/tests/unit/markdown__tests.rs
@@ -284,6 +284,48 @@ fn table_renders_as_box_with_header_and_rows() {
         .any(|s| { s.content.contains("**b**") && s.style.bg == Some(theme.panel) })));
 }
 
+/// Palettes that alias `border` onto a body gray (Ayu: border ==
+/// fg_secondary == #686868) must not get their table frames repainted by
+/// the two-tone pass: every box-drawing span keeps the border color, so the
+/// hand-drawn `├─┼─┤` junction rows between body rows match the frame (the
+/// vertical borders keep no gaps; issue #68). Cell text still two-tones.
+#[test]
+fn table_borders_keep_border_color_when_a_palette_aliases_it() {
+    let mut theme = Theme::dark();
+    theme.border = theme.fg_secondary;
+    let md = "| A |\n|---|\n| 1 |\n| 2 |";
+    let lines = render(md, &theme, 40);
+    for l in &lines {
+        for s in &l.spans {
+            let box_drawing = s
+                .content
+                .chars()
+                .all(|c| matches!(c, '│' | '─' | '┌' | '┐' | '└' | '┘' | '├' | '┤' | '┼'));
+            if box_drawing {
+                assert_eq!(
+                    s.style.fg,
+                    Some(theme.border),
+                    "box-drawing span keeps the border color: {:?}",
+                    s.content
+                );
+            }
+        }
+    }
+    // The junction rows meet the columns and match the frame color.
+    let junction = lines
+        .iter()
+        .find(|l| plain(std::slice::from_ref(l)).starts_with('├'))
+        .expect("junction row");
+    assert_eq!(junction.spans[0].style.fg, Some(theme.border));
+    // Cell text is still two-toned: Latin digits render bright.
+    let digit = lines
+        .iter()
+        .flat_map(|l| l.spans.iter())
+        .find(|s| s.content == "1")
+        .expect("digit span");
+    assert_eq!(digit.style.fg, Some(theme.fg));
+}
+
 #[test]
 fn table_body_rows_are_separated_by_frame_lines() {
     let theme = Theme::dark();


### PR DESCRIPTION
## Problem

Fixes #68 — under the Ayu theme the table frame looks broken: the vertical borders have gaps at every row boundary (default theme is fine).

The two-tone body pass (`two_tone`) repaints every span it mistakes for body text, and it judges "body" by color alone (`is_body_style`). Ayu aliases three tokens to the same gray: `border == fg_secondary == fg_tertiary == #686868`. So tui-markdown's table-frame spans (styled `fg = border`) passed the body check and were repainted to the bright `theme.fg` — while the hand-drawn `├─┼─┤` junction rows inserted between table body rows (`table_row_separator`) never go through `two_tone` and keep `theme.border`. Bright verticals vs. dark junctions = gaps. The default theme's `border` differs from its body grays, so the frame spans keep their style and the two sides match.

## Fix

- `src/markdown.rs`: `two_tone` now skips pure box-drawing runs (`is_box_drawing`) — structural borders are never body text, so they keep their own style regardless of palette aliasing. Cell *text* still two-tones (bright Latin/digits, muted CJK).
- `tests/unit/markdown__tests.rs`: new `table_borders_keep_border_color_when_a_palette_aliases_it` — builds a theme with `border == fg_secondary` and asserts every box-drawing span (incl. the junction rows) keeps `theme.border` while cell text still renders bright `theme.fg`. Verified the test fails without the fix.
- `CHANGELOG.md`: entry under Fixed.

## Validation

- `cargo test --locked` (541+2+1+1) and `cargo check --locked --tests` pass.