### PR TITLE
fix(tui): UI polish for issue #80 — /agents on/off, auto-close rail, zh command descriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,19 @@ All notable changes to this project are documented here. The project follows
 
 ### Fixed
 
+- `/agents` is now an on/off switch (issue #80): bare `/agents` toggles
+  the Agent panel, `on`/`off` set it explicitly, and an agent id still
+  selects that transcript. The panel also auto-closes once every subagent
+  task has ended — a failed task keeps it visible, `/agents on` holds it
+  open until the next batch starts, and the native no-Client-tree rail
+  follows the same rule. Finishing the last task also clears an inline
+  selection left open with ↓, which previously kept the expanded panel
+  visible forever.
+- Chinese command descriptions (issue #80): `vim`, `ui`,
+  `cordis-plugins` and the built-in Client Plugin commands `agents`,
+  `status`, `plan-view` now render in Chinese under `/lang zh`, and the
+  `/plugins` description is corrected everywhere (it only shows Host
+  plugin status — it cannot disable or re-enable plugins).
 - Composer dock context gauge (issue #77): the percentage now uses the
   harness's `usage_update` readout (`used` = final prompt size, `size` =
   the real model window) instead of accumulating per-prompt usage over a

--- a/npm/lib/agents-view.js
+++ b/npm/lib/agents-view.js
@@ -5,29 +5,49 @@ export const inject = ['tuiAgents', 'tuiSlots', 'tuiCommands']
 
 export function apply(ctx) {
   let current = ctx.tuiAgents.current()
+  // Issue #80: `/agents` is an on/off switch for the panel. `visible` is
+  // the user preference; `forced` remembers `/agents on` so the summary
+  // stays open even after every task ended, until the next batch starts.
+  let visible = true
+  let forced = false
   let panel
 
   const stopSlot = ctx.tuiSlots.inject('conversation.navigation.dock', () => {
     panel = ctx.tuiSlots.register(
       { name: 'conversation.navigation.dock', id: 'agents-view', order: 0 },
-      dockNodes(current),
+      dockNodes(current, visible, forced),
     )
     return () => panel.dispose()
   })
   const stopAgents = ctx.tuiAgents.subscribe((snapshot) => {
     current = snapshot
-    panel?.update(dockNodes(current))
+    // A new running batch clears the forced-open state so the panel
+    // auto-closes again once this batch ends.
+    if (snapshot.items.some((item) => item.kind === 'subagent' && item.status === 'running')) {
+      forced = false
+    }
+    panel?.update(dockNodes(current, visible, forced))
   })
   const stopCommand = ctx.tuiCommands.register({
     name: 'agents',
-    description: 'Switch the visible Agent transcript',
+    description: 'Toggle the Agent panel (on/off)',
+    input: { hint: '[on|off|agent-id]' },
   }, async (args) => {
-    current = ctx.tuiAgents.current()
-    const target = args.trim()
-    if (target.length > 0) {
-      return ctx.tuiAgents.select(target)
+    const arg = args.trim().toLowerCase()
+    if (arg === 'on') {
+      visible = true
+      forced = true
+    } else if (arg === 'off') {
+      visible = false
+      forced = false
+    } else if (arg === '') {
+      visible = !visible
+      forced = visible
+    } else {
+      return ctx.tuiAgents.select(args.trim())
     }
-    return ctx.tuiAgents.navigate('begin')
+    panel?.update(dockNodes(current, visible, forced))
+    return true
   })
 
   return () => {
@@ -37,9 +57,10 @@ export function apply(ctx) {
   }
 }
 
-function dockNodes(snapshot) {
+function dockNodes(snapshot, visible = true, forced = false) {
   if (!Array.isArray(snapshot?.items) || snapshot.items.length < 2) return []
   const selecting = snapshot.selectedId !== null && snapshot.selectedId !== undefined
+  if (!visible && !selecting) return []
   if (!selecting) {
     const agents = snapshot.items.filter((item) => item.kind === 'subagent')
     const marked = agents.filter((item) => item.current !== false)
@@ -47,6 +68,10 @@ function dockNodes(snapshot) {
     const completed = current.filter((item) => item.status === 'finished' || item.status === 'failed').length
     const running = current.some((item) => item.status === 'running')
     const failed = current.some((item) => item.status === 'failed')
+    // Issue #80: auto-close once every Agent task has ended. A failed task
+    // keeps the summary so the failure stays visible; `/agents on` (forced)
+    // holds it open until the next batch starts running.
+    if (!running && !failed && !forced) return []
     return [
       {
         id: 'summary', kind: 'generic', title: '· Agents', body: `${completed}/${current.length}`,

--- a/scripts/agents-view.test.mjs
+++ b/scripts/agents-view.test.mjs
@@ -58,7 +58,9 @@ function harness(initial = snapshot()) {
     tuiCommands: {
       register(options, handler) {
         assert.deepEqual(options, {
-          name: 'agents', description: 'Switch the visible Agent transcript',
+          name: 'agents',
+          description: 'Toggle the Agent panel (on/off)',
+          input: { hint: '[on|off|agent-id]' },
         })
         command = handler
         return () => {}
@@ -145,11 +147,11 @@ test('Agent view reserves lifecycle colors for status glyphs', () => {
   assert.equal(expanded[3].status, 'done')
   assert.equal(expanded[3].tone, 'fg')
 
+  // Issue #80: every subagent task ended without a failure → the panel
+  // auto-closes instead of leaving a static summary behind.
   const completed = snapshot()
   completed.items[1].status = 'finished'
-  assert.deepEqual(agentsView.dockNodes(completed)[0], {
-    id: 'summary', kind: 'generic', title: '· Agents', body: '2/2', status: 'done', tone: 'caption',
-  })
+  assert.deepEqual(agentsView.dockNodes(completed), [])
 })
 
 test('collapsed progress counts only the current batch while selection keeps history', () => {
@@ -173,7 +175,7 @@ test('collapsed progress counts only the current batch while selection keeps his
   assert.equal(expanded.at(-2).tone, 'caption')
 })
 
-test('Agent view stays keyboard-owned while the command can select a transcript', async () => {
+test('Agent view stays keyboard-owned while the command toggles the panel', async () => {
   assert.equal(typeof agentsView.apply, 'function')
   if (typeof agentsView.apply !== 'function') return
 
@@ -187,10 +189,43 @@ test('Agent view stays keyboard-owned while the command can select a transcript'
     'the Agent rail must not expose mouse command actions',
   )
 
+  // Bare `/agents` toggles the panel (issue #80). An active inline
+  // selection stays visible even while off, so ↓ navigation never vanishes
+  // mid-flight.
   await view.command()('')
-  assert.deepEqual(view.navigated, ['begin'])
-  assert.deepEqual(view.selected, [])
+  assert.equal(view.nodes().length, 5, 'active selection keeps the panel while off')
 
+  // Leaving selection applies the off preference.
+  view.update(snapshot('root-1'))
+  assert.deepEqual(view.nodes(), [], '/agents off hides the panel')
+  await view.command()('')
+  assert.equal(view.nodes().length, 2, 'bare /agents turns the panel back on')
   await view.command()('child-1')
-  assert.deepEqual(view.selected, ['child-1'])
+  assert.deepEqual(view.selected, ['child-1'], 'an id argument still selects the transcript')
+})
+
+test('Agent view auto-closes after the batch ends unless forced open', async () => {
+  assert.equal(typeof agentsView.apply, 'function')
+  if (typeof agentsView.apply !== 'function') return
+
+  const view = harness()
+  agentsView.apply(view.ctx)
+
+  const done = snapshot()
+  done.items[1].status = 'finished'
+  done.items[2].status = 'finished'
+  view.update(done)
+  assert.deepEqual(view.nodes(), [], 'all tasks ended → the panel auto-closes')
+
+  // `/agents on` forces the summary open while idle.
+  await view.command()('on')
+  assert.equal(view.nodes().length, 2, '/agents on keeps the summary open')
+  assert.equal(view.nodes()[0].status, 'done')
+
+  // A new running batch clears the forced state, so the panel auto-closes
+  // again once this batch ends.
+  view.update(snapshot())
+  assert.equal(view.nodes()[0].status, 'running')
+  view.update(done)
+  assert.deepEqual(view.nodes(), [], 'auto-close applies again after a new batch')
 })

--- a/src/app.rs
+++ b/src/app.rs
@@ -212,7 +212,7 @@ pub const SLASH_COMMANDS: &[SlashCommand] = &[
     SlashCommand {
         name: "plugins",
         usage: "/plugins",
-        desc: "show static Host plugins",
+        desc: "show Host plugin status (read-only)",
     },
     SlashCommand {
         name: "cordis-plugins",
@@ -1932,7 +1932,10 @@ impl App {
                         .as_ref()
                         .map(|input| format!("/{} [{}]", command.name, input.hint))
                         .unwrap_or_else(|| format!("/{}", command.name)),
-                    desc: command.description.clone(),
+                    desc: self
+                        .locale
+                        .plugin_command_desc(&command.name, &command.description)
+                        .to_string(),
                     skill: false,
                     plugin: true,
                     section: None,
@@ -2780,6 +2783,15 @@ impl App {
                 if let Some(view) = self.subagents.iter_mut().find(|view| view.id == parent) {
                     view.transcript.apply(ui);
                 }
+            }
+            // Issue #80: the panel auto-closes once every subagent task has
+            // ended. An inline selection left open after the last task would
+            // otherwise keep the rail visible forever — the Client plugin
+            // only hides the summary while nothing is selected.
+            if self.agent_selection.is_some()
+                && !self.subagents.iter().any(|view| view.running || view.failed)
+            {
+                self.agent_selection = None;
             }
             self.needs_redraw = true;
             return;

--- a/src/locale.rs
+++ b/src/locale.rs
@@ -62,12 +62,29 @@ impl Locale {
             "image" => "发送本地图片（png/jpeg/webp/gif）",
             "clip" => "附加剪贴板图片（macOS/Linux）",
             "theme" => "切换明暗模式或主题包",
-            "plugins" => "停用或恢复动态插件",
+            "ui" => "切换 UI 插件",
+            "vim" => "切换 vim 模式编辑（默认关闭）",
+            "plugins" => "查看 Host 插件状态（只读）",
+            "cordis-plugins" => "查看或管理动态 Cordis 插件",
             "session" => "显示会话和运行时信息",
             "auth" => "ACP 登录（Backchat authenticate）",
             "lang" => "切换界面语言",
             "liang" => "召唤小难梁 — 🤫 空闲 · ⌨︎ 工作中",
             "quit" => "退出 martty",
+            _ => fallback,
+        }
+    }
+
+    /// Built-in Client Plugin command descriptions (`tuiCommands`), keyed by
+    /// command name; unknown plugin commands keep their authored text.
+    pub fn plugin_command_desc<'a>(self, name: &str, fallback: &'a str) -> &'a str {
+        if self == Self::En {
+            return fallback;
+        }
+        match name {
+            "agents" => "切换 Agent 面板（on/off）",
+            "status" => "显示会话运行状态与关键统计",
+            "plan-view" => "打开当前 ACP 计划",
             _ => fallback,
         }
     }
@@ -129,3 +146,7 @@ impl Default for UiSettings {
         }
     }
 }
+
+#[cfg(test)]
+#[path = "../tests/unit/locale__tests.rs"]
+mod tests;

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -72,15 +72,23 @@ fn composer_dock_height(app: &App, main_height: u16, child_view: bool) -> u16 {
 
 /// One compact session-navigation row inside the composer, immediately above
 /// its meta row. A Client Plugin snapshot wins; the native Agent rail is only
-/// the no-Client-tree fallback.
+/// the no-Client-tree fallback, and it auto-closes once every subagent task
+/// has ended (issue #80): a failed task or an active inline selection keeps
+/// it visible.
 fn navigation_dock_height(app: &App, main_height: u16) -> u16 {
-    if main_height >= 8
-        && (slot_has_nodes(app, "conversation.navigation.dock") || !app.subagents.is_empty())
-    {
-        1
-    } else {
-        0
+    if main_height >= 8 {
+        let plugin_owns = app
+            .slot_snapshots
+            .contains_key("conversation.navigation.dock");
+        let native_visible = !plugin_owns
+            && !app.subagents.is_empty()
+            && (app.agent_selection.is_some()
+                || app.subagents.iter().any(|view| view.running || view.failed));
+        if slot_has_nodes(app, "conversation.navigation.dock") || native_visible {
+            return 1;
+        }
     }
+    0
 }
 
 /// Compact client-owned FIFO shelf between the conversation and composer.

--- a/tests/unit/app__mode_tests.rs
+++ b/tests/unit/app__mode_tests.rs
@@ -4155,3 +4155,151 @@ fn vim_mode_blocks_plain_typing_and_esc_returns_to_normal() {
     app.handle_key(KeyEvent::new(KeyCode::Char('q'), KeyModifiers::NONE), &ctl);
     assert_eq!(app.input.buf(), "xqtwo", "plain typing is back at the caret");
 }
+
+#[test]
+fn bridge_style_subagent_events_resolve_each_child_independently() {
+    // Bridge 0.4.26 projects subagent lifecycle as tool_call/tool_call_update
+    // with `_meta.dsh.subagent` (state started/finished + childSessionId).
+    // Every child must resolve to its own view: a finished child flips only
+    // its own running flag, so the rail auto-closes once ALL children end.
+    let (mut app, ctl, _rx) = test_app();
+    app.show_banner = false;
+
+    let subagent_call = |state: &str, child: &str, stop: &str| {
+        let status = if state == "started" {
+            "in_progress"
+        } else if stop == "completed" {
+            "completed"
+        } else {
+            "failed"
+        };
+        serde_json::json!({
+            "sessionUpdate": if state == "started" { "tool_call" } else { "tool_call_update" },
+            "toolCallId": format!("subagent:run-{child}"),
+            "status": status,
+            "rawInput": {"childSessionId": child},
+            "_meta": {"dsh": {"subagent": {
+                "state": state,
+                "runId": format!("run-{child}"),
+                "childSessionId": child,
+                "provider": "codex",
+                "local": false
+            }}}
+        })
+    };
+
+    // Two children start, then each finishes.
+    for child in ["child-1", "child-2"] {
+        app.handle(
+            AppEvent::Rpc {
+                method: "session/update".into(),
+                params: serde_json::json!({
+                    "sessionId": "dsh-test",
+                    "update": subagent_call("started", child, ""),
+                }),
+            },
+            &ctl,
+        );
+    }
+    assert_eq!(app.subagents.len(), 2, "each start creates its own view");
+    assert!(app.subagents.iter().all(|view| view.running));
+
+    app.handle(
+        AppEvent::Rpc {
+            method: "session/update".into(),
+            params: serde_json::json!({
+                "sessionId": "dsh-test",
+                "update": subagent_call("finished", "child-1", "completed"),
+            }),
+        },
+        &ctl,
+    );
+    assert!(!app.subagents[0].running, "child-1 finished");
+    assert!(app.subagents[1].running, "child-2 still runs");
+
+    app.handle(
+        AppEvent::Rpc {
+            method: "session/update".into(),
+            params: serde_json::json!({
+                "sessionId": "dsh-test",
+                "update": subagent_call("finished", "child-2", "completed"),
+            }),
+        },
+        &ctl,
+    );
+    assert!(
+        app.subagents.iter().all(|view| !view.running),
+        "every finished child flips its own view"
+    );
+    let snapshot = app.agents_snapshot();
+    let statuses = snapshot
+        .items
+        .iter()
+        .filter(|item| item.kind == "subagent")
+        .map(|item| item.status.as_str())
+        .collect::<Vec<_>>();
+    assert_eq!(statuses, ["finished", "finished"], "{snapshot:?}");
+}
+
+#[test]
+fn finished_last_subagent_clears_an_open_inline_selection() {
+    // Issue #80: an inline selection (↓) left open after the last task ends
+    // would keep the Client panel on its expanded branch forever, bypassing
+    // the auto-close. Finishing the last task must clear the selection so
+    // the plugin can hide the rail.
+    let (mut app, ctl, _rx) = test_app();
+    app.show_banner = false;
+
+    let started = |child: &str| {
+        serde_json::json!({
+            "sessionUpdate": "tool_call",
+            "toolCallId": format!("subagent:run-{child}"),
+            "status": "in_progress",
+            "rawInput": {"childSessionId": child},
+            "_meta": {"dsh": {"subagent": {
+                "state": "started", "runId": format!("run-{child}"),
+                "childSessionId": child, "provider": "codex", "local": false
+            }}}
+        })
+    };
+    let finished = |child: &str| {
+        serde_json::json!({
+            "sessionUpdate": "tool_call_update",
+            "toolCallId": format!("subagent:run-{child}"),
+            "status": "completed",
+            "_meta": {"dsh": {"subagent": {
+                "state": "finished", "runId": format!("run-{child}"),
+                "childSessionId": child, "provider": "codex", "local": false
+            }}}
+        })
+    };
+    let fire = |app: &mut crate::app::App, update: serde_json::Value| {
+        app.handle(
+            AppEvent::Rpc {
+                method: "session/update".into(),
+                params: serde_json::json!({"sessionId": "dsh-test", "update": update}),
+            },
+            &ctl,
+        );
+    };
+
+    fire(&mut app, started("child-1"));
+    fire(&mut app, started("child-2"));
+    app.agent_selection = Some("child-1".into());
+    assert_eq!(app.agents_snapshot().selected_id.as_deref(), Some("child-1"));
+
+    // child-1 finishes: child-2 still runs, the selection must survive.
+    fire(&mut app, finished("child-1"));
+    assert_eq!(
+        app.agents_snapshot().selected_id.as_deref(),
+        Some("child-1"),
+        "selection stays while another task still runs"
+    );
+
+    // child-2 finishes: no task remains, the selection auto-closes.
+    fire(&mut app, finished("child-2"));
+    assert_eq!(
+        app.agents_snapshot().selected_id, None,
+        "last task ended → the open selection clears"
+    );
+}

--- a/tests/unit/locale__tests.rs
+++ b/tests/unit/locale__tests.rs
@@ -1,0 +1,40 @@
+use crate::locale::Locale;
+
+#[test]
+fn zh_command_desc_covers_every_builtin_and_plugin_command() {
+    let zh = Locale::Zh;
+    // Builtin chrome commands advertised in the slash menu.
+    assert_eq!(zh.command_desc("vim", ""), "切换 vim 模式编辑（默认关闭）");
+    assert_eq!(zh.command_desc("ui", ""), "切换 UI 插件");
+    assert_eq!(zh.command_desc("plugins", ""), "查看 Host 插件状态（只读）");
+    assert_eq!(
+        zh.command_desc("cordis-plugins", ""),
+        "查看或管理动态 Cordis 插件"
+    );
+    // Built-in Client Plugin commands keep their authored text in English.
+    assert_eq!(zh.command_desc("unknown", "fallback"), "fallback");
+    assert_eq!(Locale::En.command_desc("plugins", "fallback"), "fallback");
+
+    // Built-in Client Plugin commands (`tuiCommands`) localize at render time.
+    assert_eq!(
+        zh.plugin_command_desc("agents", "Toggle the Agent panel (on/off)"),
+        "切换 Agent 面板（on/off）"
+    );
+    assert_eq!(
+        zh.plugin_command_desc("status", "Session run state and key stats"),
+        "显示会话运行状态与关键统计"
+    );
+    assert_eq!(
+        zh.plugin_command_desc("plan-view", "Open the current ACP plan"),
+        "打开当前 ACP 计划"
+    );
+    // Unknown plugin commands keep their authored description.
+    assert_eq!(
+        zh.plugin_command_desc("mystery", "Some plugin text"),
+        "Some plugin text"
+    );
+    assert_eq!(
+        Locale::En.plugin_command_desc("agents", "Toggle the Agent panel (on/off)"),
+        "Toggle the Agent panel (on/off)"
+    );
+}

--- a/tests/unit/ui__tests.rs
+++ b/tests/unit/ui__tests.rs
@@ -714,6 +714,51 @@ fn native_agent_rail_expands_only_during_selection() {
 }
 
 #[test]
+fn native_agent_rail_auto_closes_once_every_task_has_ended() {
+    // Issue #80: the native rail is only a live-progress surface. When no
+    // subagent is running and none failed, it closes instead of leaving a
+    // static summary; an inline selection reopens it.
+    let mut app = test_app();
+    app.show_banner = false;
+    app.subagents.push(crate::app::SubagentView {
+        id: "child-1".into(),
+        parent: "dsh-test".into(),
+        label: "subagent 1".into(),
+        running: false,
+        failed: false,
+        transcript: crate::transcript::Transcript::new("child-1".into()),
+    });
+    app.subagents.push(crate::app::SubagentView {
+        id: "child-2".into(),
+        parent: "dsh-test".into(),
+        label: "subagent 2".into(),
+        running: false,
+        failed: false,
+        transcript: crate::transcript::Transcript::new("child-2".into()),
+    });
+
+    let frame = dump_frame(&mut app, 100, 24);
+    assert!(
+        !frame.contains("Agents ·"),
+        "all tasks finished → the native rail auto-closes:\n{frame}"
+    );
+
+    // An active inline selection keeps the rail visible after the tasks end.
+    app.agent_selection = Some("child-1".into());
+    let expanded = dump_frame(&mut app, 100, 24);
+    assert!(
+        expanded.contains("subagent 1"),
+        "selection reopens the rail:\n{expanded}"
+    );
+
+    // A failed task keeps the summary visible as a failure surface.
+    app.agent_selection = None;
+    app.subagents[1].failed = true;
+    let failed = dump_frame(&mut app, 100, 24);
+    assert!(failed.contains("Agents · 2/2"), "{failed}");
+}
+
+#[test]
 fn plugin_agent_navigation_sits_above_composer_meta_with_general_theme_tokens() {
     use ratatui::backend::TestBackend;
     use ratatui::Terminal;
@@ -2788,4 +2833,45 @@ fn composer_textarea_renders_chips_selection_and_multiline_drafts() {
         .position(|l| l.contains("line two"))
         .expect("second line");
     assert!(second > first, "hard newline stacks lines");
+}
+
+#[test]
+fn empty_plugin_dock_snapshot_hides_the_agents_row_after_tasks_end() {
+    // Issue #80 end-to-end shape: all subagent views are finished and the
+    // Client panel published an EMPTY navigation.dock snapshot (the
+    // auto-close payload). The native rail must not take over as a
+    // fallback while the plugin owns the slot, so the row disappears.
+    let mut app = test_app();
+    app.show_banner = false;
+    app.subagents.push(crate::app::SubagentView {
+        id: "child-1".into(),
+        parent: "dsh-test".into(),
+        label: "subagent 1".into(),
+        running: false,
+        failed: false,
+        transcript: crate::transcript::Transcript::new("child-1".into()),
+    });
+    let (ctl, _commands) = crate::controller::tests::test_controller();
+    app.handle(
+        crate::bus::AppEvent::Rpc {
+            method: crate::cordis::SLOTS_UPDATE.into(),
+            params: serde_json::json!({
+                "protocol": 0,
+                "slot": "conversation.navigation.dock",
+                "rev": 7,
+                "nodes": [],
+            }),
+        },
+        &ctl,
+    );
+
+    let frame = dump_frame(&mut app, 100, 24);
+    assert!(
+        !frame.contains("Agents"),
+        "plugin-owned empty dock must hide the row, not fall back to the native rail:\n{frame}"
+    );
+    assert!(
+        !frame.contains("subagent 1"),
+        "no native rail entries either:\n{frame}"
+    );
 }


### PR DESCRIPTION
Closes #80

## 改进
- **`/agents` 改为 on/off 开关**: 裸 `/agents` 切换 Agent 面板显示；`on`/`off` 显式设置；`<agent-id>` 保留原"选择会话"行为。`/agents on` 强制打开后，新一轮任务开始才解除（之后恢复自动关闭）。
- **命令说明中文翻译**: `vim`、`ui`、`cordis-plugins` 及内置 Client 插件命令 `agents`、`status`、`plan-view` 在 `/lang zh` 下显示中文（`Locale::plugin_command_desc` 在 slash 菜单渲染时本地化，插件 payload 保持英文不动）。
- **`/plugins` 描述修正**: en `show Host plugin status (read-only)`；zh `查看 Host 插件状态（只读）`（原"停用或恢复动态插件"是错的——它只能查看状态，不能启停）。

## BUG 修复
- **agents 面板任务结束后自动关闭**: 所有 subagent 任务结束（无 running/failed）后面板自动收起；有 failed 任务保留（失败可见）。
  - Client 侧（agents-view dockNodes）+ 原生 no-Client-tree rail（navigation_dock_height）同规则。
  - 插件注册槽位时空节点不再回退到原生 rail。
  - **补充修复**（调查确认的缺陷）：用 `↓` 展开过 inline 选择后，`agent_selection` 无自动清空机制，任务结束面板也不关闭——现在最后一个任务结束时自动清空选择，面板正常收起；手动重新 `↓` 浏览历史不受影响。

## 验证
- Rust 595 tests passed（新增：native rail 自动关闭、空插件快照隐藏、bridge 格式多 subagent 独立完成、最后任务结束清空选择、中文描述断言）
- npm 207 tests passed（新增 /agents toggle/auto-close/forced 用例）