### PR TITLE
fix(tui): misc improvements for issue #63

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ All notable changes to this project are documented here. The project follows
 
 ### Fixed
 
+- `ctrl+shift+k` (and vim `dd`) on the last line of the draft now
+  removes the whole line — including its newline, so the line above
+  becomes the last one — and lifts the cursor onto it; repeated presses
+  keep deleting upward. Killing a middle line still merges the next
+  line up (issue #63).
 - Pasting multi-line text into the composer keeps its line structure
   instead of flattening every newline into a space; CRLF and CR-only
   line endings (iTerm2 et al.) are normalized to plain rows too
@@ -53,6 +58,21 @@ All notable changes to this project are documented here. The project follows
 
 ### Added
 
+- The light/dark theme mode (`ctrl+t`, `/theme toggle`) now persists to
+  `settings.json` (`themeMode`) and is restored on the next launch; an
+  explicit `--theme <dark|light>` flag still overrides it for that run
+  (issue #63).
+- A gallery palette saved via `/theme <id>` (ayu, iceberg, …) is
+  re-activated on the next launch: the static gallery packs register with
+  no owner, so the boot restore pass now activates the saved pick after
+  they are all registered (dynamic packs were already restored by
+  `tui-local-plugins`) (issue #63).
+- Martty prints the live session id on stderr (`session <id>`) when the
+  TUI exits, so a later `--session-id <id>` can resume the same
+  conversation (issue #63).
+- The dock bar no longer advertises `/keys` in the shortcut hints — the
+  keymap lives in the tip banner and the `/keys` modal itself, and the
+  empty state now stays quiet (issue #63).
 - `/plugins` now renders the static Host plugin inventory as a two-level
   tree grouped by provider (npm scope) → plugin name, using the
   tui-tree-widget crate: every provider branch opens expanded by default,

--- a/npm/lib/boot.js
+++ b/npm/lib/boot.js
@@ -1,4 +1,25 @@
 /**
+ * Boot-time restore of a statically-registered gallery palette (ayu,
+ * iceberg, …). `/theme` persistence writes `settings.theme`; dynamic
+ * packs are restored by tui-local-plugins (they have an owner), but the
+ * builtin gallery registers with no owner, so nothing would re-activate
+ * the saved pick on the next launch. Runs after every static theme
+ * Plugin is registered; `activate` notifies the painter (or queues until
+ * `bindNotify` flushes). A broken or unknown id must not block boot.
+ */
+export function restorePreferredTheme(tuiTheme) {
+  const preferred = tuiTheme?.preferred?.()
+  if (typeof preferred !== 'string' || preferred === 'default') return
+  if (tuiTheme?.owner?.(preferred) !== undefined) return
+  if (!tuiTheme?.isLoaded?.(preferred)) return
+  try {
+    tuiTheme.activate(preferred)
+  } catch {
+    // a broken pack must not block TUI startup
+  }
+}
+
+/**
  * Cordis client boot: tuiTheme + tuiSlots + acp-client + TUI shell.
  *
  * The process root is a client tree. A profile launch injects Host ACP stdio;
@@ -65,6 +86,7 @@ export async function bootClient(options = {}) {
     await ctx.plugin({ name: 'tui-theme-everforest', inject: everforestInject, apply: applyEverforest })
     await ctx.plugin({ name: 'tui-theme-iceberg', inject: icebergInject, apply: applyIceberg })
     await ctx.plugin({ name: 'tui-theme-solarized', inject: solarizedInject, apply: applySolarized })
+    restorePreferredTheme(ctx.get('tuiTheme'))
     await ctx.plugin({ name: 'tui-slots', inject: [], apply: applySlots })
     await ctx.plugin({ name: 'tui-commands', inject: [], apply: applyCommands })
     await ctx.plugin({ name: 'tui-overlay', inject: [], apply: applyOverlay })
@@ -122,6 +144,7 @@ export async function bootClient(options = {}) {
     applyEverforest(ctx)
     applyIceberg(ctx)
     applySolarized(ctx)
+    restorePreferredTheme(ctx.tuiTheme)
     applySlots(ctx)
     applyCommands(ctx)
     applyOverlay(ctx)

--- a/scripts/tui-theme.test.mjs
+++ b/scripts/tui-theme.test.mjs
@@ -417,3 +417,76 @@ test('disposing static palette fibers unregisters their palettes', async () => {
   }
   assert.deepEqual(ctx.tuiTheme.list(), [{ id: 'default', label: 'Default' }])
 })
+
+test('boot restore re-activates a saved static gallery palette', async () => {
+  const bootUrl = pathToFileURL(path.join(repoRoot, 'npm/lib/boot.js')).href
+  const { restorePreferredTheme } = await import(bootUrl)
+  const dir = mkdtempSync(path.join(tmpdir(), 'dsh-tui-theme-restore-'))
+  const settingsPath = path.join(dir, 'settings.json')
+  try {
+    // First boot: user picks iceberg from the static gallery — persisted.
+    const firstCtx = makeCtx()
+    const first = installTuiTheme(firstCtx, { settingsPath })
+    const iceberg = JSON.parse(
+      readFileSync(path.join(repoRoot, 'npm/lib/palettes/iceberg.json'), 'utf8'),
+    )
+    first.register(iceberg)
+    first.activate('iceberg')
+    assert.equal(first.preferred(), 'iceberg')
+
+    // Second boot: the pack is registered again as a static (ownerless)
+    // palette; the saved id is active after the restore pass.
+    const secondCtx = makeCtx()
+    const sent = []
+    const second = installTuiTheme(secondCtx, {
+      settingsPath,
+      notify(method, params) {
+        sent.push({ method, params })
+      },
+    })
+    second.register(iceberg)
+    assert.equal(second.active(), 'default', 'static register must not cover')
+    restorePreferredTheme(second)
+    assert.equal(second.active(), 'iceberg', 'saved static palette is re-activated')
+    assert.equal(
+      sent.findLast((item) => item.params?.activate === true)?.params?.palette?.id,
+      'iceberg',
+      'painter receives the activation update',
+    )
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('boot restore ignores dynamic, unknown and default preferred ids', async () => {
+  const bootUrl = pathToFileURL(path.join(repoRoot, 'npm/lib/boot.js')).href
+  const { restorePreferredTheme } = await import(bootUrl)
+  const dir = mkdtempSync(path.join(tmpdir(), 'dsh-tui-theme-restore-'))
+  const settingsPath = path.join(dir, 'settings.json')
+  try {
+    // owner-registered palette → tui-local-plugins owns the restore.
+    const ownedCtx = makeCtx()
+    const owned = installTuiTheme(ownedCtx, { settingsPath })
+    const ember = loadEmber()
+    owned.registerOwned('local:ember', ember)
+    owned.observeSelected({ protocol: 0, id: 'ember' })
+    restorePreferredTheme(owned)
+    assert.equal(owned.active(), 'ember', 'dynamic packs are left to tui-local-plugins')
+
+    // unknown id → no throw, no activation.
+    const unknownCtx = makeCtx()
+    const unknown = installTuiTheme(unknownCtx, { settingsPath })
+    writeFileSync(settingsPath, JSON.stringify({ theme: 'not-a-palette' }))
+    assert.doesNotThrow(() => restorePreferredTheme(unknown))
+    assert.equal(unknown.active(), 'default')
+
+    // default → nothing to do.
+    const defCtx = makeCtx()
+    const def = installTuiTheme(defCtx, { settingsPath })
+    writeFileSync(settingsPath, JSON.stringify({ theme: 'default' }))
+    assert.doesNotThrow(() => restorePreferredTheme(def))
+    assert.equal(def.active(), 'default')
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})

--- a/src/app.rs
+++ b/src/app.rs
@@ -1354,7 +1354,7 @@ impl App {
     }
 
     pub fn new(
-        theme: Theme,
+        theme: Option<Theme>,
         cfg: RuntimeConfig,
         session_id: String,
         demo: bool,
@@ -1362,8 +1362,15 @@ impl App {
         bus_tx: Sender<AppEvent>,
     ) -> Self {
         let palettes = vec![crate::theme::PalettePack::builtin_default()];
-        let theme = palettes[0].theme(theme.mode);
         let settings = Self::load_settings(&cfg);
+        // Explicit `--theme` on the CLI wins; otherwise the persisted
+        // light/dark mode; otherwise the builtin default (dark).
+        let mode = theme
+            .as_ref()
+            .map(|t| t.mode)
+            .or_else(|| settings.theme_mode.as_deref().and_then(crate::theme::Mode::parse))
+            .unwrap_or(crate::theme::Mode::Dark);
+        let theme = palettes[0].theme(mode);
         let locale = settings.language;
         App {
             theme,
@@ -1641,6 +1648,7 @@ impl App {
 
     fn toggle_theme_mode(&mut self) {
         self.theme = self.theme.toggled();
+        self.save_settings();
         self.show_tip(format!(
             "theme: {} {}",
             self.active_palette_id,
@@ -3373,6 +3381,7 @@ impl App {
             .filter(|value: &serde_json::Value| value.is_object())
             .unwrap_or_else(|| serde_json::json!({}));
         current["language"] = serde_json::json!(self.locale);
+        current["themeMode"] = serde_json::json!(self.theme.mode.as_str());
         if let Ok(text) = serde_json::to_string_pretty(&current) {
             let _ = std::fs::write(path, text);
         }

--- a/src/input/composer.rs
+++ b/src/input/composer.rs
@@ -328,9 +328,12 @@ impl ComposerEditor {
         self.hist_pos = None;
     }
 
-    /// Delete the whole logical line under the cursor (including its
-    /// trailing newline, so the next line moves up). The cursor lands at
-    /// the line start. A no-op on an empty last line.
+    /// Delete the whole logical line under the cursor. A middle line dies
+    /// with its trailing newline, so the next line moves up and the
+    /// cursor lands at the merged line start. The last line dies with its
+    /// preceding newline (the line above becomes the last line) and the
+    /// cursor lifts onto it, so repeated presses keep deleting upward.
+    /// A single empty line is a no-op.
     pub fn kill_line(&mut self) {
         let DataCursor(row, _) = self.textarea.cursor();
         let lines = self.lines();
@@ -343,13 +346,25 @@ impl ComposerEditor {
             .map(|l| l.chars().count() + 1)
             .sum::<usize>();
         let line_chars = lines[row].chars().count();
-        let end = if row + 1 < lines.len() {
-            start + line_chars + 1 // include the newline separator
+        let last = row + 1 == lines.len();
+        let (delete_start, delete_len) = if last {
+            if row > 0 {
+                // The final line disappears together with its preceding
+                // newline; the line above takes its place.
+                (start - 1, line_chars + 1)
+            } else if line_chars > 0 {
+                (start, line_chars)
+            } else {
+                return; // a lone empty line has nothing to kill
+            }
         } else {
-            start + line_chars
+            (start, line_chars + 1) // include the newline separator
         };
-        if end > start {
-            self.delete_char_range(start, end);
+        if delete_len > 0 {
+            self.delete_char_range(delete_start, delete_start + delete_len);
+            if last && row > 0 {
+                self.move_cursor(CursorMove::Jump((row - 1) as u16, 0));
+            }
         }
     }
 

--- a/src/locale.rs
+++ b/src/locale.rs
@@ -104,6 +104,12 @@ pub struct UiSettings {
     pub language: Locale,
     #[serde(rename = "uiPreset")]
     pub ui_preset: String,
+    /// Persisted light/dark mode (`dark` | `light`). Absent → the CLI
+    /// `--theme` value or the builtin default. The palette pack id lives
+    /// in the same file under `theme`, owned by the compositor's
+    /// `tuiTheme` service.
+    #[serde(rename = "themeMode")]
+    pub theme_mode: Option<String>,
 }
 
 impl Default for UiSettings {
@@ -111,6 +117,7 @@ impl Default for UiSettings {
         Self {
             language: Locale::default(),
             ui_preset: default_ui_preset(),
+            theme_mode: None,
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -66,7 +66,7 @@ OPTIONS:
       --api-key <key>       sets DEEPSEEK_API_KEY for a spawned agent
       --agent <cmd>         ACP agent command (default: dsh-acp or $DSH_TUI_AGENT)
       --agent-arg <arg>     extra argument for --agent (repeatable)
-      --theme <dark|light>  DeepSeek Web UI palette (default: dark)
+      --theme <dark|light>  DeepSeek Web UI palette (default: persisted, then dark)
       --demo                scripted turns, no runtime / API key needed
       --demo-skin           ember gallery palette via the plugin runner (implies --demo)
       --attach-fds          speak ACP over inherited fds 3/4 (Node mux / demo-skin)
@@ -95,7 +95,7 @@ struct Args {
     api_key: Option<String>,
     agent: Option<String>,
     agent_args: Vec<String>,
-    theme: String,
+    theme: Option<String>,
     demo: bool,
     demo_skin: bool,
     attach_fds: bool,
@@ -120,7 +120,7 @@ fn parse_args_from(args: impl IntoIterator<Item = String>) -> Result<Args> {
         api_key: None,
         agent: None,
         agent_args: Vec::new(),
-        theme: "dark".into(),
+        theme: None,
         demo: false,
         demo_skin: false,
         attach_fds: false,
@@ -144,7 +144,7 @@ fn parse_args_from(args: impl IntoIterator<Item = String>) -> Result<Args> {
             "--api-key" => args_out.api_key = Some(take("--api-key")?),
             "--agent" => args_out.agent = Some(take("--agent")?),
             "--agent-arg" => args_out.agent_args.push(take("--agent-arg")?),
-            "--theme" => args_out.theme = take("--theme")?,
+            "--theme" => args_out.theme = Some(take("--theme")?),
             "--demo" => args_out.demo = true,
             "--demo-skin" => {
                 args_out.demo_skin = true;
@@ -363,7 +363,7 @@ fn main() -> Result<()> {
         };
         Controller::start_acp(cfg.clone(), endpoint, bus_tx.clone())
     };
-    let theme = ui::theme_for(&args.theme);
+    let theme = args.theme.as_deref().map(ui::theme_for);
     let mut app = App::new(
         theme,
         cfg,
@@ -536,6 +536,11 @@ fn main() -> Result<()> {
 
     controller.send(Cmd::Shutdown);
     restore_terminal();
+    // Out-of-band (stderr, never the ACP stdout channel): let the caller
+    // grab the live session id for `--session-id` resume.
+    if !app.demo {
+        eprintln!("session {}", app.session_id);
+    }
     run
 }
 
@@ -652,7 +657,7 @@ fn dump_frame(args: &Args, w: u16, h: u16) -> Result<()> {
     args_demo.demo = true;
     let cfg = build_config(&args_demo)?;
     let (bus_tx, bus_rx) = mpsc::channel::<AppEvent>();
-    let theme = ui::theme_for(&args.theme);
+    let theme = args.theme.as_deref().map(ui::theme_for);
     let mut app = App::new(theme, cfg, "dsh-demo".into(), true, false, bus_tx.clone());
     app.git_branch = ui::head_branch(&app.cfg.workspace);
 

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -109,6 +109,14 @@ impl Mode {
             Mode::Light => "light",
         }
     }
+
+    pub fn parse(s: &str) -> Option<Mode> {
+        match s {
+            "dark" => Some(Mode::Dark),
+            "light" => Some(Mode::Light),
+            _ => None,
+        }
+    }
 }
 
 /// Closed token names for protocol 0 palettes (`tuiTheme.register` / Cordis theme update).

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1549,7 +1549,8 @@ fn status_title(app: &App) -> Line<'static> {
 
 /// Contextual shortcut hints — a tiny state machine over (run state ×
 /// draft): what Enter does *right now*, how to interrupt, how to steer
-/// immediately. Idle+empty falls back to the `/keys` discovery hint.
+/// immediately. Idle+empty renders nothing (`/keys` lives in the tip
+/// banner, not the dock).
 fn context_hints(app: &App) -> Vec<Span<'static>> {
     let theme = app.theme;
     let key = Style::default()
@@ -1599,13 +1600,11 @@ fn context_hints(app: &App) -> Vec<Span<'static>> {
                 ("ctrl+⏎", "steer"),
                 ("esc", app.locale.tr("interrupt", "中断")),
             ],
-            // Idle, empty: point at the FIFO editor or the shortcut list
-            // (ctrl+k belongs to the text editor; /keys opens the modal).
-            (false, true) if app.queued > 0 => vec![
-                (edit_queue_key, app.locale.tr("edit queue", "编辑队列")),
-                ("/keys", app.locale.tr("keys", "快捷键")),
-            ],
-            (false, true) => vec![("/keys", app.locale.tr("keys", "快捷键"))],
+            // Idle, empty: point at the FIFO editor; otherwise nothing.
+            (false, true) if app.queued > 0 => {
+                vec![(edit_queue_key, app.locale.tr("edit queue", "编辑队列"))]
+            }
+            (false, true) => vec![],
             // Idle with a draft: enter's meaning follows the prefix.
             (false, false) if app.input.lines()[0].starts_with('/') => {
                 vec![("⏎", app.locale.tr("command", "命令"))]
@@ -1625,10 +1624,12 @@ fn context_hints(app: &App) -> Vec<Span<'static>> {
         spans.push(Span::styled(k.to_string(), key));
         spans.push(Span::styled(format!(" {l}"), lbl));
     }
-    spans.push(Span::styled(
-        " · ".to_string(),
-        Style::default().fg(theme.border),
-    ));
+    if !pairs.is_empty() {
+        spans.push(Span::styled(
+            " · ".to_string(),
+            Style::default().fg(theme.border),
+        ));
+    }
     spans
 }
 

--- a/tests/unit/app__mode_tests.rs
+++ b/tests/unit/app__mode_tests.rs
@@ -36,7 +36,7 @@ fn test_app() -> (App, Controller, Receiver<AppEvent>) {
     let cfg = test_cfg();
     let (tx, rx) = std::sync::mpsc::channel::<AppEvent>();
     let ctl = Controller::start(cfg.clone(), true, None, tx.clone());
-    let app = App::new(Theme::dark(), cfg, "dsh-test".into(), true, false, tx);
+    let app = App::new(Some(Theme::dark()), cfg, "dsh-test".into(), true, false, tx);
     (app, ctl, rx)
 }
 
@@ -62,7 +62,7 @@ fn legacy_mode_cache_is_neither_read_nor_written() {
     let (tx, rx) = std::sync::mpsc::channel::<AppEvent>();
     let ctl = Controller::start(cfg.clone(), true, None, tx.clone());
     let mut app = App::new(
-        Theme::dark(),
+        Some(Theme::dark()),
         cfg.clone(),
         "s1".into(),
         true,
@@ -137,7 +137,7 @@ fn lang_switch_repaints_immediately_and_persists_for_the_workspace() {
     let (tx, _rx) = std::sync::mpsc::channel::<AppEvent>();
     let (ctl, _commands) = crate::controller::tests::test_controller();
     let mut app = App::new(
-        Theme::dark(),
+        Some(Theme::dark()),
         cfg.clone(),
         "s1".into(),
         true,
@@ -154,7 +154,7 @@ fn lang_switch_repaints_immediately_and_persists_for_the_workspace() {
         "{frame}"
     );
 
-    let mut restarted = App::new(Theme::dark(), cfg, "s2".into(), true, false, tx);
+    let mut restarted = App::new(Some(Theme::dark()), cfg, "s2".into(), true, false, tx);
     restarted.show_banner = false;
     let frame = crate::ui::dump_frame(&mut restarted, 100, 24);
     assert!(
@@ -763,7 +763,7 @@ fn the_client_agents_selection_can_open_any_subagent_or_return_to_main() {
 fn live_subagent_changes_publish_a_client_compositor_snapshot() {
     let cfg = test_cfg();
     let (tx, _rx) = std::sync::mpsc::channel::<AppEvent>();
-    let mut app = App::new(Theme::dark(), cfg, "live-session".into(), false, true, tx);
+    let mut app = App::new(Some(Theme::dark()), cfg, "live-session".into(), false, true, tx);
     let (ctl, commands) = crate::controller::tests::test_controller();
 
     app.handle(
@@ -2358,7 +2358,7 @@ fn live_queue_changes_publish_a_client_compositor_snapshot() {
 
     let cfg = test_cfg();
     let (tx, _rx) = std::sync::mpsc::channel::<AppEvent>();
-    let mut app = App::new(Theme::dark(), cfg, "live-session".into(), false, true, tx);
+    let mut app = App::new(Some(Theme::dark()), cfg, "live-session".into(), false, true, tx);
     let (ctl, commands) = crate::controller::tests::test_controller();
     app.state = RunState::Running;
     app.input.set("queued from composer".into());
@@ -2402,7 +2402,7 @@ fn live_queue_snapshot_contains_every_queued_prompt() {
 
     let cfg = test_cfg();
     let (tx, _rx) = std::sync::mpsc::channel::<AppEvent>();
-    let mut app = App::new(Theme::dark(), cfg, "live-session".into(), false, true, tx);
+    let mut app = App::new(Some(Theme::dark()), cfg, "live-session".into(), false, true, tx);
     let (ctl, commands) = crate::controller::tests::test_controller();
     app.state = RunState::Running;
 

--- a/tests/unit/app__palette_tests.rs
+++ b/tests/unit/app__palette_tests.rs
@@ -30,7 +30,7 @@ fn test_app() -> (App, Controller, Receiver<AppEvent>) {
     };
     let (tx, rx) = std::sync::mpsc::channel::<AppEvent>();
     let ctl = Controller::start(cfg.clone(), true, None, tx.clone());
-    let app = App::new(Theme::dark(), cfg, "dsh-test".into(), true, false, tx);
+    let app = App::new(Some(Theme::dark()), cfg, "dsh-test".into(), true, false, tx);
     (app, ctl, rx)
 }
 
@@ -422,4 +422,55 @@ fn invalid_palette_keeps_previous_theme() {
     );
     assert_eq!(app.active_palette_id, "default");
     assert_eq!(app.theme.brand, DEEPSEEK_450);
+}
+
+#[test]
+fn theme_mode_persists_across_restarts_unless_cli_overrides() {
+    let cfg = RuntimeConfig {
+        bin: "demo".into(),
+        cordis: "demo".into(),
+        workspace: "/tmp".into(),
+        session_root: fresh_root(),
+        provider: "deepseek-official".into(),
+        model: "deepseek-v4-flash".into(),
+        max_tokens: None,
+        base_url: None,
+        api_key: None,
+    };
+    let (tx, _rx) = std::sync::mpsc::channel::<AppEvent>();
+    let (ctl, _commands) = crate::controller::tests::test_controller();
+
+    // Explicit CLI light wins at startup; ctrl+t flips to dark and persists.
+    let mut app = App::new(
+        Some(Theme::light()),
+        cfg.clone(),
+        "s1".into(),
+        true,
+        false,
+        tx.clone(),
+    );
+    assert_eq!(app.theme.mode, crate::theme::Mode::Light);
+    app.handle(
+        AppEvent::Term(Event::Key(KeyEvent::new(
+            KeyCode::Char('t'),
+            crossterm::event::KeyModifiers::CONTROL,
+        ))),
+        &ctl,
+    );
+    assert_eq!(app.theme.mode, crate::theme::Mode::Dark);
+    let path = crate::runtime::settings_path(&cfg.session_root);
+    let saved: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(&path).expect("settings.json written on toggle"),
+    )
+    .expect("settings.json is valid JSON");
+    assert_eq!(saved["themeMode"], "dark", "{saved}");
+
+    // Restart with no CLI flag → the persisted dark mode comes back.
+    let restarted = App::new(None, cfg.clone(), "s2".into(), true, false, tx.clone());
+    assert_eq!(restarted.theme.mode, crate::theme::Mode::Dark);
+    assert_eq!(restarted.theme.brand, Theme::dark().brand);
+
+    // A restart with an explicit --theme still overrides persistence.
+    let cli_light = App::new(Some(Theme::light()), cfg, "s3".into(), true, false, tx);
+    assert_eq!(cli_light.theme.mode, crate::theme::Mode::Light);
 }

--- a/tests/unit/app__persistent_shell_tests.rs
+++ b/tests/unit/app__persistent_shell_tests.rs
@@ -14,7 +14,7 @@ fn test_app(workspace: &std::path::Path) -> (App, Receiver<AppEvent>) {
         api_key: None,
     };
     let (tx, rx) = std::sync::mpsc::channel::<AppEvent>();
-    let app = App::new(Theme::dark(), cfg, "dsh-test".into(), true, false, tx);
+    let app = App::new(Some(Theme::dark()), cfg, "dsh-test".into(), true, false, tx);
     (app, rx)
 }
 

--- a/tests/unit/app__resume_tests.rs
+++ b/tests/unit/app__resume_tests.rs
@@ -15,7 +15,7 @@ fn test_app_with_root(root: &str, workspace: &str) -> (App, Controller) {
     };
     let (tx, _rx) = std::sync::mpsc::channel::<AppEvent>();
     let ctl = Controller::start(cfg.clone(), true, None, tx.clone());
-    let app = App::new(Theme::dark(), cfg, "dsh-current".into(), true, false, tx);
+    let app = App::new(Some(Theme::dark()), cfg, "dsh-current".into(), true, false, tx);
     (app, ctl)
 }
 

--- a/tests/unit/app__right_slot_tests.rs
+++ b/tests/unit/app__right_slot_tests.rs
@@ -19,7 +19,7 @@ fn test_app() -> (App, Controller, Receiver<AppEvent>) {
     };
     let (tx, rx) = std::sync::mpsc::channel::<AppEvent>();
     let ctl = Controller::start(cfg.clone(), true, None, tx.clone());
-    let app = App::new(Theme::dark(), cfg, "dsh-test".into(), true, false, tx);
+    let app = App::new(Some(Theme::dark()), cfg, "dsh-test".into(), true, false, tx);
     (app, ctl, rx)
 }
 

--- a/tests/unit/app__scroll_tests.rs
+++ b/tests/unit/app__scroll_tests.rs
@@ -17,7 +17,7 @@ fn test_app() -> (App, Receiver<AppEvent>) {
         api_key: None,
     };
     let (tx, rx) = std::sync::mpsc::channel::<AppEvent>();
-    let app = App::new(Theme::dark(), cfg, "s1".into(), true, false, tx);
+    let app = App::new(Some(Theme::dark()), cfg, "s1".into(), true, false, tx);
     (app, rx)
 }
 

--- a/tests/unit/app__selection_tests.rs
+++ b/tests/unit/app__selection_tests.rs
@@ -52,7 +52,7 @@ fn test_app() -> App {
     };
     let (tx, _rx) = std::sync::mpsc::channel();
     App::new(
-        crate::theme::Theme::dark(),
+        Some(crate::theme::Theme::dark()),
         cfg,
         "dsh-test".into(),
         true,
@@ -76,7 +76,7 @@ fn test_app_and_ctl() -> (App, Controller) {
     let (tx, _rx) = std::sync::mpsc::channel::<AppEvent>();
     let ctl = Controller::start(cfg.clone(), true, None, tx.clone());
     let app = App::new(
-        crate::theme::Theme::dark(),
+        Some(crate::theme::Theme::dark()),
         cfg,
         "dsh-test".into(),
         true,

--- a/tests/unit/input__composer__tests.rs
+++ b/tests/unit/input__composer__tests.rs
@@ -335,27 +335,52 @@ fn kill_line_removes_the_logical_line_and_merges() {
     assert_eq!(e.cursor_char(), 4, "cursor at the merged line start");
 
     e.kill_line();
-    assert_eq!(e.buf(), "one\n", "last content line dies");
+    assert_eq!(e.buf(), "one", "the last line dies with its newline");
+    assert_eq!(e.cursor_char(), 0, "cursor lifts onto the previous line");
     e.kill_line();
-    assert_eq!(e.buf(), "one\n", "the trailing empty line is a no-op");
-
-    e.set_cursor_char(0);
-    e.kill_line();
-    assert_eq!(e.buf(), "", "first line + newline go away");
+    assert_eq!(e.buf(), "", "the final lone line empties out");
     e.kill_line();
     assert_eq!(e.buf(), "", "empty draft: no-op");
 }
 
 #[test]
-fn kill_line_on_the_last_line_keeps_its_newline_friends() {
+fn kill_line_on_the_trailing_empty_line_removes_it() {
     let mut e = ComposerEditor::new();
     e.insert_str("a\nb\n");
     e.set_cursor_char(e.buf().chars().count()); // end of the empty last line
     e.kill_line();
-    assert_eq!(e.buf(), "a\nb\n", "empty last line is a no-op");
-    e.set_cursor_char(2);
+    assert_eq!(e.buf(), "a\nb", "the empty last line dies with its newline");
+    assert_eq!(e.cursor_char(), 2, "cursor lifts onto the line above");
     e.kill_line();
-    assert_eq!(e.buf(), "a\n", "last content line dies, newline stays");
+    assert_eq!(e.buf(), "a", "the next last line dies too");
+    assert_eq!(e.cursor_char(), 0);
+    e.kill_line();
+    assert_eq!(e.buf(), "", "the lone line empties out");
+    e.kill_line();
+    assert_eq!(e.buf(), "", "empty draft: no-op");
+}
+
+#[test]
+fn kill_line_on_the_last_line_removes_it_and_lifts_the_cursor() {
+    let mut e = ComposerEditor::new();
+    e.insert_str("a\nb");
+    e.set_cursor_char(2); // on the last content line
+    e.kill_line();
+    assert_eq!(e.buf(), "a", "the last line disappears entirely");
+    assert_eq!(e.cursor_char(), 0, "cursor moves up onto the previous line");
+
+    // Repeated presses keep deleting upward.
+    e.kill_line();
+    assert_eq!(e.buf(), "", "the lone line empties out");
+    assert_eq!(e.cursor_char(), 0);
+
+    // Single-line draft: nothing above, cursor stays on the empty draft.
+    let mut e = ComposerEditor::new();
+    e.insert_str("hello");
+    e.set_cursor_char(3);
+    e.kill_line();
+    assert_eq!(e.buf(), "");
+    assert_eq!(e.cursor_char(), 0);
 }
 
 #[test]

--- a/tests/unit/main__cli_args_tests.rs
+++ b/tests/unit/main__cli_args_tests.rs
@@ -115,6 +115,6 @@ fn dump_frame_does_not_swallow_the_next_flag() {
     ])
     .unwrap();
     assert_eq!(args.dump_frame, Some((100, 34)));
-    assert_eq!(args.theme, "light");
+    assert_eq!(args.theme.as_deref(), Some("light"));
     assert!(args.demo);
 }

--- a/tests/unit/ui__rpc_probe.rs
+++ b/tests/unit/ui__rpc_probe.rs
@@ -19,7 +19,7 @@ fn probe_app() -> App {
         api_key: None,
     };
     let (tx, _rx) = mpsc::channel();
-    App::new(Theme::dark(), cfg, "dsh-test".into(), true, false, tx)
+    App::new(Some(Theme::dark()), cfg, "dsh-test".into(), true, false, tx)
 }
 
 fn push_view(app: &mut App, ctl: &crate::controller::Controller, text: &str) {

--- a/tests/unit/ui__tests.rs
+++ b/tests/unit/ui__tests.rs
@@ -29,7 +29,7 @@ fn test_app() -> App {
         api_key: None,
     };
     let (tx, _rx) = mpsc::channel();
-    App::new(Theme::dark(), cfg, "dsh-test".into(), true, false, tx)
+    App::new(Some(Theme::dark()), cfg, "dsh-test".into(), true, false, tx)
 }
 
 fn live_test_app() -> App {
@@ -45,7 +45,7 @@ fn live_test_app() -> App {
         api_key: None,
     };
     let (tx, _rx) = mpsc::channel();
-    App::new(Theme::dark(), cfg, "pending".into(), false, true, tx)
+    App::new(Some(Theme::dark()), cfg, "pending".into(), false, true, tx)
 }
 
 #[test]
@@ -320,7 +320,7 @@ fn live_meta_row_hides_session_options_until_session_bound() {
 
     assert_eq!(flat_line(status_title(&app)), "");
     let pending = flat_spans(status_right(&app));
-    assert!(pending.contains("/keys keys"), "{pending}");
+    assert!(!pending.contains("/keys"), "{pending}");
     assert!(!pending.contains("deepseek-chat"), "{pending}");
     assert!(!pending.contains("high"), "{pending}");
 
@@ -429,10 +429,10 @@ fn meta_row_hints_follow_the_state_machine() {
         spans.iter().map(|s| s.content.as_ref()).collect::<String>()
     };
     let mut app = test_app();
-    // idle · empty → /keys discovery hint (ctrl+k belongs to the editor)
+    // idle · empty → no dock hint at all (no /keys; ctrl+k belongs to the editor)
     let s = flat(context_hints(&app));
-    assert!(s.contains("/keys keys"), "{s}");
-    assert!(!s.contains("^k"), "{s}");
+    assert!(s.is_empty(), "{s}");
+    assert!(!s.contains("keys"), "{s}");
     // idle · draft → enter sends
     app.input.set("hello".into());
     let s = flat(context_hints(&app));

--- a/tests/unit/ui_diff_option__tests.rs
+++ b/tests/unit/ui_diff_option__tests.rs
@@ -32,7 +32,7 @@ fn test_app() -> App {
         api_key: None,
     };
     let (tx, _rx) = mpsc::channel();
-    App::new(Theme::dark(), cfg, "dsh-test".into(), true, false, tx)
+    App::new(Some(Theme::dark()), cfg, "dsh-test".into(), true, false, tx)
 }
 
 /// Issue #38: scrolled CJK content leaves orphan halves of wide chars on the


### PR DESCRIPTION
Closes #63 — four small improvements:

1. **Dock bar no longer advertises `/keys`** — idle+empty renders nothing (the keymap lives in the tip banner and the `/keys` modal); empty hint sets no longer emit a stray `·` separator.
2. **Light/dark theme mode persists** — `themeMode` is stored in `settings.json` next to the compositor-owned palette id (`theme`); `ctrl+t` / `/theme toggle` write it, `App::new` restores it on launch, and an explicit `--theme <dark|light>` flag still wins for that run. The `--theme` CLI arg is now `Option` so "unset" is distinguishable from "explicit".
3. **`ctrl+shift+k` on the last line removes the whole line** — the final line dies together with its preceding newline, so the line above becomes the last one and the cursor lifts onto it; repeated presses keep deleting upward (vim `dd` shares the path).
4. **Session id printed on exit** — `session <id>` goes to stderr (never the ACP stdout channel) after the terminal is restored, so a later `--session-id <id>` can resume the same conversation. Demo runs skip it.

Also fixes the related palette-restore gap found while testing: **a gallery palette saved via `/theme <id>` (ayu, iceberg, …) is now re-activated at boot** — the static gallery packs register without an owner, so `tui-local-plugins` skipped them and the saved pick was lost on restart. A boot restore pass (`restorePreferredTheme`) activates the preferred palette after every static theme plugin registers; dynamic packs keep their existing restore path.

Verification: `cargo test --locked` (547), `cargo check --locked --tests`, `npm test --prefix npm` (210) all green; end-to-end pty runs confirmed persistence write+restore, boot palette restore, and the line-kill behavior.