### PR TITLE
fix(tui): slash menu black blocks from orphaned wide-char cells (issue #83)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,13 @@ All notable changes to this project are documented here. The project follows
 
 ### Fixed
 
+- Slash-menu and `@file` black blocks (issue #83): scrolling the command
+  candidate list (or the file browser) moved wide (CJK) glyphs and could
+  orphan a trailing half-cell on the real screen while both ratatui
+  buffers agreed the cell was unchanged, so the frame diff skipped it and
+  the leftover half-glyph stayed as a black rectangle. Both popups now
+  mark every cell for a full rewrite each frame, the same guard the
+  transcript and review overlay already use (issue #38 class).
 - `/agents` is now an on/off switch (issue #80): bare `/agents` toggles
   the Agent panel, `on`/`off` set it explicitly, and an agent id still
   selects that transcript. The panel also auto-closes once every subagent

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -760,6 +760,13 @@ fn wrap_line(s: &str, cells: usize) -> Vec<String> {
 /// cells regardless of terminal-specific wide-char erase behavior.
 fn force_full_rewrite(f: &mut Frame, area: Rect) {
     let buf = f.buffer_mut();
+    // Overlays compute their rect from screen math that can saturate at the
+    // top edge; never index a cell outside the buffer (widgets clip via
+    // `intersection`, direct indexing would panic).
+    let area = area.intersection(Rect::new(0, 0, buf.area.width, buf.area.height));
+    if area.is_empty() {
+        return;
+    }
     for pos in area.positions() {
         buf[pos].set_diff_option(ratatui::buffer::CellDiffOption::AlwaysUpdate);
     }
@@ -2764,6 +2771,13 @@ fn draw_slash_menu(f: &mut Frame, app: &App, input: Rect, chat: Rect) {
         ));
     }
     f.render_widget(Paragraph::new(lines).block(block), area);
+    // The popup floats over the transcript: scrolling it with ↑/↓ moves
+    // wide (CJK) glyphs and can orphan their trailing halves on the real
+    // screen while both ratatui buffers agree the cell is unchanged, so
+    // the diff skips it and the leftover half-glyph stays as a black block
+    // (issue #83 — same class as the #38 transcript fix). Force a full
+    // rewrite of the popup every frame to flush any stale terminal cells.
+    force_full_rewrite(f, area);
 }
 
 /// Rows of the `@file` browser shown at once; the explorer's own List
@@ -2798,6 +2812,10 @@ fn draw_file_menu(f: &mut Frame, app: &mut App, input: Rect, chat: Rect) {
     let area = Rect::new(input.x + 2, y, w, h);
     f.render_widget(Clear, area);
     f.render_widget_ref(menu.explorer().widget(), area);
+    // Same class as #83 / #38: CJK file names scroll through the explorer
+    // window and orphan wide-char trailing cells on the real screen; force
+    // a full rewrite so the diff never trusts a half-erased cell.
+    force_full_rewrite(f, area);
 }
 
 /// Pad `s` to exactly `w` display cells, ellipsizing when longer — keeps

--- a/tests/unit/ui_diff_option__tests.rs
+++ b/tests/unit/ui_diff_option__tests.rs
@@ -131,3 +131,115 @@ fn overlay_area(buf: &Buffer) -> Rect {
         .expect("overlay bottom border");
     Rect::new(left, top, right - left + 1, bottom - top + 1)
 }
+
+/// Locate the slash menu popup by its title row (`┌ 命令 ┬───┐`; the
+/// composer card uses rounded corners, so the square ┌/┐ are unique to
+/// this popup) and read the painted border back as the area.
+fn slash_menu_area(buf: &Buffer) -> Rect {
+    let (width, height) = (buf.area.width, buf.area.height);
+    for y in 0..height {
+        let row: String = (0..width).map(|x| buf[(x, y)].symbol().to_string()).collect();
+        if row.contains("commands") || row.contains("命令") {
+            let left = (0..width)
+                .find(|&x| buf[(x, y)].symbol() == "┌")
+                .expect("slash menu top-left corner");
+            let right = (0..width)
+                .rfind(|&x| buf[(x, y)].symbol() == "┐")
+                .expect("slash menu top-right corner");
+            let bottom = (y + 1..height)
+                .find(|&yy| buf[(left, yy)].symbol() == "└" && buf[(right, yy)].symbol() == "┘")
+                .expect("slash menu bottom border");
+            return Rect::new(left, y, right - left + 1, bottom - y + 1);
+        }
+    }
+    panic!("slash menu popup not found")
+}
+
+/// Locate the `@file` browser popup via its bottom hint row (owned by the
+/// explorer chrome) and read the painted border back as the area.
+fn file_menu_area(buf: &Buffer) -> Rect {
+    let (width, height) = (buf.area.width, buf.area.height);
+    let mut border = None;
+    for y in 0..height {
+        let row: String = (0..width).map(|x| buf[(x, y)].symbol().to_string()).collect();
+        if row.contains("move") || row.contains("移动") {
+            let left = (0..width)
+                .find(|&x| buf[(x, y)].symbol() == "└")
+                .expect("file menu bottom-left corner");
+            let right = (0..width)
+                .rfind(|&x| buf[(x, y)].symbol() == "┘")
+                .expect("file menu bottom-right corner");
+            border = Some((y, left, right));
+            break;
+        }
+    }
+    let (bottom, left, right) = border.expect("file menu hint row");
+    let top = (0..bottom)
+        .rev()
+        .find(|&y| buf[(left, y)].symbol() == "┌" && buf[(right, y)].symbol() == "┐")
+        .expect("file menu top border");
+    Rect::new(left, top, right - left + 1, bottom - top + 1)
+}
+
+/// Issue #83: the slash menu floats over CJK transcript content; scrolling
+/// it with ↑/↓ moves wide glyphs and can orphan a trailing half-cell on the
+/// real screen while both ratatui buffers agree the cell is unchanged (same
+/// class as #38). The popup must force a full rewrite every frame.
+#[test]
+fn slash_menu_popup_forces_a_full_rewrite() {
+    let mut app = test_app();
+    app.show_banner = false;
+    app.input.insert_str("/");
+    assert!(app.slash_completion_open(), "slash menu must be open");
+    let backend = TestBackend::new(100, 30);
+    let mut terminal = Terminal::new(backend).expect("test terminal");
+    terminal
+        .draw(|f| {
+            draw(f, &mut app);
+            let area = slash_menu_area(f.buffer_mut());
+            assert_always_update(f.buffer_mut(), area, "slash menu");
+        })
+        .expect("draw frame");
+    // Scroll the follow-window to the bottom of the catalog and redraw: the
+    // marks must persist on every frame, not only the first paint.
+    let n = app.slash_matches().len();
+    app.slash_sel = n - 1;
+    terminal
+        .draw(|f| {
+            draw(f, &mut app);
+            let area = slash_menu_area(f.buffer_mut());
+            assert_always_update(f.buffer_mut(), area, "slash menu (scrolled)");
+        })
+        .expect("redraw frame");
+}
+
+/// Issue #83, sibling: the `@file` browser lists CJK file names and scrolls
+/// through the explorer window — same orphaned wide-char class, same
+/// full-rewrite guard.
+#[test]
+fn file_menu_popup_forces_a_full_rewrite() {
+    let mut app = test_app();
+    app.show_banner = false;
+    app.input.insert_str("@");
+    let ws = std::env::temp_dir().join(format!(
+        "dsh-tui-ui-file-menu-diff-{}",
+        std::process::id()
+    ));
+    let _ = std::fs::remove_dir_all(&ws);
+    std::fs::create_dir_all(ws.join("src")).expect("mkdir");
+    std::fs::write(ws.join("主程序.rs"), "").expect("write");
+    let token = crate::file_ref::active_at_token("@", 1).expect("token");
+    app.cfg.workspace = ws.to_string_lossy().into_owned();
+    app.file_menu =
+        Some(crate::file_ref::FileMenu::open(&ws, 0, &token).expect("menu opens"));
+    let backend = TestBackend::new(100, 30);
+    let mut terminal = Terminal::new(backend).expect("test terminal");
+    terminal
+        .draw(|f| {
+            draw(f, &mut app);
+            let area = file_menu_area(f.buffer_mut());
+            assert_always_update(f.buffer_mut(), area, "file menu");
+        })
+        .expect("draw frame");
+}
+


### PR DESCRIPTION
## What

Closes #83 — scrolling the `/` command candidate list (and the `@file` browser) leaves black rectangle blocks on the screen.

## Root cause

Same class as #38. ratatui's frame diff skips cells that are identical between frames. When the popup scrolls, wide (CJK) glyphs move; terminals that render wide chars as clusters can be left with an orphaned trailing half-cell on the real screen. Both ratatui buffers agree that cell is unchanged (`" "` + panel bg), so the diff never re-emits it and the leftover half-glyph persists as a black block.

The transcript pane and the review overlay already guard against this with `force_full_rewrite` (`CellDiffOption::AlwaysUpdate`, added for #38); the two anchored popups missed it.

## Changes

- `draw_slash_menu` / `draw_file_menu`: force a full rewrite of the popup area every frame (few KB/frame while open).
- `force_full_rewrite`: clip the rect to the buffer — popup rects can saturate at the top edge and direct indexing would panic.
- Regression tests: both popups must mark every cell `AlwaysUpdate`, including after scrolling the follow-window to the bottom (issue #38 test pattern).
- CHANGELOG entry under `[Unreleased]`.

## Verification

- `cargo test --locked` — 600 passed
- `cargo check --locked --tests` — clean
- Reproduced the byte-level diff behavior: after a wide→narrow transition, subsequent frames emit nothing for the stale cell (artifact persists); with `AlwaysUpdate` the cell is rewritten every frame (artifact flushed).