### PR TITLE
fix(tui): /status opens the popup on a fresh start (issue #53)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ All notable changes to this project are documented here. The project follows
 
 ### Fixed
 
+- `/status` on runs without a Client tree (demo, standalone painter) now
+  opens the same popup as `/keys`, `/help` and `/session` instead of pushing
+  into the scrollback: directly after startup the transcript was hidden
+  behind the welcome banner, so the command appeared to do nothing until a
+  conversation dismissed the banner (issue #53).
 - `ctrl+shift+k` (and vim `dd`) on the last line of the draft now
   removes the whole line — including its newline, so the line above
   becomes the last one — and lifts the cursor onto it; repeated presses

--- a/src/app.rs
+++ b/src/app.rs
@@ -5743,8 +5743,8 @@ context, subagent lifecycles, token usage (incl. cache hits), end reason.";
     }
 
     /// Open one builtin info dialog (popup) from a markdown body. `/keys`,
-    /// `/help` and `/session` share this surface, so the facts never land in
-    /// the scrollback as transcript cells.
+    /// `/help`, `/session` and the painter-side `/status` fallback share this
+    /// surface, so the facts never land in the scrollback as transcript cells.
     fn open_text_overlay(&mut self, id: &str, title: String, text: String) {
         self.view_overlay = Some(ViewOverlay {
             id: id.into(),
@@ -5858,7 +5858,16 @@ context, subagent lifecycles, token usage (incl. cache hits), end reason.";
             perm_label,
             if self.modes.plan { "on" } else { "off" },
         ));
-        self.transcript.push_markdown(text);
+        // Same popup surface as `/keys`, `/help` and `/session` (issue #53):
+        // a status pushed into the transcript would be invisible behind the
+        // welcome banner on a fresh start — the chat pane only draws the
+        // banner while `show_banner` is set — and would pollute the
+        // scrollback with facts that belong to the overlay.
+        self.open_text_overlay(
+            "builtin.status",
+            self.locale.tr("Status", "状态").to_string(),
+            text,
+        );
     }
 }
 

--- a/src/transcript.rs
+++ b/src/transcript.rs
@@ -88,11 +88,6 @@ pub enum CellKind {
         level: NoticeLevel,
         text: String,
     },
-    /// A notice rendered through the markdown pipeline (headings, tables,
-    /// inline code) instead of plain wrapped text — used by `/keys`.
-    MarkdownNotice {
-        text: String,
-    },
 }
 
 pub struct Cell {
@@ -319,12 +314,6 @@ fn build_body(
             }
             (lines, 0)
         }
-        CellKind::MarkdownNotice { text } => {
-            if text.trim().is_empty() {
-                return (Vec::new(), 0);
-            }
-            (crate::markdown::render(text, theme, width), 0)
-        }
         _ => (Vec::new(), 0),
     }
 }
@@ -479,14 +468,6 @@ impl Transcript {
 
     pub fn push_notice(&mut self, level: NoticeLevel, text: String) {
         self.cells.push(Cell::new(CellKind::Notice { level, text }));
-    }
-
-    /// Push a notice rendered through the markdown pipeline (tables,
-    /// headings, inline code). No `· ` prefix and no manual wrapping: the
-    /// markdown renderer owns line layout and truncation.
-    pub fn push_markdown(&mut self, text: String) {
-        self.cells
-            .push(Cell::new(CellKind::MarkdownNotice { text }));
     }
 
     pub fn push_shell(&mut self, command: String) -> usize {
@@ -991,7 +972,6 @@ impl Transcript {
                     | CellKind::Assistant { .. }
                     | CellKind::Tool { .. }
                     | CellKind::Shell { .. }
-                    | CellKind::MarkdownNotice { .. }
             ) {
                 cell.ensure_render(theme, width as u16, expanded, thumbs);
             }
@@ -1331,16 +1311,6 @@ impl Transcript {
                             ]),
                             None,
                         );
-                    }
-                }
-                CellKind::MarkdownNotice { text } => {
-                    if text.trim().is_empty() {
-                        continue;
-                    }
-                    emit(&mut out, &mut owners, Line::default(), None);
-                    let render = cell.render.as_ref().expect("body cache");
-                    for l in &render.body {
-                        emit(&mut out, &mut owners, l.clone(), None);
                     }
                 }
             }

--- a/tests/unit/app__right_slot_tests.rs
+++ b/tests/unit/app__right_slot_tests.rs
@@ -453,9 +453,14 @@ fn status_slash_fallback_shows_run_state_without_transcript_stats() {
 
     app.run_slash("status", "", &ctl);
 
-    let last = app.transcript.cells.last().expect("status cell");
-    let crate::transcript::CellKind::MarkdownNotice { text } = &last.kind else {
-        panic!("/status should be a markdown notice, got {:?}", last.kind);
+    // The fallback opens the same popup surface as `/keys`, `/help` and
+    // `/session` (issue #53): a transcript cell would be invisible behind the
+    // welcome banner on a fresh start (the chat pane only draws the banner
+    // while `show_banner` is set) and would pollute the scrollback.
+    let overlay = app.view_overlay.as_ref().expect("/status opens the overlay");
+    assert_eq!(overlay.id, "builtin.status");
+    let crate::slots::TuiNode::Markdown { text, .. } = &overlay.nodes[0] else {
+        panic!("/status overlay should be one markdown node, got {:?}", overlay.nodes);
     };
     assert!(text.contains("## status"), "{text}");
     assert!(text.contains("- state · "), "{text}");
@@ -474,6 +479,10 @@ fn status_slash_fallback_shows_run_state_without_transcript_stats() {
     assert!(!text.contains("- LLM ·"), "{text}");
     assert!(!text.contains("- TTFT avg ·"), "{text}");
     assert!(!text.contains("- rate ·"), "{text}");
+    assert!(
+        app.transcript.cells.is_empty(),
+        "the status facts never land in the scrollback"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Closes #53

## Problem

After startup, typing `/help` directly appeared to do nothing; the
`/help /status /session` displays only showed up after sending an
arbitrary conversation first.

Root cause: on a fresh start `show_banner` is set and the chat pane
draws **only** the welcome banner — transcript lines are never
rendered (`draw_chat` gates `lines.extend(layout.lines)` behind
`!app.show_banner`). Any command that pushed its output into the
transcript was therefore invisible until the first conversation
dismissed the banner.

`/help` and `/session` were already migrated to the popup overlay
surface (issue #49 work); the painter-side `/status` fallback (runs
without a Client tree: demo, standalone painter) was still pushing
into the scrollback.

## Fix

- `push_status_info` now opens the same `open_text_overlay` popup as
  `/keys`, `/help` and `/session` (`builtin.status`), mirroring what
  the Client-tree `status-view` plugin does on live runs. Facts never
  land in the scrollback as transcript cells.
- Removed the now-dead `CellKind::MarkdownNotice` variant and
  `Transcript::push_markdown` (no external references; transcript
  cells are not part of the session JSONL persistence).
- Updated the fallback unit test to assert the overlay + untouched
  transcript; CHANGELOG entry.

## Verification

- Manual: fresh `martty --demo` → `/status` at startup opens the
  overlay immediately; `/help` and `/session` behave identically.
- `cargo test --locked --bin martty`: 543 passed.
- `cargo build --locked` / `cargo check --locked --tests`: no new
  warnings.