### PR TITLE
feat(tui): @file workspace mentions with a ratatui-explorer browser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project are documented here. The project follows
 
 ## [Unreleased]
 
+### Added
+
+- `@file` mentions in the composer (issue #62): typing `@` at a word
+  boundary opens a workspace file browser (ratatui-explorer) above the
+  input. The query's directory prefix descends as you type (`@src/m` opens
+  `src/` and jumps to the first `ma*` entry), `↑/↓` move, `Tab`/`→` drill
+  into a directory (rewriting the token to `@dir/`), `←` goes up, `Enter`
+  picks (`@path`, `@"path with spaces"` quoted automatically, directories
+  keep their trailing `/`), `Esc` dismisses the token until its text
+  changes. Emails and URL hosts never trigger; the `@"…"` form allows
+  spaces and keeps the quote open while drilling. The browser colors from
+  the active theme tokens (panel/border/fg/brand/chip_bg), so palette
+  packs and both UI presets apply.
+
 ### Fixed
 
 - `ctrl+shift+k` (and vim `dd`) on the last line of the draft now

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -532,6 +532,7 @@ dependencies = [
  "image",
  "libc",
  "ratatui",
+ "ratatui-explorer",
  "ratatui-textarea",
  "ruzstd",
  "serde",
@@ -646,10 +647,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "educe"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d7bc049e1bd8cdeb31b68bbd586a9464ecf9f3944af3958a7a9d0f8b9799417"
+dependencies = [
+ "enum-ordinalize",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "either"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
+
+[[package]]
+name = "enum-ordinalize"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89dd01549b09589510cf0647475075d12071456586d70f5c75c98ae2a5537677"
+dependencies = [
+ "enum-ordinalize-derive",
+]
+
+[[package]]
+name = "enum-ordinalize-derive"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a65863d15a4ce2888bd2f0f543cc963d3879c3a022c8ee43f6141d479a3ac815"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
 
 [[package]]
 name = "equivalent"
@@ -1768,6 +1801,16 @@ dependencies = [
  "crossterm",
  "instability",
  "ratatui-core",
+]
+
+[[package]]
+name = "ratatui-explorer"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1034d08c806b090cf2eb450f60717e38d28b3a0a9fae01eee282db488d2e513b"
+dependencies = [
+ "educe",
+ "ratatui",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,8 @@ anyhow = "1"
 libc = "0.2"
 signal-hook = "0.3"
 crossterm = "0.29"
-ratatui = "0.30.2"
+ratatui = { version = "0.30.2", features = ["unstable-widget-ref"] }
+ratatui-explorer = "0.3"
 ratatui-textarea = "0.9.2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/docs/composer-input.md
+++ b/docs/composer-input.md
@@ -112,6 +112,25 @@ Composer（底部输入区）自 v0.2.27 起基于 [`ratatui-textarea`](https://
 - `⌫` 或 `delete` 碰到芯片会整块删除（并取消暂存的图片），不会只删一个括号
 - 编辑删除文本中的芯片文本时，托盘自动同步清理
 
+### 6.1 `@file` 路径提及（文件浏览器）
+
+在词边界输入 `@`（行首、空白或标点后；email、URL 中的 `@` 不触发）打开
+workspace 文件浏览器，悬停在输入区上方：
+
+| 按键 | 行为 |
+|---|---|
+| `↑` / `↓` | 移动选择（浏览器打开时输入区的上下键让位） |
+| `←` | 上一级目录（纯浏览，不改草稿） |
+| `→` / `tab` | 目录行下钻 / 文件行落定；下钻把 token 改写为 `@dir/` |
+| `enter` | 落定：文件 → `@path`，目录 → `@dir/`（带空格路径自动转 `@"…"` 引号形式） |
+| `esc` | 关闭浏览器；同一 token 文本不变不会重新弹出 |
+| `home` / `end` / `pgup` / `pgdn` | 首 / 尾 / 翻页 |
+
+- 输入会实时驱动浏览器：`@src/m` 自动进入 `src/` 并选中第一个 `ma*` 条目
+- 引号形式 `@"dir with space/` 在目录下钻时保持引号打开，可继续输入
+- 选中的只是提示文本（`@path`），与文件内容、附件无关；宿主按
+  workspace 相对路径解析（尾斜杠 = 目录）
+
 ### 7. 鼠标
 
 | 操作 | 行为 |
@@ -220,9 +239,28 @@ textarea_mut() -> &mut TextArea // 直接操作 widget（会失效化布局镜�
   全部走 `classify → dispatch` 显式调用。
 - 未启用的库能力：搜索高亮（`search` feature）、行号、placeholder（自绘）。
 
-### 6. 测试
+### 6. `@file` 浏览器（`src/file_ref.rs`）
+
+- **语法层零依赖**：`active_at_token(line, cursor_col)` 是纯函数（词边界、
+  email/URL carve-out、`@"…"` 引号形式），`format_file_mention` 只产出提示文本。
+- **浏览器是 ratatui-explorer**（issue #62 指定的 UI 控件）：`FileMenu` 包一个
+  以 `cfg.workspace` 为根的 `FileExplorer`；目录浏览、排序、隐藏文件过滤都由库负责，
+  Rust 侧不写文件系统遍历。
+- **每次按键后的同步点在 `app.rs::refresh_file_menu`**（handle_key 末尾、vim
+  消费分支、composer 鼠标点击三处）：重新扫描光标所在行的 token，query 变了才驱动
+  浏览器（`apply_query` 对相同 query 是 no-op，箭头导航不会被重置）；token 消失、
+  vim normal 或 slash 菜单打开时关闭。
+- **Esc 的 dismissed 状态存在 App 上**（`file_menu_dismissed`，tag 见
+  `file_ref::token_tag`）：菜单重建（`FileMenu` 每次打开重新 `build`）不能丢它。
+- **主题适配**：`FileMenu::apply_chrome` 每帧用 `app.theme` token 重建
+  ratatui-explorer 的 `Theme`（panel 面板、border 边框、brand 目录、chip_bg 选中行），
+  palette 包和 locale 切换即时生效；与 slash 菜单弹层同几何（composer 上方，宽 72）。
+
+### 7. 测试
 
 - `tests/unit/input__composer__tests.rs`：布局镜像、点击映射、视觉行、kill、滚动镜像、undo/redo
 - `tests/unit/app__mode_tests.rs` / `app__selection_tests.rs`：键位全链路、鼠标选择
-- `tests/unit/ui__tests.rs`：真实 buffer 渲染断言（chip 样式、拖选反色、多行堆叠）
+- `tests/unit/file_ref__tests.rs`：语法（边界、引号、email、URL）、格式化、浏览器导航
+- `tests/unit/app__at_menu_tests.rs`：键交互、token 替换、下钻、dismiss、vim/slash 共存
+- `tests/unit/ui__tests.rs`：真实 buffer 渲染断言（chip 样式、拖选反色、多行堆叠、@ 弹层）
 - `tests/unit/input__keymap__tests.rs`：键位表反漂移（每个文档行必须能被 classify 解析）

--- a/src/app.rs
+++ b/src/app.rs
@@ -22,7 +22,7 @@ use crate::bus::{
 };
 use crate::controller::Controller;
 use crate::events::parse_notification;
-use crate::input::Action;
+use crate::input::{Action, VimMode};
 use crate::locale::{Locale, UiSettings};
 use crate::runtime::{legacy_settings_path, settings_path, RuntimeConfig};
 use crate::theme::Theme;
@@ -1021,6 +1021,12 @@ pub struct App {
     /// Last ACP `session_info_update` title.
     session_title: Option<String>,
     pub slash_sel: usize,
+    /// Open `@file` browser menu (grammar + ratatui-explorer in `file_ref`).
+    pub file_menu: Option<crate::file_ref::FileMenu>,
+    /// Esc-dismissed `@` token tag (see `file_ref::token_tag`): an
+    /// unchanged token must not reopen the browser. Survives menu
+    /// rebuilds, so it lives on the App, not in `file_menu`.
+    pub file_menu_dismissed: Option<String>,
     pub picker: Option<Picker>,
     /// Rows the open picker actually shows (`h - border`), recorded by
     /// `ui::draw_model_picker` — the page size for picker PageUp/PageDown.
@@ -1413,6 +1419,8 @@ impl App {
             load_session: false,
             session_title: None,
             slash_sel: 0,
+            file_menu: None,
+            file_menu_dismissed: None,
             picker: None,
             picker_page_rows: 0,
             permission_ask: None,
@@ -2965,6 +2973,7 @@ impl App {
                         head: cell,
                     });
                     self.input_selecting = true;
+                    self.refresh_file_menu();
                     return;
                 }
                 let Some(p) = self.chat_hit(mouse.column, mouse.row) else {
@@ -3612,6 +3621,7 @@ impl App {
         {
             if self.vim.handle_key(&key, &mut self.input) {
                 self.reconcile_attachments();
+                self.refresh_file_menu();
                 return;
             }
         }
@@ -3711,6 +3721,58 @@ impl App {
             return;
         }
 
+        // The @file browser owns its navigation keys while open; everything
+        // else falls through to normal editing (which re-syncs the browser
+        // through `refresh_file_menu`). Enter settles, Tab drills into a
+        // directory, → follows the explorer's enter semantics.
+        if let Some(menu) = &mut self.file_menu {
+            if key.modifiers == KeyModifiers::NONE {
+                match key.code {
+                    KeyCode::Up => {
+                        crate::file_ref::navigate(menu, crate::file_ref::Input::Up);
+                        return;
+                    }
+                    KeyCode::Down => {
+                        crate::file_ref::navigate(menu, crate::file_ref::Input::Down);
+                        return;
+                    }
+                    KeyCode::Home => {
+                        crate::file_ref::navigate(menu, crate::file_ref::Input::Home);
+                        return;
+                    }
+                    KeyCode::End => {
+                        crate::file_ref::navigate(menu, crate::file_ref::Input::End);
+                        return;
+                    }
+                    KeyCode::PageUp => {
+                        crate::file_ref::navigate(menu, crate::file_ref::Input::PageUp);
+                        return;
+                    }
+                    KeyCode::PageDown => {
+                        crate::file_ref::navigate(menu, crate::file_ref::Input::PageDown);
+                        return;
+                    }
+                    KeyCode::Left => {
+                        crate::file_ref::navigate(menu, crate::file_ref::Input::Left);
+                        return;
+                    }
+                    KeyCode::Right | KeyCode::Tab => {
+                        self.file_menu_drill();
+                        return;
+                    }
+                    KeyCode::Enter => {
+                        self.file_menu_settle();
+                        return;
+                    }
+                    KeyCode::Esc => {
+                        self.dismiss_file_menu();
+                        return;
+                    }
+                    _ => {}
+                }
+            }
+        }
+
         if let Some(selected) = self.queue_selection {
             let n = self.prompt_queue.len();
             if n == 0 {
@@ -3807,6 +3869,123 @@ impl App {
         // Any edit may have cut an [image n] token — the tray follows the
         // text (grok's lexicon-scan model).
         self.reconcile_attachments();
+        // Caret/token changes drive the @file browser: open, navigate the
+        // query's directory prefix, or close it.
+        self.refresh_file_menu();
+    }
+
+    /// Re-scan the composer line at the caret and sync the `@file` browser:
+    /// open it on an active token (unless the same token was Esc-dismissed
+    /// or vim normal mode is active), re-navigate on query edits, close it
+    /// when the token is gone.
+    fn refresh_file_menu(&mut self) {
+        // Vim normal mode is command editing — no mention browser.
+        if self.vim.is_active() && self.vim.mode == VimMode::Normal {
+            self.file_menu = None;
+            return;
+        }
+        // The slash menu and the @ menu are mutually exclusive.
+        if self.slash_completion_open() {
+            self.file_menu = None;
+            return;
+        }
+        let (row, col) = self.input.char_to_rowcol(self.input.cursor_char());
+        let Some(line) = self.input.lines().get(row).cloned() else {
+            self.file_menu = None;
+            return;
+        };
+        let Some(token) = crate::file_ref::active_at_token(&line, col) else {
+            // The token is gone (draft cleared, caret left it): a fresh
+            // `@` must be able to reopen the browser, so drop the
+            // dismissal tag along with the menu.
+            self.file_menu = None;
+            self.file_menu_dismissed = None;
+            return;
+        };
+        let tag = crate::file_ref::token_tag(token.quoted, &token.query);
+        if let Some(menu) = &mut self.file_menu {
+            if menu.row() != row || menu.start() != token.start || menu.end() != token.end {
+                menu.retoken(row, &token);
+            }
+            menu.apply_query(&token.query);
+        } else {
+            // Esc-dismissed tokens stay closed until their text changes.
+            if self.file_menu_dismissed.as_deref() == Some(tag.as_str()) {
+                return;
+            }
+            self.file_menu_dismissed = None;
+            if let Some(mut menu) = crate::file_ref::FileMenu::open(
+                std::path::Path::new(&self.cfg.workspace),
+                row,
+                &token,
+            ) {
+                // The token may already carry a query (dismissed-token
+                // reopen): drive the browser to it before showing.
+                menu.apply_query(&token.query);
+                self.file_menu = Some(menu);
+            }
+        }
+    }
+
+    /// `Enter` on the selected entry: replace the token with `@path` (or
+    /// `@dir/` for directories) and close the browser.
+    fn file_menu_settle(&mut self) {
+        let Some(mention) = self.file_menu.as_ref().and_then(|m| m.current_mention()) else {
+            return;
+        };
+        let (row, start, end) = {
+            let menu = self.file_menu.as_ref().expect("checked above");
+            (menu.row(), menu.start(), menu.end())
+        };
+        crate::file_ref::replace_span(&mut self.input, row, start, end, &mention);
+        self.file_menu = None;
+        self.input_sel = None;
+        self.reconcile_attachments();
+    }
+
+    /// `Tab` on a directory: rewrite the token to `@dir/` (quoted form
+    /// keeps the quote open) and keep the browser inside the directory.
+    /// `Tab` on a file settles like `Enter`.
+    fn file_menu_drill(&mut self) {
+        let Some(menu) = self.file_menu.as_ref() else {
+            return;
+        };
+        if menu.explorer().files().is_empty() {
+            return;
+        }
+        let file = menu.explorer().current().clone();
+        if !file.is_dir {
+            self.file_menu_settle();
+            return;
+        }
+        let rel = crate::file_ref::relative_path(menu.base(), &file.path);
+        let Some(mention) = crate::file_ref::format_file_mention(&rel, true, menu.quoted()) else {
+            return;
+        };
+        let (row, start) = (menu.row(), menu.start());
+        let end = start + mention.chars().count();
+        crate::file_ref::replace_span(&mut self.input, row, menu.start(), menu.end(), &mention);
+        if let Some(menu) = &mut self.file_menu {
+            menu.retoken(row, &crate::file_ref::AtToken {
+                start,
+                end,
+                query: format!("{rel}/"),
+                quoted: mention.starts_with("@\""),
+            });
+            menu.apply_query(&format!("{rel}/"));
+        }
+    }
+
+    /// Esc: close the browser and remember the token so it stays closed
+    /// until its text changes.
+    fn dismiss_file_menu(&mut self) {
+        if let Some(menu) = &self.file_menu {
+            self.file_menu_dismissed = Some(crate::file_ref::token_tag(
+                menu.quoted(),
+                &menu.token_query(),
+            ));
+        }
+        self.file_menu = None;
     }
 
     /// Apply one classified [`Action`] — the only place key semantics touch
@@ -5884,6 +6063,8 @@ fn fmt_duration(ms: u64) -> String {
 
 impl App {
     fn submit(&mut self, ctl: &Controller) {
+        // A pending @file browser never survives a send.
+        self.file_menu = None;
         let text = self.input.buf().trim().to_string();
         // Client namespaces don't take images — keep the chips editable
         // instead of silently dropping them.
@@ -6609,3 +6790,7 @@ mod right_slot_tests;
 #[cfg(test)]
 #[path = "../tests/unit/app__scroll_tests.rs"]
 mod scroll_tests;
+
+#[cfg(test)]
+#[path = "../tests/unit/app__at_menu_tests.rs"]
+mod at_menu_tests;

--- a/src/file_ref.rs
+++ b/src/file_ref.rs
@@ -1,0 +1,404 @@
+//! `@file` mentions: caret-token grammar plus the file-browser menu.
+//!
+//! The grammar mirrors the DeepSeek Harness `file-reference` grammar
+//! (pure functions, no filesystem access): an `@` at a word boundary opens
+//! a token that extends to whitespace, or to the closing quote for the
+//! `@"…"` form (which allows spaces). Emails and URL hosts never trigger.
+//!
+//! The browser menu is built on [`ratatui-explorer`] (the issue-62 UI
+//! control) and colored from the app [`Theme`] tokens — `panel`/`border`/
+//! `fg`/`brand`/`chip_bg` — so it tracks dark/light, palette packs and
+//! both UI presets like every other piece of painter chrome. The Rust
+//! painter owns the menu; no filesystem traversal is shipped to plugins.
+//!
+//! Typing keeps the token live: the query's directory prefix navigates
+//! the browser (`@src/ma` opens `src/` and jumps to the first `ma*`), and
+//! `Tab` on a directory drills down by rewriting the token to `@dir/`
+//! (quoted form keeps the quote open: `@"dir/`).
+
+use std::path::{Component, Path, PathBuf};
+
+use ratatui::style::{Modifier, Style};
+use ratatui::widgets::{Block, Borders};
+use ratatui_explorer::{FileExplorer, FileExplorerBuilder, Theme as ExplorerTheme};
+
+pub use ratatui_explorer::Input;
+
+use crate::input::composer::ComposerEditor;
+use crate::locale::Locale;
+use crate::theme::Theme as AppTheme;
+
+// --- grammar --------------------------------------------------------------
+
+/// An active `@` token on one composer line, in char offsets.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AtToken {
+    /// Char offset of the `@` within the line.
+    pub start: usize,
+    /// Char offset just past the token (exclusive).
+    pub end: usize,
+    /// Text after `@` (or after `@"` in the quoted form), quotes removed.
+    pub query: String,
+    /// `@"…"` form: the query may contain spaces and runs to the closing
+    /// quote (or the line end when unterminated).
+    pub quoted: bool,
+}
+
+/// The token the caret sits in, if any. `cursor_col` is a char offset.
+///
+/// Rules (mirroring the harness grammar):
+/// - `@` must sit at a word boundary: line start, or after a non-word
+///   char. Emails (`a@b`) and URL hosts (`https://user@host`) therefore
+///   never trigger.
+/// - The caret must be on or inside the token (`start <= col <= end`);
+///   `@` alone (empty query) is a valid token.
+/// - `@"…"` spans to the closing quote; `@` chars inside quoted regions
+///   are not separate tokens.
+pub fn active_at_token(line: &str, cursor_col: usize) -> Option<AtToken> {
+    let chars: Vec<char> = line.chars().collect();
+    let mut found: Option<AtToken> = None;
+    let mut i = 0;
+    while i < chars.len() {
+        if chars[i] == '@' {
+            let boundary = i == 0 || !(chars[i - 1].is_alphanumeric() || chars[i - 1] == '_');
+            if boundary {
+                let quoted = chars.get(i + 1) == Some(&'"');
+                let body = i + 1 + usize::from(quoted);
+                let (end, query) = if quoted {
+                    match chars[body..].iter().position(|&c| c == '"') {
+                        Some(off) => (body + off, chars[body..body + off].iter().collect()),
+                        None => (chars.len(), chars[body..].iter().collect()),
+                    }
+                } else {
+                    let mut e = body;
+                    while e < chars.len() && !chars[e].is_whitespace() {
+                        e += 1;
+                    }
+                    (e, chars[body..e].iter().collect())
+                };
+                if i <= cursor_col && cursor_col <= end {
+                    found = Some(AtToken {
+                        start: i,
+                        end,
+                        query,
+                        quoted,
+                    });
+                }
+                // A quoted token owns everything up to its end; `@` inside
+                // it is path text, not a new mention.
+                if quoted {
+                    i = end.max(i + 1);
+                    continue;
+                }
+            }
+        }
+        i += 1;
+    }
+    found
+}
+
+/// Stable dismissal identity for a token: quote marker + query text.
+/// Esc-dismissed tokens stay closed until this changes.
+pub fn token_tag(quoted: bool, query: &str) -> String {
+    format!("{}{}", if quoted { "\"" } else { "" }, query)
+}
+
+/// Turn a picked relative path into the mention text that replaces the
+/// token. Returns `None` when the path is not representable (control
+/// chars, or a `"` — the quoted form cannot nest quotes).
+///
+/// Whitespace forces the quoted form; directories keep their trailing `/`
+/// and, quoted, keep the quote open so the user can keep drilling.
+pub fn format_file_mention(rel: &str, is_dir: bool, quoted: bool) -> Option<String> {
+    if rel.is_empty() || rel.chars().any(|c| c.is_control() || c == '"') {
+        return None;
+    }
+    let mut path = rel.to_string();
+    if is_dir && !path.ends_with('/') {
+        path.push('/');
+    }
+    if quoted || path.chars().any(char::is_whitespace) {
+        if is_dir {
+            Some(format!("@\"{path}"))
+        } else {
+            Some(format!("@\"{path}\""))
+        }
+    } else {
+        Some(format!("@{path}"))
+    }
+}
+
+/// Workspace-relative spelling of `path` against `base`: `src/main.rs`
+/// under the workspace, `..`-prefixed for ancestors, `.` for the base
+/// itself, and the absolute path when the two share no root.
+pub fn relative_path(base: &Path, path: &Path) -> String {
+    if let Ok(rel) = path.strip_prefix(base) {
+        let s = rel.to_string_lossy();
+        return if s.is_empty() { ".".into() } else { s.into_owned() };
+    }
+    let base_comp: Vec<Component> = base.components().collect();
+    let path_comp: Vec<Component> = path.components().collect();
+    let mut common = 0;
+    while common < base_comp.len()
+        && common < path_comp.len()
+        && base_comp[common] == path_comp[common]
+    {
+        common += 1;
+    }
+    if common == 0 {
+        return path.to_string_lossy().into_owned();
+    }
+    let mut out = String::new();
+    for _ in common..base_comp.len() {
+        out.push_str("../");
+    }
+    for c in &path_comp[common..] {
+        out.push_str(&c.as_os_str().to_string_lossy());
+        out.push('/');
+    }
+    if out.ends_with('/') {
+        out.pop();
+    }
+    if out.is_empty() {
+        ".".into()
+    } else {
+        out
+    }
+}
+
+/// Best explorer row for a query's last segment: exact > prefix > contains,
+/// directories preferred over files, `../` never matched.
+fn best_match(files: &[ratatui_explorer::File], last: &str) -> Option<usize> {
+    let needle = last.to_lowercase();
+    let mut best: Option<(usize, u8)> = None;
+    for (i, file) in files.iter().enumerate() {
+        if file.name == "../" {
+            continue;
+        }
+        let name = file
+            .name
+            .strip_suffix('/')
+            .unwrap_or(&file.name)
+            .to_lowercase();
+        let score = if name == needle {
+            0
+        } else if name.starts_with(&needle) {
+            1
+        } else if name.contains(&needle) {
+            2
+        } else {
+            continue;
+        };
+        let total = score * 2 + usize::from(!file.is_dir) as u8;
+        if best.is_none_or(|(_, s)| total < s) {
+            best = Some((i, total));
+        }
+    }
+    best.map(|(i, _)| i)
+}
+
+// --- the browser menu -----------------------------------------------------
+
+/// Live `@file` browser state. Wraps a [`FileExplorer`] rooted at the
+/// workspace; the explorer is the source of truth for the pick, the token
+/// text is the source of truth for re-typing.
+pub struct FileMenu {
+    /// Workspace root the explorer started from (relative mentions are
+    /// spelled against it).
+    base: PathBuf,
+    /// The ratatui-explorer widget (browser + its theme).
+    explorer: FileExplorer,
+    /// Composer row the token lives on.
+    row: usize,
+    /// Token char span inside that row.
+    start: usize,
+    end: usize,
+    quoted: bool,
+    /// Query the explorer currently mirrors; `apply_query` no-ops on the
+    /// same query so arrow navigation is never reset by the per-key
+    /// refresh.
+    applied_query: String,
+    /// Explorer cwd mirror (avoids redundant relisting and keeps the
+    /// popup title in lockstep after `Left`/`Right` navigation).
+    cwd: PathBuf,
+}
+
+impl FileMenu {
+    /// Open the browser at `base` for a fresh token. Returns `None` when
+    /// the workspace cannot be listed (the menu silently stays closed).
+    pub fn open(base: &Path, row: usize, token: &AtToken) -> Option<Self> {
+        let explorer = FileExplorerBuilder::default().working_dir(base).build().ok()?;
+        Some(Self {
+            base: base.to_path_buf(),
+            explorer,
+            row,
+            start: token.start,
+            end: token.end,
+            quoted: token.quoted,
+            applied_query: String::new(),
+            cwd: base.to_path_buf(),
+        })
+    }
+
+    pub fn row(&self) -> usize {
+        self.row
+    }
+
+    pub fn start(&self) -> usize {
+        self.start
+    }
+
+    pub fn end(&self) -> usize {
+        self.end
+    }
+
+    pub fn quoted(&self) -> bool {
+        self.quoted
+    }
+
+    /// The token query text the browser currently mirrors (the source of
+    /// truth for Esc-dismissal tags).
+    pub fn token_query(&self) -> &str {
+        &self.applied_query
+    }
+
+    pub fn base(&self) -> &Path {
+        &self.base
+    }
+
+    pub fn explorer(&self) -> &FileExplorer {
+        &self.explorer
+    }
+
+    /// Re-anchor the token span (text edited before `@`).
+    pub fn retoken(&mut self, row: usize, token: &AtToken) {
+        self.row = row;
+        self.start = token.start;
+        self.end = token.end;
+        self.quoted = token.quoted;
+        self.applied_query.clear();
+    }
+
+    /// Drive the browser from the token query: directory segments before
+    /// the last `/` are descended (the trailing slash is the drill
+    /// delimiter — `@src` filters the workspace, `@src/` opens the dir),
+    /// then the selection jumps to the best match of the last segment.
+    /// No-op when the query did not change (preserves arrow navigation).
+    pub fn apply_query(&mut self, query: &str) {
+        if query == self.applied_query {
+            return;
+        }
+        self.applied_query = query.to_string();
+        let (nav, last_seg) = query.rsplit_once('/').map_or(("", query), |(d, l)| (d, l));
+        let mut cwd = self.base.clone();
+        let mut nav_consumed = 0;
+        for seg in nav.split('/') {
+            match seg {
+                "" | "." => nav_consumed += 1,
+                ".." => {
+                    if let Some(parent) = cwd.parent() {
+                        cwd = parent.to_path_buf();
+                    }
+                    nav_consumed += 1;
+                }
+                seg => {
+                    let candidate = cwd.join(seg);
+                    if candidate.is_dir() {
+                        cwd = candidate;
+                        nav_consumed += 1;
+                    } else {
+                        break;
+                    }
+                }
+            }
+        }
+        // Segments the navigation could not consume stay part of the
+        // filter (`nope/main` filters for `nope/main` in the workspace).
+        let mut last = nav.split('/').skip(nav_consumed).collect::<Vec<_>>().join("/");
+        if !last.is_empty() {
+            last.push('/');
+        }
+        last.push_str(last_seg);
+        if cwd != self.cwd && self.explorer.set_cwd(&cwd).is_ok() {
+            self.cwd = cwd;
+        }
+        if !last.is_empty() {
+            if let Some(idx) = best_match(self.explorer.files(), &last) {
+                self.explorer.set_selected_idx(idx);
+            }
+        }
+    }
+
+    /// The mention text for the currently selected entry (used by both
+    /// settle and drill). `None` when there is nothing to pick or the
+    /// path is not representable.
+    pub fn current_mention(&self) -> Option<String> {
+        if self.explorer.files().is_empty() {
+            return None;
+        }
+        let file = self.explorer.current();
+        let rel = relative_path(&self.base, &file.path);
+        format_file_mention(&rel, file.is_dir, self.quoted)
+    }
+
+    /// Browser theme built from the app theme tokens, refreshed every
+    /// frame so palette-pack switches and locale changes land immediately.
+    pub fn apply_chrome(&mut self, theme: &AppTheme, locale: Locale, workspace: &str) {
+        let rel = relative_path(Path::new(workspace), &self.cwd);
+        let title = format!(" @{rel} ");
+        let hint = locale.tr(
+            " ↑↓ move · ← parent · →/tab open · enter pick · esc close ",
+            " ↑↓ 移动 · ← 上级 · →/tab 进入 · enter 选择 · esc 关闭 ",
+        );
+        let explorer_theme = ExplorerTheme::default()
+            .with_block(
+                Block::default()
+                    .borders(Borders::ALL)
+                    .border_style(Style::default().fg(theme.border))
+                    .style(Style::default().bg(theme.panel)),
+            )
+            .with_style(Style::default().bg(theme.panel).fg(theme.fg))
+            .with_item_style(Style::default().fg(theme.fg))
+            .with_dir_style(Style::default().fg(theme.brand).add_modifier(Modifier::BOLD))
+            .with_highlight_item_style(Style::default().fg(theme.fg).bg(theme.chip_bg))
+            .with_highlight_dir_style(
+                Style::default()
+                    .fg(theme.brand)
+                    .bg(theme.chip_bg)
+                    .add_modifier(Modifier::BOLD),
+            )
+            .with_highlight_symbol("▸ ")
+            .with_scroll_padding(1)
+            .with_title_top(move |_| ratatui::text::Line::from(title.clone()))
+            .with_title_bottom(move |_| ratatui::text::Line::from(hint));
+        self.explorer.set_theme(explorer_theme);
+    }
+}
+
+/// Replace the char span `[start, end)` on composer `row` with `text`,
+/// leaving the caret after it.
+pub fn replace_span(editor: &mut ComposerEditor, row: usize, start: usize, end: usize, text: &str) {
+    let line_start = editor
+        .lines()
+        .iter()
+        .take(row)
+        .map(|l| l.chars().count() + 1)
+        .sum::<usize>();
+    editor.delete_char_range(line_start + start, line_start + end);
+    editor.insert_str(text);
+}
+
+/// Navigate the explorer with a ratatui-explorer [`Input`] and keep the
+/// cwd mirror in lockstep. `Left`/`Right` are pure browser navigation —
+/// they move the pick position without rewriting the draft token (the
+/// token text only changes through typing, `Tab` drill and `Enter`
+/// settle).
+pub fn navigate(menu: &mut FileMenu, input: Input) {
+    if menu.explorer.handle(input).is_ok() {
+        menu.cwd = menu.explorer.cwd().clone();
+    }
+}
+
+#[cfg(test)]
+#[path = "../tests/unit/file_ref__tests.rs"]
+mod tests;

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@ mod deepseek_logo;
 mod demo;
 mod elicitation;
 mod events;
+mod file_ref;
 mod input;
 mod locale;
 mod logo;

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -4,7 +4,7 @@ use ratatui::layout::{Alignment, Constraint, Margin, Rect};
 use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{
-    Block, BorderType, Borders, Cell, Clear, HighlightSpacing, Paragraph, Row, Scrollbar,
+    Block, BorderType, Borders, Cell, Clear, FrameExt, HighlightSpacing, Paragraph, Row, Scrollbar,
     ScrollbarOrientation, ScrollbarState, Table, TableState,
 };
 use ratatui::Frame;
@@ -326,6 +326,10 @@ pub fn draw(f: &mut Frame, app: &mut App) {
             composer
         };
         draw_slash_menu(f, app, menu_anchor, chat);
+        // The @file browser rides the same anchor; drawn after the slash
+        // menu (the two are mutually exclusive, but the browser owns the
+        // space above the composer either way).
+        draw_file_menu(f, app, menu_anchor, chat);
         // Hover/cursor preview for inline [image n] chips sits above the
         // composer (drawn last so it tops the menu-free chat area).
         draw_attachment_preview(f, app, composer, area);
@@ -2741,6 +2745,40 @@ fn draw_slash_menu(f: &mut Frame, app: &App, input: Rect, chat: Rect) {
         ));
     }
     f.render_widget(Paragraph::new(lines).block(block), area);
+}
+
+/// Rows of the `@file` browser shown at once; the explorer's own List
+/// scrolls the selection within this window.
+const FILE_MENU_ROWS: usize = 12;
+
+fn draw_file_menu(f: &mut Frame, app: &mut App, input: Rect, chat: Rect) {
+    let Some(menu) = &mut app.file_menu else {
+        return;
+    };
+    if menu.explorer().files().is_empty() {
+        return;
+    }
+    // Rebuild the explorer chrome from the app theme every frame: palette
+    // packs and locale can switch under us, and the title factories need
+    // the current cwd.
+    let theme = app.theme;
+    let locale = app.locale;
+    menu.apply_chrome(&theme, locale, &app.cfg.workspace);
+    let n = menu.explorer().files().len();
+    let vis = FILE_MENU_ROWS
+        .min(n)
+        .min(chat.height.saturating_sub(2) as usize);
+    if vis == 0 {
+        return;
+    }
+    // Wider than the slash menu — entries carry paths; the List truncates
+    // long names instead of hard-clipping.
+    let h = vis as u16 + 2;
+    let w = 72.min(input.width.saturating_sub(2));
+    let y = input.y.saturating_sub(h);
+    let area = Rect::new(input.x + 2, y, w, h);
+    f.render_widget(Clear, area);
+    f.render_widget_ref(menu.explorer().widget(), area);
 }
 
 /// Pad `s` to exactly `w` display cells, ellipsizing when longer — keeps

--- a/tests/unit/app__at_menu_tests.rs
+++ b/tests/unit/app__at_menu_tests.rs
@@ -1,0 +1,316 @@
+//! App-level `@file` menu tests: typing, key interception, token span
+//! replacement, dismissal, drilling, vim and slash-menu coexistence.
+
+use super::*;
+use crate::bus::AppEvent;
+use crate::controller::Controller;
+use crate::runtime::RuntimeConfig;
+use crate::theme::Theme;
+use std::fs;
+use std::path::PathBuf;
+use std::sync::mpsc::Receiver;
+
+/// Unique session root per call — keeps persisted UI fixtures isolated.
+fn fresh_root() -> String {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static N: AtomicU64 = AtomicU64::new(0);
+    let dir = std::env::temp_dir().join(format!(
+        "dsh-tui-at-menu-{}-{}",
+        std::process::id(),
+        N.fetch_add(1, Ordering::Relaxed),
+    ));
+    let _ = std::fs::create_dir_all(&dir);
+    dir.to_string_lossy().into_owned()
+}
+
+/// A controlled workspace tree:
+/// ```text
+/// <ws>/
+/// ├── src/
+/// │   ├── nested/
+/// │   └── main.rs
+/// ├── README.md
+/// └── notes.txt
+/// ```
+struct Workspace {
+    root: PathBuf,
+}
+
+impl Workspace {
+    fn new() -> Self {
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static N: AtomicU64 = AtomicU64::new(0);
+        let root = std::env::temp_dir().join(format!(
+            "martty-at-menu-ws-{}-{}",
+            std::process::id(),
+            N.fetch_add(1, Ordering::Relaxed),
+        ));
+        let _ = fs::remove_dir_all(&root);
+        fs::create_dir_all(root.join("src/nested")).expect("create tree");
+        fs::write(root.join("src/main.rs"), "").expect("write");
+        fs::write(root.join("README.md"), "").expect("write");
+        fs::write(root.join("notes.txt"), "").expect("write");
+        Self { root }
+    }
+}
+
+impl Drop for Workspace {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.root);
+    }
+}
+
+fn test_app(workspace: &PathBuf) -> (App, Controller, Receiver<AppEvent>) {
+    let cfg = RuntimeConfig {
+        bin: "demo".into(),
+        cordis: "demo".into(),
+        workspace: workspace.to_string_lossy().into_owned(),
+        session_root: fresh_root(),
+        provider: "deepseek-official".into(),
+        model: "deepseek-v4-flash".into(),
+        max_tokens: None,
+        base_url: None,
+        api_key: None,
+    };
+    let (tx, rx) = std::sync::mpsc::channel::<AppEvent>();
+    let ctl = Controller::start(cfg.clone(), true, None, tx.clone());
+    let app = App::new(Some(Theme::dark()), cfg, "dsh-test".into(), true, false, tx);
+    (app, ctl, rx)
+}
+
+fn key(code: KeyCode) -> KeyEvent {
+    KeyEvent::new(code, KeyModifiers::NONE)
+}
+
+fn char_key(c: char) -> KeyEvent {
+    KeyEvent::new(KeyCode::Char(c), KeyModifiers::NONE)
+}
+
+#[test]
+fn typing_at_opens_the_browser_and_enter_picks() {
+    let ws = Workspace::new();
+    let (mut app, ctl, _rx) = test_app(&ws.root);
+    assert!(app.file_menu.is_none());
+
+    app.handle_key(char_key('@'), &ctl);
+    let menu = app.file_menu.as_ref().expect("menu opens on @");
+    // parent entry, then dirs, then files, each alphabetical
+    let names: Vec<&str> = menu
+        .explorer()
+        .files()
+        .iter()
+        .map(|f| f.name.as_str())
+        .collect();
+    assert_eq!(names, ["../", "src/", "README.md", "notes.txt"]);
+
+    // README.md is the first file after the parent and src/ dirs.
+    app.handle_key(key(KeyCode::Down), &ctl);
+    app.handle_key(key(KeyCode::Down), &ctl);
+    app.handle_key(key(KeyCode::Enter), &ctl);
+
+    assert!(app.file_menu.is_none(), "menu closes on settle");
+    assert_eq!(app.input.buf(), "@README.md");
+    assert_eq!(app.input.cursor_char(), "@README.md".chars().count());
+}
+
+#[test]
+fn typing_extends_the_query_and_navigates() {
+    let ws = Workspace::new();
+    let (mut app, ctl, _rx) = test_app(&ws.root);
+    app.handle_key(char_key('@'), &ctl);
+    app.handle_key(char_key('s'), &ctl);
+    app.handle_key(char_key('r'), &ctl);
+    app.handle_key(char_key('c'), &ctl);
+    app.handle_key(char_key('/'), &ctl);
+    app.handle_key(char_key('m'), &ctl);
+
+    let menu = app.file_menu.as_ref().expect("menu stays open");
+    assert_eq!(menu.explorer().cwd(), &ws.root.join("src"));
+    assert_eq!(menu.explorer().current().name, "main.rs");
+    assert_eq!(app.input.buf(), "@src/m");
+}
+
+#[test]
+fn enter_after_query_navigation_inserts_the_full_path() {
+    let ws = Workspace::new();
+    let (mut app, ctl, _rx) = test_app(&ws.root);
+    app.handle_key(char_key('@'), &ctl);
+    for c in ['s', 'r', 'c', '/', 'm'] {
+        app.handle_key(char_key(c), &ctl);
+    }
+    app.handle_key(key(KeyCode::Enter), &ctl);
+    assert!(app.file_menu.is_none());
+    assert_eq!(app.input.buf(), "@src/main.rs");
+}
+
+#[test]
+fn tab_drills_into_a_directory_and_enter_settles_inside() {
+    let ws = Workspace::new();
+    let (mut app, ctl, _rx) = test_app(&ws.root);
+    app.handle_key(char_key('@'), &ctl);
+    app.handle_key(key(KeyCode::Down), &ctl); // src/
+    app.handle_key(key(KeyCode::Tab), &ctl);
+
+    // The token was rewritten to @src/ and the browser moved inside.
+    assert_eq!(app.input.buf(), "@src/");
+    let menu = app.file_menu.as_ref().expect("menu stays open after drill");
+    assert_eq!(menu.explorer().cwd(), &ws.root.join("src"));
+
+    // Inside src/ the list is [../, nested/, main.rs].
+    app.handle_key(key(KeyCode::Down), &ctl); // nested/
+    app.handle_key(key(KeyCode::Down), &ctl); // main.rs
+    app.handle_key(key(KeyCode::Enter), &ctl);
+    assert!(app.file_menu.is_none());
+    assert_eq!(app.input.buf(), "@src/main.rs");
+}
+
+#[test]
+fn drill_updates_the_caret_and_reopens_on_typing() {
+    let ws = Workspace::new();
+    let (mut app, ctl, _rx) = test_app(&ws.root);
+    app.handle_key(char_key('@'), &ctl);
+    app.handle_key(key(KeyCode::Down), &ctl); // src/
+    app.handle_key(key(KeyCode::Tab), &ctl);
+    assert_eq!(app.input.buf(), "@src/");
+    // Caret lands after the rewritten token.
+    assert_eq!(app.input.cursor_char(), "@src/".chars().count());
+    // More typing extends the token inside the drilled dir.
+    app.handle_key(char_key('n'), &ctl);
+    assert_eq!(app.input.buf(), "@src/n");
+    let menu = app.file_menu.as_ref().expect("menu re-syncs");
+    assert_eq!(menu.explorer().current().name, "nested/");
+}
+
+#[test]
+fn esc_dismisses_until_the_token_changes() {
+    let ws = Workspace::new();
+    let (mut app, ctl, _rx) = test_app(&ws.root);
+    app.handle_key(char_key('@'), &ctl);
+    app.handle_key(char_key('r'), &ctl);
+    app.handle_key(key(KeyCode::Esc), &ctl);
+    assert!(app.file_menu.is_none(), "esc closes the browser");
+    assert_eq!(app.input.buf(), "@r", "the draft text survives");
+
+    // Same token, caret moves: stays dismissed.
+    app.handle_key(key(KeyCode::Left), &ctl);
+    assert!(app.file_menu.is_none());
+
+    // Token text changes: the browser returns. The caret sat on the `@`
+    // after Left, so the new char lands before the `r`.
+    app.handle_key(char_key('e'), &ctl);
+    assert!(app.file_menu.is_some(), "editing the token reopens the menu");
+    assert_eq!(app.input.buf(), "@er");
+}
+
+#[test]
+fn deleting_the_token_clears_the_dismissal() {
+    let ws = Workspace::new();
+    let (mut app, ctl, _rx) = test_app(&ws.root);
+    app.handle_key(char_key('@'), &ctl);
+    app.handle_key(char_key('r'), &ctl);
+    app.handle_key(key(KeyCode::Esc), &ctl);
+    assert!(app.file_menu.is_none());
+
+    // Deleting the whole token, then retyping the exact same text, must
+    // reopen the browser — the dismissal only lives with the token.
+    app.handle_key(key(KeyCode::Backspace), &ctl);
+    app.handle_key(key(KeyCode::Backspace), &ctl);
+    app.handle_key(char_key('@'), &ctl);
+    app.handle_key(char_key('r'), &ctl);
+    assert!(app.file_menu.is_some(), "fresh token reopens the browser");
+}
+
+#[test]
+fn deleting_the_at_closes_the_browser() {
+    let ws = Workspace::new();
+    let (mut app, ctl, _rx) = test_app(&ws.root);
+    app.handle_key(char_key('@'), &ctl);
+    assert!(app.file_menu.is_some());
+    app.handle_key(key(KeyCode::Backspace), &ctl);
+    assert!(app.file_menu.is_none());
+    assert_eq!(app.input.buf(), "");
+}
+
+#[test]
+fn email_like_text_never_opens_the_browser() {
+    let ws = Workspace::new();
+    let (mut app, ctl, _rx) = test_app(&ws.root);
+    for c in ['h', 'i', '@', 'x'] {
+        app.handle_key(char_key(c), &ctl);
+    }
+    assert!(app.file_menu.is_none(), "a@b must not trigger the menu");
+    assert_eq!(app.input.buf(), "hi@x");
+}
+
+#[test]
+fn slash_draft_does_not_open_the_browser() {
+    let ws = Workspace::new();
+    let (mut app, ctl, _rx) = test_app(&ws.root);
+    app.handle_key(char_key('/'), &ctl);
+    app.handle_key(char_key('n'), &ctl);
+    app.handle_key(char_key('e'), &ctl);
+    // /ne matches /new → the slash menu owns the draft; the @ after a
+    // word char is not a boundary anyway.
+    assert!(app.slash_completion_open());
+    app.handle_key(char_key('@'), &ctl);
+    assert!(app.file_menu.is_none(), "slash context never opens @ menu");
+}
+
+#[test]
+fn vim_normal_mode_closes_the_browser() {
+    let ws = Workspace::new();
+    let (mut app, ctl, _rx) = test_app(&ws.root);
+    app.vim.set(true); // insert mode
+    app.handle_key(char_key('@'), &ctl);
+    assert!(app.file_menu.is_some());
+    // Esc returns to vim normal; the browser must not linger there.
+    app.handle_key(key(KeyCode::Esc), &ctl);
+    assert_eq!(app.vim.mode, VimMode::Normal);
+    assert!(app.file_menu.is_none());
+}
+
+#[test]
+fn arrow_keys_are_owned_by_the_browser() {
+    let ws = Workspace::new();
+    let (mut app, ctl, _rx) = test_app(&ws.root);
+    app.handle_key(char_key('@'), &ctl);
+    app.handle_key(char_key('s'), &ctl);
+    // Up/Down move the browser selection, not the caret.
+    let before = app.input.cursor_char();
+    app.handle_key(key(KeyCode::Up), &ctl);
+    app.handle_key(key(KeyCode::Down), &ctl);
+    assert_eq!(app.input.cursor_char(), before);
+    // Left goes to the parent directory.
+    app.handle_key(key(KeyCode::Left), &ctl);
+    let menu = app.file_menu.as_ref().expect("menu open");
+    assert_eq!(menu.explorer().cwd(), ws.root.parent().unwrap());
+}
+
+#[test]
+fn quoted_spaced_path_round_trips() {
+    let ws = Workspace::new();
+    fs::create_dir_all(ws.root.join("my dir")).expect("create");
+    fs::write(ws.root.join("my dir/file with space.txt"), "").expect("write");
+    let (mut app, ctl, _rx) = test_app(&ws.root);
+    app.handle_key(char_key('@'), &ctl);
+    // [../, my dir/, src/, README.md, notes.txt]
+    app.handle_key(key(KeyCode::Down), &ctl); // my dir/
+    app.handle_key(key(KeyCode::Tab), &ctl); // drill → @"my dir/
+    assert_eq!(app.input.buf(), "@\"my dir/");
+    app.handle_key(key(KeyCode::Down), &ctl); // file with space.txt
+    app.handle_key(key(KeyCode::Enter), &ctl);
+    assert!(app.file_menu.is_none());
+    assert_eq!(app.input.buf(), "@\"my dir/file with space.txt\"");
+}
+
+#[test]
+fn send_now_closes_the_browser() {
+    let ws = Workspace::new();
+    let (mut app, ctl, _rx) = test_app(&ws.root);
+    app.handle_key(char_key('@'), &ctl);
+    assert!(app.file_menu.is_some());
+    // ctrl+enter steers immediately — the browser must not survive the
+    // send (plain Enter settles a mention while the menu is open).
+    app.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::CONTROL), &ctl);
+    assert!(app.file_menu.is_none());
+}

--- a/tests/unit/file_ref__tests.rs
+++ b/tests/unit/file_ref__tests.rs
@@ -1,0 +1,340 @@
+//! Grammar + browser tests for the `@file` mention feature.
+
+use super::*;
+use std::fs;
+use std::path::PathBuf;
+
+// A tiny hand-rolled temp root keeps the browser tests hermetic (the repo
+// deliberately has no tempfile dev-dependency).
+struct TempRoot {
+    path: PathBuf,
+}
+
+impl TempRoot {
+    fn new(name: &str) -> Self {
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static N: AtomicU64 = AtomicU64::new(0);
+        let dir = std::env::temp_dir().join(format!(
+            "martty-file-ref-{name}-{}-{}",
+            std::process::id(),
+            N.fetch_add(1, Ordering::Relaxed),
+        ));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).expect("create temp root");
+        Self { path: dir }
+    }
+
+    fn file(&self, rel: &str) -> PathBuf {
+        let p = self.path.join(rel);
+        if let Some(parent) = p.parent() {
+            fs::create_dir_all(parent).expect("create parent dirs");
+        }
+        fs::write(&p, "").expect("write temp file");
+        p
+    }
+
+    fn dir(&self, rel: &str) -> PathBuf {
+        let p = self.path.join(rel);
+        fs::create_dir_all(&p).expect("create temp dir");
+        p
+    }
+}
+
+impl Drop for TempRoot {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.path);
+    }
+}
+
+// --- grammar --------------------------------------------------------------
+
+#[test]
+fn token_at_line_start() {
+    let t = active_at_token("@foo", 4).expect("token");
+    assert_eq!((t.start, t.end), (0, 4));
+    assert_eq!(t.query, "foo");
+    assert!(!t.quoted);
+}
+
+#[test]
+fn bare_at_is_a_token() {
+    let t = active_at_token("@", 1).expect("token");
+    assert_eq!((t.start, t.end), (0, 1));
+    assert_eq!(t.query, "");
+}
+
+#[test]
+fn inline_token_after_space() {
+    let t = active_at_token("look at @src/main.rs now", 16).expect("token");
+    assert_eq!(t.query, "src/main.rs");
+    assert_eq!(t.end, 20);
+}
+
+#[test]
+fn caret_must_be_inside_or_on_the_token() {
+    // Caret on the `@` itself counts as inside.
+    assert!(active_at_token("@foo", 0).is_some());
+    // Caret after the token (in the trailing space) is outside.
+    assert!(active_at_token("@foo ", 5).is_none());
+    // Caret before the token is outside.
+    assert!(active_at_token("x @foo", 1).is_none());
+}
+
+#[test]
+fn email_and_url_hosts_do_not_trigger() {
+    assert!(active_at_token("mail me at a@b.com", 18).is_none());
+    assert!(active_at_token("handle foo@bar", 12).is_none());
+    assert!(active_at_token("https://user@host/path", 18).is_none());
+}
+
+#[test]
+fn punctuation_is_a_boundary() {
+    // The unquoted token runs to whitespace, so the closing paren stays
+    // part of it (paths may contain parens); quote for exotic cases.
+    let t = active_at_token("try (@src)", 8).expect("token");
+    assert_eq!(t.query, "src)");
+    assert_eq!(t.end, 10);
+}
+
+#[test]
+fn quoted_token_allows_spaces() {
+    let t = active_at_token("@\"my file.txt\"", 13).expect("token");
+    assert!(t.quoted);
+    assert_eq!(t.query, "my file.txt");
+    assert_eq!(t.end, 13);
+}
+
+#[test]
+fn unterminated_quote_runs_to_line_end() {
+    let t = active_at_token("open @\"dir with space", 21).expect("token");
+    assert!(t.quoted);
+    assert_eq!(t.query, "dir with space");
+    assert_eq!(t.end, 21);
+}
+
+#[test]
+fn inner_at_inside_quotes_is_path_text() {
+    let t = active_at_token("@\"a@b\" tail", 4).expect("token");
+    assert_eq!(t.query, "a@b");
+}
+
+#[test]
+fn last_token_wins_when_caret_is_in_it() {
+    let t = active_at_token("@a @b", 4).expect("token");
+    assert_eq!(t.query, "b");
+}
+
+#[test]
+fn token_stops_at_whitespace() {
+    let t = active_at_token("@foo bar", 4).expect("token");
+    assert_eq!(t.query, "foo");
+}
+
+// --- formatting -----------------------------------------------------------
+
+#[test]
+fn plain_mention() {
+    assert_eq!(format_file_mention("src/main.rs", false, false), Some("@src/main.rs".into()));
+}
+
+#[test]
+fn dir_mention_keeps_trailing_slash() {
+    assert_eq!(format_file_mention("src", true, false), Some("@src/".into()));
+}
+
+#[test]
+fn whitespace_forces_quoted_form() {
+    assert_eq!(
+        format_file_mention("my dir", true, false),
+        Some("@\"my dir/".into())
+    );
+    assert_eq!(
+        format_file_mention("my dir/file.txt", false, false),
+        Some("@\"my dir/file.txt\"".into())
+    );
+}
+
+#[test]
+fn quoted_dir_keeps_the_quote_open() {
+    assert_eq!(format_file_mention("src", true, true), Some("@\"src/".into()));
+    assert_eq!(
+        format_file_mention("src/main.rs", false, true),
+        Some("@\"src/main.rs\"".into())
+    );
+}
+
+#[test]
+fn unrepresentable_paths_are_none() {
+    assert_eq!(format_file_mention("a\nb", false, false), None);
+    assert_eq!(format_file_mention("a\"b", false, false), None);
+    assert_eq!(format_file_mention("a\"b", false, true), None);
+    assert_eq!(format_file_mention("", false, false), None);
+}
+
+// --- relative paths -------------------------------------------------------
+
+#[test]
+fn relative_under_base() {
+    let base = PathBuf::from("/w");
+    assert_eq!(relative_path(&base, &base.join("src/main.rs")), "src/main.rs");
+    assert_eq!(relative_path(&base, &base), ".");
+}
+
+#[test]
+fn relative_above_base() {
+    let base = PathBuf::from("/w/sub");
+    assert_eq!(relative_path(&base, Path::new("/w")), "..");
+    assert_eq!(relative_path(&base, Path::new("/w/sib")), "../sib");
+}
+
+#[test]
+fn relative_unrelated_falls_back_to_shared_root() {
+    // Both live under `/`, so the relative spelling is `..`-prefixed;
+    // only truly foreign roots (Windows drives) fall back to absolute.
+    let base = PathBuf::from("/w");
+    assert_eq!(relative_path(&base, Path::new("/etc/passwd")), "../etc/passwd");
+}
+
+// --- browser --------------------------------------------------------------
+
+fn tree() -> (TempRoot, PathBuf) {
+    let root = TempRoot::new("browser");
+    root.dir("src/nested");
+    root.file("src/main.rs");
+    root.file("README.md");
+    root.file("notes.txt");
+    let base = root.path.clone();
+    (root, base)
+}
+
+fn token(query: &str) -> AtToken {
+    AtToken {
+        start: 0,
+        end: 1 + query.chars().count(),
+        query: query.into(),
+        quoted: false,
+    }
+}
+
+#[test]
+fn open_lists_the_workspace() {
+    let (root, base) = tree();
+    let menu = FileMenu::open(&base, 0, &token("")).expect("opens");
+    let names: Vec<&str> = menu.explorer().files().iter().map(|f| f.name.as_str()).collect();
+    // parent entry first, then dirs, then files — all alphabetical
+    assert_eq!(names, ["../", "src/", "README.md", "notes.txt"]);
+    drop(root);
+}
+
+#[test]
+fn open_fails_silently_for_a_missing_workspace() {
+    let missing = std::env::temp_dir().join("does-not-exist-martty-file-ref");
+    assert!(FileMenu::open(&missing, 0, &token("")).is_none());
+}
+
+#[test]
+fn query_navigates_the_directory_prefix() {
+    let (root, base) = tree();
+    let mut menu = FileMenu::open(&base, 0, &token("")).expect("opens");
+    menu.apply_query("src/m");
+    assert_eq!(menu.explorer().cwd(), &base.join("src"));
+    assert_eq!(menu.explorer().current().name, "main.rs");
+    drop(root);
+}
+
+#[test]
+fn query_prefix_selects_best_match() {
+    let (root, base) = tree();
+    let mut menu = FileMenu::open(&base, 0, &token("")).expect("opens");
+    menu.apply_query("re");
+    assert_eq!(menu.explorer().current().name, "README.md");
+    // directory wins a tie over a file with the same prefix
+    menu.apply_query("src");
+    assert_eq!(menu.explorer().current().name, "src/");
+    drop(root);
+}
+
+#[test]
+fn missing_middle_segment_treats_the_rest_as_one_last_segment() {
+    let (root, base) = tree();
+    let mut menu = FileMenu::open(&base, 0, &token("")).expect("opens");
+    menu.apply_query("nope/main");
+    // cwd stays at the workspace; nothing matches — selection unchanged
+    assert_eq!(menu.explorer().cwd(), &base);
+    drop(root);
+}
+
+#[test]
+fn unchanged_query_preserves_arrow_navigation() {
+    let (root, base) = tree();
+    let mut menu = FileMenu::open(&base, 0, &token("")).expect("opens");
+    menu.apply_query("");
+    navigate(&mut menu, Input::Down);
+    let selected = menu.explorer().selected_idx();
+    assert_eq!(selected, 1);
+    // Same query again: the browser must not reset the selection.
+    menu.apply_query("");
+    assert_eq!(menu.explorer().selected_idx(), selected);
+    drop(root);
+}
+
+#[test]
+fn left_moves_to_the_parent() {
+    let (root, base) = tree();
+    let mut menu = FileMenu::open(&base.join("src"), 0, &token("")).expect("opens");
+    navigate(&mut menu, Input::Left);
+    assert_eq!(menu.explorer().cwd(), &base);
+    drop(root);
+}
+
+#[test]
+fn current_mention_reflects_the_selection() {
+    let (root, base) = tree();
+    let mut menu = FileMenu::open(&base, 0, &token("")).expect("opens");
+    menu.apply_query("src/m");
+    assert_eq!(menu.current_mention().as_deref(), Some("@src/main.rs"));
+    navigate(&mut menu, Input::Up); // nested/
+    assert_eq!(menu.current_mention().as_deref(), Some("@src/nested/"));
+    drop(root);
+}
+
+#[test]
+fn spaced_paths_quote_automatically() {
+    let root = TempRoot::new("spaced");
+    root.dir("my dir");
+    root.file("my dir/file with space.txt");
+    let mut menu = FileMenu::open(&root.path, 0, &token("")).expect("opens");
+    menu.apply_query("my dir/f");
+    assert_eq!(
+        menu.current_mention().as_deref(),
+        Some("@\"my dir/file with space.txt\"")
+    );
+    drop(root);
+}
+
+#[test]
+fn token_tag_distinguishes_quoted_and_query() {
+    assert_eq!(token_tag(false, "re"), "re");
+    assert_eq!(token_tag(true, "re"), "\"re");
+    assert_eq!(token_tag(false, "readme"), "readme");
+    assert_ne!(token_tag(false, "re"), token_tag(false, "readme"));
+}
+
+#[test]
+fn drill_rewrites_the_token_query() {
+    let (root, base) = tree();
+    let mut menu = FileMenu::open(&base, 0, &token("")).expect("opens");
+    // Simulate the app's Tab drill on the src/ entry: retoken + apply.
+    menu.retoken(
+        0,
+        &AtToken {
+            start: 0,
+            end: 6,
+            query: "src/".into(),
+            quoted: false,
+        },
+    );
+    menu.apply_query("src/");
+    assert_eq!(menu.explorer().cwd(), &base.join("src"));
+    drop(root);
+}

--- a/tests/unit/ui__tests.rs
+++ b/tests/unit/ui__tests.rs
@@ -49,6 +49,52 @@ fn live_test_app() -> App {
 }
 
 #[test]
+fn file_menu_popup_renders_above_the_composer() {
+    use ratatui::backend::TestBackend;
+    use ratatui::Terminal;
+    let mut app = test_app();
+    app.show_banner = false;
+    app.input.insert_str("@");
+    // A small controlled workspace: [../, src/, README.md].
+    let ws = std::env::temp_dir().join(format!(
+        "dsh-tui-ui-file-menu-{}",
+        std::process::id()
+    ));
+    let _ = std::fs::remove_dir_all(&ws);
+    std::fs::create_dir_all(ws.join("src")).expect("mkdir");
+    std::fs::write(ws.join("src/main.rs"), "").expect("write");
+    std::fs::write(ws.join("README.md"), "").expect("write");
+    let token = crate::file_ref::active_at_token("@", 1).expect("token");
+    app.cfg.workspace = ws.to_string_lossy().into_owned();
+    app.file_menu =
+        Some(crate::file_ref::FileMenu::open(&ws, 0, &token).expect("menu opens"));
+    let backend = TestBackend::new(80, 20);
+    let mut terminal = Terminal::new(backend).expect("test terminal");
+    terminal.draw(|f| draw(f, &mut app)).expect("draw frame");
+    let buf = terminal.backend().buffer().clone();
+    let theme = app.theme;
+    let row_text = |y: u16| -> String {
+        (0..80).map(|x| buf[(x, y)].symbol().to_string()).collect()
+    };
+    // The popup sits above the composer box (rows 11..15 on this layout:
+    // 12 list rows cap to 3 entries + 2 border rows).
+    let title_row = row_text(11);
+    assert!(
+        title_row.contains("@") && title_row.contains("."),
+        "popup title shows the relative cwd: {title_row:?}"
+    );
+    let joined = [row_text(12), row_text(13), row_text(14)].join("\n");
+    assert!(
+        joined.contains("src/") && joined.contains("README.md"),
+        "entries listed: {joined:?}"
+    );
+    // The panel surface colors the popup; the selected row uses chip_bg.
+    assert_eq!(buf[(4, 12)].bg, theme.chip_bg, "selected row highlight");
+    assert_eq!(buf[(4, 13)].bg, theme.panel, "unselected rows keep panel");
+    let _ = std::fs::remove_dir_all(&ws);
+}
+
+#[test]
 fn composer_is_a_rounded_box_surface() {
     use ratatui::backend::TestBackend;
     use ratatui::Terminal;


### PR DESCRIPTION
## 背景

Closes #62 — 同步 Deepseek Harness 的 `@file` 功能。按 issue 评论的最终结论实施：

> 重新改回在 Rust 侧实现的方案; UI 控件可以用 ratatui-explorer
> - 要适应本项目的 theme 实现
> - 要适应本项目的 ui preset 实现

## 实现

**Rust 侧实现，无 ACP 扩展、无宿主改动**（`npm/` 零改动）：

- `src/file_ref.rs`（新）：
  - **语法层（纯函数）**：`active_at_token(line, cursor_col)` 检测光标处活跃 `@` token —— 词边界触发（行首/空白/标点后），email 与 URL host 不触发；`@"…"` 引号形式允许空格，引号区内 `@` 不算新 token；`format_file_mention` 产出提示文本（空白路径自动引号形式，目录尾加 `/`，引号形式下目录保持引号打开便于下钻）；`relative_path` 以 workspace 为根。
  - **浏览器层**：`FileMenu` 包装 ratatui-explorer（issue 指定的 UI 控件），以 `cfg.workspace` 为根；目录浏览/排序/隐藏过滤全由库负责，Rust 侧无文件系统遍历代码。
- `src/app.rs`：按键后 `refresh_file_menu`（handle_key 末尾 / vim 分支 / 鼠标点击）驱动浏览器；键交互：`↑↓` 选择、`←` 上级、`→`/`Tab` 下钻（token 改写为 `@dir/`）、`Enter` 落定、`Esc` 关闭（同 token 不再弹出，token 文本变化自动重开）。slash 菜单与 vim normal 互斥。
- `src/ui.rs`：`draw_file_menu` 弹层（composer 上方，宽 72，最多 12 行）。
- **主题适配**：弹层每帧用 `app.theme` token 重建 ratatui-explorer Theme —— `panel`/`border`/`fg`/`brand`/`chip_bg`，palette 包、dark/light 切换即时生效。
- **ui preset 适配**：painter chrome 与 slash 菜单同几何同 token 体系，文案走 `locale.tr`，对 `default`/`deepseek` 两个 UI preset 一视同仁。

## 测试

- `tests/unit/file_ref__tests.rs`：30 个（语法边界、引号、email/URL、格式化、相对路径、浏览器导航、dismiss）
- `tests/unit/app__at_menu_tests.rs`：14 个（键交互、token 替换、下钻、dismiss、vim/slash 共存、引号路径往返）
- `tests/unit/ui__tests.rs`：真实 buffer 渲染断言（弹层、选中行 chip_bg）
- `cargo test --locked` 全绿（588 passed）；`cargo check --locked --tests` 无新增警告

## 文档

- `docs/composer-input.md`：用户按键表 + 开发者接线说明
- `CHANGELOG.md`：Unreleased 新增条目
