### PR TITLE
fix(tui): UI polish for issue #77 — martty naming, dock gauge, zh hints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,23 @@ All notable changes to this project are documented here. The project follows
 
 ### Fixed
 
+- Composer dock context gauge (issue #77): the percentage now uses the
+  harness's `usage_update` readout (`used` = final prompt size, `size` =
+  the real model window) instead of accumulating per-prompt usage over a
+  model-name guess, which over-counted every step's full context and
+  pegged at 100% early. Plain ACP agents without `usage_update` keep the
+  old heuristic.
+- Chinese locale gaps (issue #77): composer `ctrl+shift+a`/`shift+tab`
+  hint labels (`steer`, `shell`), the run-state notes (starting runtime,
+  cancelling, sending images/followups, queue paused) and the native
+  agent rail (Agents/History/expand/close hints) now render in Chinese;
+  the composer key hints also drop the brand accent and match the light
+  tertiary tone of the stats dock readout.
+- User-visible product strings say `martty` instead of the legacy
+  `dsh-tui` name (quit/keys descriptions, welcome version row, auth
+  hint); filesystem paths, settings file names, env vars and the
+  `dsh-tui` compatibility alias are unchanged (issue #77).
+
 - `/status` on runs without a Client tree (demo, standalone painter) now
   opens the same popup as `/keys`, `/help` and `/session` instead of pushing
   into the scrollback: directly after startup the transcript was hidden

--- a/npm/lib/acp-session-stats.js
+++ b/npm/lib/acp-session-stats.js
@@ -25,6 +25,7 @@ function zero(sessionId) {
     usage: {
       input: 0, output: 0, cached: 0, cacheRead: 0, cacheWrite: 0, reasoning: 0,
     },
+    context: { used: 0, size: 0 },
     stats: {
       turns: 0,
       steps: 0,
@@ -137,6 +138,19 @@ export function installAcpSessionStats(ctx, options = {}) {
     }
 
     const type = readString(update, 'sessionUpdate', 'session_update')
+    if (type === 'usage_update') {
+      // Harness-authoritative context gauge: `used` is the final prompt
+      // size (input + cache + output) of the last step and `size` the
+      // real model window from `request/context`. Client-side
+      // accumulation cannot derive either: per-prompt input sums every
+      // step's full context, and standard ACP does not carry the window.
+      const size = number(update.size)
+      if (size > 0) {
+        value.context = { used: number(update.used), size }
+        publish()
+      }
+      return
+    }
     const prompt = sessionId === undefined ? undefined : activePrompts.get(sessionId)
     if (prompt !== undefined && prompt.firstToken === undefined
       && (type === 'agent_message_chunk' || type === 'agent_thought_chunk')

--- a/npm/lib/stats-view.js
+++ b/npm/lib/stats-view.js
@@ -36,12 +36,10 @@ function nodesOf(snapshot, status) {
   const nodes = []
   if ((usage.input ?? 0) > 0 || (usage.output ?? 0) > 0) {
     nodes.push(node('tokens', `↑${formatTokens(usage.input)} · ↓${formatTokens(usage.output)}`))
-    const used = (usage.input ?? 0) + (usage.output ?? 0)
-      + (usage.cached ?? 0) + (usage.reasoning ?? 0)
-    const size = contextWindowOf(model)
-    if (used > 0 && size > 0) {
-      const pct = Math.min(100, used / size * 100).toFixed(1)
-      nodes.push(node('context', `${pct}%/${contextSizeLabel(size)}`))
+    const gauge = contextGauge(snapshot, usage, model)
+    if (gauge.used > 0 && gauge.size > 0) {
+      const pct = Math.min(100, gauge.used / gauge.size * 100).toFixed(1)
+      nodes.push(node('context', `${pct}%/${contextSizeLabel(gauge.size)}`))
     }
   }
   if ((stats.turns ?? 0) > 0 || (stats.steps ?? 0) > 0) {
@@ -83,9 +81,24 @@ function node(id, title) {
 function plural(value, singular) { return value === 1 ? singular : `${singular}s` }
 
 /**
- * Context window of the current model (tokens). The ACP surface does not
- * carry the window size, so the known DeepSeek family sizes stand in;
- * unknown models fall back to a common 128K.
+ * Context-window gauge. The harness streams the authoritative readout
+ * (`usage_update`: `used` = final prompt size, `size` = real model
+ * window); that is what the dock percentage shows. Without it (plain
+ * ACP agents), fall back to the legacy heuristic — accumulated per-turn
+ * usage over a model-name-guessed window.
+ */
+function contextGauge(snapshot, usage, model) {
+  const context = snapshot?.context
+  if (context?.size > 0) return { used: context.used ?? 0, size: context.size }
+  const used = (usage.input ?? 0) + (usage.output ?? 0)
+    + (usage.cached ?? 0) + (usage.reasoning ?? 0)
+  return { used, size: contextWindowOf(model) }
+}
+
+/**
+ * Context window of the current model (tokens), guessed from the model
+ * name when the agent does not stream `usage_update`. Known DeepSeek
+ * family sizes stand in; unknown models fall back to a common 128K.
  */
 function contextWindowOf(model) {
   switch (model) {

--- a/scripts/acp-session-stats.test.mjs
+++ b/scripts/acp-session-stats.test.mjs
@@ -60,6 +60,13 @@ test('standard ACP prompt traffic produces the durable stats footer facts', () =
       },
     },
   })
+  now = 1_700
+  stats.observeAgent({
+    jsonrpc: '2.0', method: 'session/update', params: {
+      sessionId: 's-1',
+      update: { sessionUpdate: 'usage_update', used: 12_300, size: 128_000 },
+    },
+  })
   now = 2_000
   stats.observeAgent({
     jsonrpc: '2.0', id: 2,
@@ -77,6 +84,7 @@ test('standard ACP prompt traffic produces the durable stats footer facts', () =
     usage: {
       input: 100, output: 20, cached: 55, cacheRead: 50, cacheWrite: 5, reasoning: 7,
     },
+    context: { used: 12_300, size: 128_000 },
     stats: {
       turns: 1,
       steps: 1,
@@ -112,5 +120,6 @@ test('session load restores only the latest prompt usage snapshot', () => {
   assert.deepEqual(stats.current().usage, {
     input: 7, output: 2, cached: 4, cacheRead: 3, cacheWrite: 1, reasoning: 0,
   })
+  assert.deepEqual(stats.current().context, { used: 0, size: 0 })
   assert.equal(stats.current().stats.turns, 0)
 })

--- a/scripts/stats-view.test.mjs
+++ b/scripts/stats-view.test.mjs
@@ -68,4 +68,24 @@ test('the stats Client Plugin contributes only through the composer dock', () =>
     },
   })
   assert.deepEqual(nodes, [])
+
+  // The harness `usage_update` gauge wins over the model-name heuristic:
+  // 17000/128000 = 13.3%, not the guessed 1.0M window of the model.
+  listener({
+    sessionId: 's-1',
+    usage: {
+      input: 5000, output: 300, cached: 4000, cacheRead: 4000, cacheWrite: 0, reasoning: 0,
+    },
+    context: { used: 17_000, size: 128_000 },
+    stats: {
+      turns: 2, steps: 4, llmMillis: 0, toolMillis: 0,
+      ttftTotalMillis: 0, ttftCount: 0,
+    },
+  })
+  assert.deepEqual(nodes.map((node) => node.title), [
+    '↑5K · ↓300',
+    '13.3%/128K',
+    '2 turns · 4 steps',
+    'Cache hit 44%',
+  ])
 })

--- a/src/acp_auth.rs
+++ b/src/acp_auth.rs
@@ -402,7 +402,7 @@ fn needs_auth_notice(snapshot: &AuthSnapshot) -> String {
         }
         if method.form {
             lines.push(
-                "  /auth <api-key>  submits through ACP authenticate (dsh-tui does not keep it)"
+                "  /auth <api-key>  submits through ACP authenticate (martty does not keep it)"
                     .into(),
             );
         } else if method.terminal_launch.is_some() {

--- a/src/app.rs
+++ b/src/app.rs
@@ -242,7 +242,7 @@ pub const SLASH_COMMANDS: &[SlashCommand] = &[
     SlashCommand {
         name: "quit",
         usage: "/quit",
-        desc: "exit dsh-tui",
+        desc: "exit martty",
     },
 ];
 
@@ -5235,7 +5235,7 @@ impl App {
                     ctl.send(Cmd::Interrupt {
                         session_id: self.session_id.clone(),
                     });
-                    self.state_note = "cancelling".into();
+                    self.state_note = self.locale.tr("cancelling", "正在取消").into();
                 } else {
                     self.show_tip("demo turn — it finishes on its own");
                 }
@@ -6161,7 +6161,7 @@ impl App {
             self.state_note = if self.demo {
                 String::new()
             } else {
-                "contacting runtime".into()
+                self.locale.tr("contacting runtime", "正在连接运行时").into()
             };
         }
         self.scroll_up = 0;
@@ -6175,7 +6175,10 @@ impl App {
 
     fn dispatch_next_queued(&mut self, ctl: &Controller) {
         if self.queue_selection.is_some() || self.queue_edit.is_some() {
-            self.state_note = "queue paused for selection/edit".into();
+            self.state_note = self
+                .locale
+                .tr("queue paused for selection/edit", "队列已暂停 · 请选择或编辑")
+                .into();
             self.show_tip("queue paused · finish or close the queue editor");
             return;
         }
@@ -6187,7 +6190,7 @@ impl App {
         self.prompt_pending = true;
         self.state = RunState::Starting;
         self.run_started = Some(Instant::now());
-        self.state_note = "sending queued followup".into();
+        self.state_note = self.locale.tr("sending queued followup", "正在发送排队消息").into();
         self.scroll_up = 0;
 
         match prompt.blocks.as_slice() {
@@ -6257,7 +6260,7 @@ impl App {
         self.prompt_pending = true;
         self.state = RunState::Starting;
         self.run_started = Some(Instant::now());
-        self.state_note = "sending queued followup".into();
+        self.state_note = self.locale.tr("sending queued followup", "正在发送排队消息").into();
         ctl.send(if let Some(text) = text {
             Cmd::Prompt {
                 session_id: self.session_id.clone(),
@@ -6562,9 +6565,10 @@ impl App {
             self.state = RunState::Starting;
             self.run_started = Some(Instant::now());
             self.state_note = if n <= 1 {
-                "sending image".into()
+                self.locale.tr("sending image", "正在发送图片").into()
             } else {
-                format!("sending {n} images")
+                self.locale
+                    .tr_fmt("sending {} images", "正在发送 {} 张图片", n)
             };
         }
         self.emit_staged_prompt(staged, None, ctl);
@@ -6608,9 +6612,10 @@ impl App {
                 self.state = RunState::Starting;
                 self.run_started = Some(Instant::now());
                 self.state_note = if n == 1 {
-                    "sending image".into()
+                    self.locale.tr("sending image", "正在发送图片").into()
                 } else {
-                    format!("sending {n} images")
+                    self.locale
+                        .tr_fmt("sending {} images", "正在发送 {} 张图片", n)
                 };
             }
             let steer_message_id = running.then(|| self.next_prompt_id());

--- a/src/input/keymap.rs
+++ b/src/input/keymap.rs
@@ -404,8 +404,8 @@ pub const KEY_ROWS: &[KeyRow] = &[
         chords_mac: &["ctrl+q"],
         chords_other: &["ctrl+q"],
         ctx: CtxNote::Always,
-        desc_en: "quit dsh-tui",
-        desc_zh: "退出 dsh-tui",
+        desc_en: "quit martty",
+        desc_zh: "退出 martty",
         probes: &[p(KeyCode::Char('q'), CTRL, false)],
     },
     // --- scroll · navigate ------------------------------------------------

--- a/src/locale.rs
+++ b/src/locale.rs
@@ -36,6 +36,14 @@ impl Locale {
         }
     }
 
+    /// Localized template with one `{}` placeholder (counts, sizes…).
+    pub fn tr_fmt(self, en: &'static str, zh: &'static str, arg: usize) -> String {
+        match self {
+            Self::En => en.replace("{}", &arg.to_string()),
+            Self::Zh => zh.replace("{}", &arg.to_string()),
+        }
+    }
+
     pub fn command_desc(self, name: &str, fallback: &'static str) -> &'static str {
         if self == Self::En {
             return fallback;
@@ -59,7 +67,7 @@ impl Locale {
             "auth" => "ACP 登录（Backchat authenticate）",
             "lang" => "切换界面语言",
             "liang" => "召唤小难梁 — 🤫 空闲 · ⌨︎ 工作中",
-            "quit" => "退出 dsh-tui",
+            "quit" => "退出 martty",
             _ => fallback,
         }
     }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1128,25 +1128,32 @@ fn draw_agent_rail(f: &mut Frame, app: &App, area: Rect, embedded: bool) {
         } else {
             theme.caption
         };
+        let agents = app.locale.tr("Agents", "代理");
+        let expand = app.locale.tr("↓ expand", "↓ 展开");
         f.render_widget(
             Paragraph::new(Line::from(vec![
                 Span::styled(
                     format!(
-                        "{}Agents · {completed}/{}",
+                        "{}{agents} · {completed}/{}",
                         if embedded { "· " } else { " · " },
                         current.len(),
                     ),
                     Style::default().fg(title_color),
                 ),
-                Span::styled("  ↓ expand", Style::default().fg(theme.caption)),
+                Span::styled(format!("  {expand}"), Style::default().fg(theme.caption)),
             ]))
             .style(Style::default().bg(theme.panel)),
             content,
         );
         return;
     }
+    let agents_label = app.locale.tr("Agents", "代理");
     let mut spans = vec![Span::styled(
-        if embedded { "Agents  " } else { " Agents  " },
+        if embedded {
+            format!("{agents_label}  ")
+        } else {
+            format!(" {agents_label}  ")
+        },
         Style::default()
             .fg(if choosing { theme.brand } else { theme.caption })
             .add_modifier(if choosing {
@@ -1253,14 +1260,15 @@ fn draw_agent_rail(f: &mut Frame, app: &App, area: Rect, embedded: bool) {
         let focused = app.agent_selection.as_deref() == Some(crate::app::AGENT_HISTORY_ID);
         spans.push(Span::styled(
             format!(
-                "  {}History ({history_count})",
+                "  {}{} ({history_count})",
                 if focused || (active && !choosing) {
                     "▸ "
                 } else if active {
                     "• "
                 } else {
                     ""
-                }
+                },
+                app.locale.tr("History", "历史"),
             ),
             Style::default()
                 .fg(if active || focused {
@@ -1281,7 +1289,10 @@ fn draw_agent_rail(f: &mut Frame, app: &App, area: Rect, embedded: bool) {
         ));
     }
     spans.push(Span::styled(
-        "  ←/→ · enter · esc close",
+        format!(
+            "  {}",
+            app.locale.tr("←/→ · enter · esc close", "←/→ · enter · esc 关闭")
+        ),
         Style::default().fg(theme.brand_soft),
     ));
     f.render_widget(
@@ -1499,9 +1510,7 @@ fn status_title(app: &App) -> Line<'static> {
     }
     let theme = app.theme;
     let mut spans: Vec<Span> = Vec::new();
-    let key_style = Style::default()
-        .fg(theme.brand_soft)
-        .add_modifier(Modifier::BOLD);
+    let key_style = Style::default().fg(theme.fg_tertiary);
     // Mode chips: folded from the durable event stream (same facts as the
     // Web UI chips). Stock defaults render until the host reports its own
     // facts, so the landing screen still advertises preset + permission.
@@ -1601,7 +1610,7 @@ fn context_hints(app: &App) -> Vec<Span<'static>> {
             // cancellation.
             (true, false) => vec![
                 ("⏎", app.locale.tr("queue", "排队")),
-                ("ctrl+⏎", "steer"),
+                ("ctrl+⏎", app.locale.tr("steer", "立即转向")),
                 ("esc", app.locale.tr("interrupt", "中断")),
             ],
             // Idle, empty: point at the FIFO editor; otherwise nothing.
@@ -1613,7 +1622,9 @@ fn context_hints(app: &App) -> Vec<Span<'static>> {
             (false, false) if app.input.lines()[0].starts_with('/') => {
                 vec![("⏎", app.locale.tr("command", "命令"))]
             }
-            (false, false) if app.input.lines()[0].starts_with('!') => vec![("⏎", "shell")],
+            (false, false) if app.input.lines()[0].starts_with('!') => {
+                vec![("⏎", app.locale.tr("shell", "运行命令"))]
+            }
             (false, false) => vec![("⏎", app.locale.tr("send", "发送"))],
         }
     };
@@ -2363,7 +2374,7 @@ fn draw_attachment_preview(f: &mut Frame, app: &mut App, composer: Rect, screen:
     )));
     let dims_txt = dims
         .map(|(iw, ih)| format!("{iw}×{ih} px"))
-        .unwrap_or_else(|| "unknown size".into());
+        .unwrap_or_else(|| app.locale.tr("unknown size", "未知尺寸").into());
     let kb = att.data.len() as f64 / 1024.0;
     let size_txt = if kb >= 1024.0 {
         format!("{:.1} MB", kb / 1024.0)
@@ -3297,7 +3308,7 @@ fn welcome_info_lines(app: &App) -> Vec<Line<'static>> {
     };
     out.push(kv(
         app.locale.tr("version", "版本"),
-        format!("dsh-tui {}", env!("CARGO_PKG_VERSION")),
+        format!("martty {}", env!("CARGO_PKG_VERSION")),
     ));
     out.push(kv(
         app.locale.tr("model", "模型"),

--- a/tests/unit/ui__tests.rs
+++ b/tests/unit/ui__tests.rs
@@ -424,8 +424,8 @@ fn status_shortcut_hints_follow_their_values_and_use_key_styling() {
         .collect::<Vec<_>>();
     assert_eq!(key_spans.len(), 2, "{en}");
     assert!(key_spans.iter().all(|span| {
-        span.style.fg == Some(app.theme.brand_soft)
-            && span.style.add_modifier.contains(Modifier::BOLD)
+        span.style.fg == Some(app.theme.fg_tertiary)
+            && !span.style.add_modifier.contains(Modifier::BOLD)
     }));
     let value_spans = en_line
         .spans
@@ -438,7 +438,9 @@ fn status_shortcut_hints_follow_their_values_and_use_key_styling() {
     assert!(value_spans
         .iter()
         .all(|span| span.style.fg == Some(app.theme.fg_tertiary)));
-    assert_ne!(key_spans[0].style.fg, value_spans[0].style.fg);
+    // Issue #77: the shortcut hints share the light tertiary tone of the
+    // mode labels and the composer stats dock readout (no brand accent).
+    assert_eq!(key_spans[0].style.fg, value_spans[0].style.fg);
 }
 
 #[test]
@@ -1425,7 +1427,7 @@ fn welcome_hero_slot_replaces_only_the_martty_lockup() {
         !frame.contains("https://martty.sh"),
         "Martty hero replaced:\n{frame}"
     );
-    assert!(frame.contains("dsh-tui"), "session facts remain:\n{frame}");
+    assert!(frame.contains("martty"), "session facts remain:\n{frame}");
     assert!(
         frame.contains("/help commands"),
         "help row remains:\n{frame}"
@@ -1514,7 +1516,7 @@ fn welcome_info_slot_replaces_only_the_native_information_region() {
         "custom info:\n{frame}"
     );
     assert!(
-        !frame.contains("dsh-tui"),
+        !frame.contains("martty "),
         "native version row replaced:\n{frame}"
     );
     assert!(


### PR DESCRIPTION
Closes #77

## 改进
- **dsh-tui → martty（用户可见文案）**: `/quit` 与 `/keys` 退出键描述、欢迎页版本行、`/auth` 提示。文件路径、环境变量、`dsh-tui-shell`/`dsh-tui-runner` 等内部插件/服务名保持不变（兼容别名与装配依赖）。
- **composer 快捷键提示颜色**: `ctrl+shift+a` / `shift+tab` 由 brand 强调色改为 `fg_tertiary` 浅色，与 stats dock 的 LLM/token 统计同色（去粗体）。

## BUG 修复
- **dock 上下文百分比**: 之前把每轮累计用量（每步含全量上下文、cached 重复计数）除以按模型名猜测的窗口，导致实际用量不大就显示 100%。现在消费 harness 的 `usage_update`（`used` = 最后一步完整 prompt 大小，`size` = `request/context` 真实窗口）；无 `usage_update` 的普通 ACP agent 保留旧启发式回退。
- **中文提示补齐**: composer 提示（steer→立即转向、shell→运行命令）、运行状态行（启动中/正在取消/正在发送图片/排队暂停等）、原生 agent rail（代理/历史/展开/关闭）、附件预览 unknown size，在中文设置下均显示中文。

## 验证
- Rust: 588 tests passed（含更新后的 welcome 版本行与快捷键样式断言）
- npm: 206 tests passed（新增 `usage_update` 与权威 gauge 用例）
- `cargo check --locked --tests` 通过；`--dump-frame` 目检正常