### PR TITLE
fix(tui): context gauge shows only the authoritative usage_update readout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,8 +26,9 @@ All notable changes to this project are documented here. The project follows
   harness's `usage_update` readout (`used` = final prompt size, `size` =
   the real model window) instead of accumulating per-prompt usage over a
   model-name guess, which over-counted every step's full context and
-  pegged at 100% early. Plain ACP agents without `usage_update` keep the
-  old heuristic.
+  pegged at 100% early. Without an authoritative readout the gauge is
+  hidden rather than guessed, and `stats-view` no longer depends on
+  `acpSessionStatus`.
 - Chinese locale gaps (issue #77): composer `ctrl+shift+a`/`shift+tab`
   hint labels (`steer`, `shell`), the run-state notes (starting runtime,
   cancelling, sending images/followups, queue paused) and the native

--- a/npm/lib/stats-view.js
+++ b/npm/lib/stats-view.js
@@ -1,42 +1,35 @@
 /** Built-in Client Plugin: standard ACP usage and timing in the composer dock. */
 
 export const name = 'stats-view'
-export const inject = ['acpSessionStats', 'acpSessionStatus', 'tuiSlots']
+export const inject = ['acpSessionStats', 'tuiSlots']
 
 export function apply(ctx) {
   let current = ctx.acpSessionStats.current()
-  let status = ctx.acpSessionStatus.current()
   let panel
   const stopSlot = ctx.tuiSlots.inject('conversation.composer.dock', () => {
     panel = ctx.tuiSlots.register(
       { name: 'conversation.composer.dock', id: 'stats' },
-      nodesOf(current, status),
+      nodesOf(current),
     )
     return () => panel.dispose()
   })
   const stopStats = ctx.acpSessionStats.subscribe((snapshot) => {
     current = snapshot
-    panel?.update(nodesOf(current, status))
-  })
-  const stopStatus = ctx.acpSessionStatus.subscribe((snapshot) => {
-    status = snapshot
-    panel?.update(nodesOf(current, status))
+    panel?.update(nodesOf(current))
   })
   return () => {
     stopStats?.()
-    stopStatus?.()
     stopSlot?.()
   }
 }
 
-function nodesOf(snapshot, status) {
+function nodesOf(snapshot) {
   const usage = snapshot?.usage ?? {}
   const stats = snapshot?.stats ?? {}
-  const model = status?.model
   const nodes = []
   if ((usage.input ?? 0) > 0 || (usage.output ?? 0) > 0) {
     nodes.push(node('tokens', `↑${formatTokens(usage.input)} · ↓${formatTokens(usage.output)}`))
-    const gauge = contextGauge(snapshot, usage, model)
+    const gauge = contextGauge(snapshot)
     if (gauge.used > 0 && gauge.size > 0) {
       const pct = Math.min(100, gauge.used / gauge.size * 100).toFixed(1)
       nodes.push(node('context', `${pct}%/${contextSizeLabel(gauge.size)}`))
@@ -81,33 +74,19 @@ function node(id, title) {
 function plural(value, singular) { return value === 1 ? singular : `${singular}s` }
 
 /**
- * Context-window gauge. The harness streams the authoritative readout
- * (`usage_update`: `used` = final prompt size, `size` = real model
- * window); that is what the dock percentage shows. Without it (plain
- * ACP agents), fall back to the legacy heuristic — accumulated per-turn
- * usage over a model-name-guessed window.
+ * Context-window gauge. Only the harness `usage_update` readout is shown:
+ * `used` is the final prompt size and `size` the real model window from
+ * `request/context`. Nothing client-side can reproduce either — per-turn
+ * usage sums every step's full context (multi-step turns over-report),
+ * and a model-name guess does not know the window (the old 128K guess is
+ * what pegged the dock at 100% early in issue #77). Without an
+ * authoritative readout the gauge is hidden instead of showing a wrong
+ * percentage.
  */
-function contextGauge(snapshot, usage, model) {
+function contextGauge(snapshot) {
   const context = snapshot?.context
   if (context?.size > 0) return { used: context.used ?? 0, size: context.size }
-  const used = (usage.input ?? 0) + (usage.output ?? 0)
-    + (usage.cached ?? 0) + (usage.reasoning ?? 0)
-  return { used, size: contextWindowOf(model) }
-}
-
-/**
- * Context window of the current model (tokens), guessed from the model
- * name when the agent does not stream `usage_update`. Known DeepSeek
- * family sizes stand in; unknown models fall back to a common 128K.
- */
-function contextWindowOf(model) {
-  switch (model) {
-    case 'deepseek-v4-flash':
-    case 'deepseek-v4-pro':
-      return 1_000_000
-    default:
-      return 128_000
-  }
+  return { used: 0, size: 0 }
 }
 
 /** `1000000` → `1.0M`, `128000` → `128K` — keeps the one-decimal look of

--- a/scripts/stats-view.test.mjs
+++ b/scripts/stats-view.test.mjs
@@ -8,7 +8,7 @@ const statsView = await import(pathToFileURL(
 ).href).catch(() => ({}))
 
 test('the stats Client Plugin contributes only through the composer dock', () => {
-  assert.deepEqual(statsView.inject, ['acpSessionStats', 'acpSessionStatus', 'tuiSlots'])
+  assert.deepEqual(statsView.inject, ['acpSessionStats', 'tuiSlots'])
   assert.equal(typeof statsView.apply, 'function')
   if (typeof statsView.apply !== 'function') return
 
@@ -29,10 +29,6 @@ test('the stats Client Plugin contributes only through the composer dock', () =>
       }),
       subscribe(next) { listener = next; return () => { listener = undefined } },
     },
-    acpSessionStatus: {
-      current: () => ({ model: 'deepseek-v4-flash' }),
-      subscribe() { return () => {} },
-    },
     tuiSlots: {
       inject(name, callback) {
         assert.equal(name, 'conversation.composer.dock')
@@ -47,10 +43,11 @@ test('the stats Client Plugin contributes only through the composer dock', () =>
   }
 
   statsView.apply(ctx)
-  assert.equal(nodes.length, 6)
+  // No `usage_update` yet: the gauge is hidden rather than guessed from
+  // the model name (issue #77 — the old 128K guess pegged early 100%).
+  assert.equal(nodes.length, 5)
   assert.deepEqual(nodes.map((node) => node.title), [
     '↑1.8K · ↓412',
-    '0.3%/1.0M',
     '1 turn · 67 steps',
     'Cache hit 40%',
     'LLM 15s · Tool call 0s',


### PR DESCRIPTION
## 结论（harness 侧事实）
- **分母 size** 只能来自 provider 元数据：`llm-deepseek` 的 `configured?.contextWindow ?? defaultContextWindow`（默认 `1_000_000`，`index.ts:182`），经 `request/context` 事件 → `usage_update.size`。非目录模型（`deepseek-v4`/`v3.2`/`chat`/`reasoner`）在 harness 里也是 1M——TUI 旧表猜 128K 正是 issue #77 "提前 100%" 的根源。
- **分子 used** 必须取"最后一次请求"的 usage（input+cacheRead+cacheWrite+output），加自那以后的 surface 变化（token-meter `measure(session).totalTokens`）；**绝不能跨步累加**（每步 prompt 都含全量上下文）。
- `prompt/usage` replay 的 `totalTokens` 是 per-prompt 累计，多步 turn 会高估，不能用作分子。

## 本 PR 改动
- `stats-view.js`：删除模型名猜测表 `contextWindowOf` 与累计 used 的 fallback；gauge 只在收到权威 `usage_update`（`used`/`size`）时显示，缺失时隐藏而非显示错误百分比。
- `stats-view.js`：移除不再需要的 `acpSessionStatus` 注入（`inject` → `['acpSessionStats', 'tuiSlots']`）。
- 测试与 CHANGELOG 同步更新。

## 行为
| 场景 | 显示 |
|---|---|
| 正常会话（每轮 `usage_update`） | `used/size` 真实百分比（1.0M 窗口） |
| 普通 ACP agent / load 后首轮前 | 隐藏 gauge，不误导 |
| 多步 turn | 每步覆盖式更新，无累加错误 |

验证：npm 206 tests passed。