### PR TITLE
fix(tui): popup titles no longer repeat inside the body (issue #85)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,6 +138,10 @@ All notable changes to this project are documented here. The project follows
   with a queue that never drains.
 - User message bubbles no longer overflow the chat pane by two cells, which
   clipped the last visible character of every wrapped CJK line.
+- Review/info popups no longer repeat their title (issue #85): `/plan-view`
+  moves the `Plan n/m` counter into the popup window title, and the
+  in-body `## …` headings were dropped from `/plan-view`, `/keys`, `/help`,
+  `/session` and `/status` — the popup border already names the window.
 
 ### Added
 

--- a/npm/lib/plan-view.js
+++ b/npm/lib/plan-view.js
@@ -25,7 +25,7 @@ export function apply(ctx) {
     current = ctx.acpSessionPlan.current()
     ctx.tuiOverlay.openView({
       id: 'plan-view',
-      title: 'Plan',
+      title: viewTitle(current),
       nodes: viewNodes(current),
     })
   })
@@ -67,6 +67,18 @@ function dockNodes(plan) {
   }]
 }
 
+// The overlay window title: the `n/m` counter lives in the border, not in
+// the body, so the review never repeats its heading (issue #85).
+function viewTitle(plan) {
+  if (plan !== null && plan.kind === 'items') {
+    const total = plan.entries.length
+    if (total === 0) return 'Plan'
+    const completed = plan.entries.filter((entry) => entry.status === 'completed').length
+    return `Plan ${completed}/${total}`
+  }
+  return 'Plan'
+}
+
 function viewNodes(plan) {
   if (plan === null) {
     return [{ id: 'empty', kind: 'notice', level: 'info', text: 'No active plan' }]
@@ -78,10 +90,8 @@ function viewNodes(plan) {
     return [{ id: 'file', kind: 'notice', level: 'info', text: plan.uri }]
   }
   // Items render as one markdown node: a task-list review the transcript
-  // pipeline can fully render (headings, bold, strikethrough).
-  const total = plan.entries.length
-  const completed = plan.entries.filter((entry) => entry.status === 'completed').length
-  const lines = [`## Plan · ${completed}/${total}`, '']
+  // pipeline can fully render (bold, strikethrough).
+  const lines = []
   for (const entry of plan.entries) {
     const content = entry.content.replace(/\s*\n\s*/g, ' ')
     let item

--- a/npm/lib/status-view.js
+++ b/npm/lib/status-view.js
@@ -27,7 +27,8 @@ export function apply(ctx) {
 }
 
 /**
- * One `## status` markdown node. Run-state facts come from
+ * One markdown node of run-state facts (the window border already names
+ * the popup, so no in-body heading). Facts come from
  * `acpSessionStatus`; every token/turn/step/timing fact comes from
  * `acpSessionStats.current()` — the same snapshot `stats-view` renders in
  * the composer dock, so the two readouts can never drift apart.
@@ -37,7 +38,7 @@ function statusMarkdown(status, stats) {
   const folded = stats?.stats ?? {}
   const total = (usage.input ?? 0) + (usage.output ?? 0)
     + (usage.cached ?? 0) + (usage.reasoning ?? 0)
-  const lines = ['## status', '']
+  const lines = []
   lines.push(`- state · ${status.state ?? 'idle'}`)
   lines.push(`- acp · ${status.connection ?? 'not attached'}`)
   if (status.auth?.status !== undefined) {

--- a/scripts/plan-view.test.mjs
+++ b/scripts/plan-view.test.mjs
@@ -86,12 +86,13 @@ test('the Plan Client Plugin owns its dock, fallback command, and modal together
 
   await command.handler('')
   assert.equal(opened.id, 'plan-view')
-  // Items render as one markdown task-list node the transcript pipeline
-  // can fully render (heading, [x]/[ ], bold, strikethrough).
+  // The counter lives in the window title; the body is a task-list review
+  // the transcript pipeline can fully render ([x]/[ ], bold, strikethrough).
+  assert.equal(opened.title, 'Plan 1/2')
   assert.equal(opened.nodes.length, 1)
   assert.equal(opened.nodes[0].kind, 'markdown')
   const md = opened.nodes[0].text
-  assert.match(md, /## Plan · 1\/2/)
+  assert.ok(!md.includes('## Plan'), md)
   assert.match(md, /- \[x\] Inspect · priority · high/)
   assert.match(md, /- \[ \] \*\*Implement\*\* · priority · medium/)
 

--- a/scripts/status-view.test.mjs
+++ b/scripts/status-view.test.mjs
@@ -70,7 +70,7 @@ test('the status Client Plugin registers /status and opens the markdown overlay'
   assert.equal(overlay.nodes[0].kind, 'markdown')
 
   const text = overlay.nodes[0].text
-  assert.ok(text.startsWith('## status\n'), text)
+  assert.ok(text.startsWith('- state · running'), text)
   assert.ok(text.includes('- state · running'), text)
   assert.ok(text.includes('- acp · attached'), text)
   assert.ok(text.includes('- auth · configured · agent'), text)

--- a/src/app.rs
+++ b/src/app.rs
@@ -5756,8 +5756,6 @@ impl App {
     fn push_help(&mut self) {
         if self.locale == Locale::Zh {
             let text = "\
-## help
-
 - enter · 发送；空 composer 且 Queue 非空时立即发送队首
 - alt+↑ · 选择任意排队消息；↑/↓ 选择，enter 编辑/保存，ctrl+d 删除，esc 退出
 - ctrl+enter · 立即 steer 当前轮次
@@ -5788,8 +5786,6 @@ token 用量（含缓存命中）以及轮次结束原因。";
             return;
         }
         let text = "\
-## help
-
 - enter · send · with an empty composer, sends the Queue head now
 - alt+↑ · choose any queued prompt · ↑/↓ select, enter edits/saves, ctrl+d deletes, esc closes
 - ctrl+enter · steer the active turn immediately
@@ -5880,8 +5876,7 @@ context, subagent lifecycles, token usage (incl. cache hits), end reason.";
             .map(|effort| format!("\n- effort · {effort}"))
             .unwrap_or_default();
         let mut text = format!(
-            "## session\n\n\
-             - session · {}{}\n\
+            "- session · {}{}\n\
              - provider · {} / {}{}\n\
              - agent · {}{}\n\
              - workspace · {}\n\
@@ -6028,7 +6023,7 @@ context, subagent lifecycles, token usage (incl. cache hits), end reason.";
             }
             _ => None,
         };
-        let mut text = format!("## status\n\n- state · {state}\n- acp · {acp}\n");
+        let mut text = format!("- state · {state}\n- acp · {acp}\n");
         if let Some(auth) = auth_line {
             text.push_str(&format!("- auth · {auth}\n"));
         }

--- a/src/input/keymap.rs
+++ b/src/input/keymap.rs
@@ -920,9 +920,11 @@ pub const MOUSE_ROWS: &[MouseRow] = &[
 pub fn keys_markdown(zh: bool, mac: bool) -> String {
     let mut out = String::new();
     out.push_str(if zh {
-        "## 快捷键\n\n双用途键：`[空输入时]` 滚动，`[输入时]` 编辑。\n\n"
+        // The popup window border already names the dialog (`/keys`); the
+        // body starts with the intro sentence, not a repeated heading.
+        "双用途键：`[空输入时]` 滚动，`[输入时]` 编辑。\n\n"
     } else {
-        "## keys — shortcut map\n\nDual-use keys: `[empty]` scrolls, `[typing]` edits.\n\n"
+        "Dual-use keys: `[empty]` scrolls, `[typing]` edits.\n\n"
     });
     let mut last_group: Option<KeyGroup> = None;
     for row in KEY_ROWS {

--- a/tests/unit/app__right_slot_tests.rs
+++ b/tests/unit/app__right_slot_tests.rs
@@ -462,7 +462,7 @@ fn status_slash_fallback_shows_run_state_without_transcript_stats() {
     let crate::slots::TuiNode::Markdown { text, .. } = &overlay.nodes[0] else {
         panic!("/status overlay should be one markdown node, got {:?}", overlay.nodes);
     };
-    assert!(text.contains("## status"), "{text}");
+    assert!(!text.contains("## status"), "{text}");
     assert!(text.contains("- state · "), "{text}");
     // ACP facts: demo run shows the demo marker and its session.
     assert!(text.contains("- acp · demo"), "{text}");
@@ -536,7 +536,7 @@ fn session_slash_shows_effort_when_set() {
     let crate::slots::TuiNode::Markdown { text, .. } = &view.nodes[0] else {
         panic!("/session popup should carry markdown, got {:?}", view.nodes);
     };
-    assert!(text.contains("## session"), "{text}");
+    assert!(!text.contains("## session"), "{text}");
     assert!(text.contains("- effort · max"), "{text}");
     assert!(app.transcript.cells.is_empty(), "no transcript cell for /session");
 

--- a/tests/unit/input__keymap__tests.rs
+++ b/tests/unit/input__keymap__tests.rs
@@ -398,7 +398,9 @@ fn keys_markdown_uses_the_platform_spellings_and_groups_everything() {
         );
     }
     let zh = keys_markdown(true, false);
-    assert!(zh.contains("快捷键"), "zh title missing:\n{zh}");
+    // The popup window border names the dialog; the body starts with the
+    // intro sentence instead of a repeated `## 快捷键` heading.
+    assert!(zh.contains("双用途键"), "zh intro missing:\n{zh}");
     assert!(zh.contains("[空输入时]"), "zh context tag missing:\n{zh}");
     assert!(zh.contains("发送"), "zh send group missing:\n{zh}");
     assert!(


### PR DESCRIPTION
Fixes #85

## What changed

Review/info popups repeated their title: the popup window border already names the dialog, but the markdown body carried the same heading again.

- **`/plan-view`** — the `Plan n/m` counter now lives in the popup window title (`Plan 1/2`); the in-body `## Plan · n/m` heading is gone. The `n/m` counter moves with the plan snapshot, so the title stays current.
- **`/keys`** — dropped the `## 快捷键` / `## keys — shortcut map` heading from the body.
- **`/help`** — dropped `## help` (both zh and en).
- **`/session`** — dropped `## session`.
- **`/status`** — dropped `## status` from the JS `status-view` Client Plugin and the painter-side fallback alike.

## Verification

- Rust: 597 unit tests pass (`cargo test --locked`)
- JS: 207 tests pass (`npm test --prefix npm`)
- `cargo check --locked --tests` clean