### PR TITLE
fix(tui): preserve prompt history navigation at draft boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,13 @@ All notable changes to this project are documented here. The project follows
 
 ### Fixed
 
+- Prompt history now keeps browsing older/newer entries on repeated `↑`/`↓`
+  presses after the first recall. In a non-empty draft, `↑` still moves by
+  visual line until the cursor reaches the top, then stashes the draft and
+  enters history; `↓` restores that draft after the newest history entry.
+- macOS native-package staging now atomically replaces an existing executable,
+  so repeated source-checkout builds do not leave a linked `martty` process
+  killed by a stale Mach-O vnode signature cache.
 - Slash-menu and `@file` black blocks (issue #83): scrolling the command
   candidate list (or the file browser) moved wide (CJK) glyphs and could
   orphan a trailing half-cell on the real screen while both ratatui

--- a/scripts/package-native.mjs
+++ b/scripts/package-native.mjs
@@ -1,6 +1,14 @@
 #!/usr/bin/env node
 
-import { chmodSync, copyFileSync, existsSync, mkdirSync, statSync } from 'node:fs'
+import {
+  chmodSync,
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  renameSync,
+  rmSync,
+  statSync,
+} from 'node:fs'
 import path from 'node:path'
 
 const supported = [
@@ -48,9 +56,18 @@ function stage(values) {
 
   const destinationDir = path.join(vendorRoot, `${platform}-${arch}`)
   const destination = path.join(destinationDir, spec.file)
+  const temporary = `${destination}.tmp-${process.pid}`
   mkdirSync(destinationDir, { recursive: true })
-  copyFileSync(source, destination)
-  if (platform !== 'win32') chmodSync(destination, 0o755)
+  try {
+    copyFileSync(source, temporary)
+    if (platform !== 'win32') chmodSync(temporary, 0o755)
+    // Never overwrite a Mach-O that may already have been executed. macOS
+    // caches its code signature by vnode and can SIGKILL a binary whose
+    // contents changed in place. rename swaps in a fresh inode atomically.
+    renameSync(temporary, destination)
+  } finally {
+    rmSync(temporary, { force: true })
+  }
   process.stdout.write(`${destination}\n`)
 }
 

--- a/scripts/package-native.test.mjs
+++ b/scripts/package-native.test.mjs
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict'
 import { spawnSync } from 'node:child_process'
-import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
+import { mkdtempSync, readFileSync, statSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
 import test from 'node:test'
@@ -43,6 +43,35 @@ test('stages native binaries under npm platform keys', () => {
       'native-binary-fixture',
     )
   }
+})
+
+test('restaging replaces the executable inode instead of overwriting it in place', () => {
+  const root = mkdtempSync(path.join(tmpdir(), 'dsh-tui-restage-'))
+  const source = path.join(root, 'compiled-binary')
+  const vendorRoot = path.join(root, 'vendor')
+  const destination = path.join(vendorRoot, 'darwin-arm64', 'martty')
+  const args = [
+    'stage',
+    '--source', source,
+    '--platform', 'darwin',
+    '--arch', 'arm64',
+    '--vendor-root', vendorRoot,
+  ]
+
+  writeFileSync(source, 'first-native-binary')
+  const first = run(args)
+  assert.equal(first.status, 0, first.stderr)
+  const firstInode = statSync(destination).ino
+
+  writeFileSync(source, 'second-native-binary')
+  const second = run(args)
+  assert.equal(second.status, 0, second.stderr)
+  assert.notEqual(
+    statSync(destination).ino,
+    firstInode,
+    'macOS caches Mach-O signatures by vnode, so an executed binary must be atomically replaced',
+  )
+  assert.equal(readFileSync(destination, 'utf8'), 'second-native-binary')
 })
 
 test('verifies that a release contains every supported platform', () => {

--- a/src/app.rs
+++ b/src/app.rs
@@ -3715,7 +3715,10 @@ impl App {
                 self.begin_agent_navigation();
                 return;
             }
-            let ctx = crate::input::KeyCtx { input_empty: true };
+            let ctx = crate::input::KeyCtx {
+                input_empty: true,
+                history_active: false,
+            };
             if let Some(action) = crate::input::classify(&key, ctx) {
                 match action {
                     Action::Esc
@@ -3881,6 +3884,7 @@ impl App {
 
         let ctx = crate::input::KeyCtx {
             input_empty: self.input.is_empty(),
+            history_active: self.input.hist_pos.is_some(),
         };
         if let Some(action) = crate::input::classify(&key, ctx) {
             self.dispatch(action, ctl);
@@ -4121,7 +4125,13 @@ impl App {
             }
             Action::CursorLeft => self.input.move_left(),
             Action::CursorRight => self.input.move_right(),
-            Action::CursorUp => self.input.move_up(),
+            Action::CursorUp => {
+                let cursor = self.input.cursor_char();
+                self.input.move_up();
+                if self.queue_edit.is_none() && self.input.cursor_char() == cursor {
+                    self.history_prev_from_draft();
+                }
+            }
             Action::CursorDown => self.input.move_down(),
             Action::WordLeft => self.input.word_left(),
             Action::WordRight => self.input.word_right(),
@@ -4317,6 +4327,7 @@ impl App {
                     &key,
                     crate::input::KeyCtx {
                         input_empty: self.input.is_empty(),
+                        history_active: self.input.hist_pos.is_some(),
                     },
                 ),
                 Some(Action::ToggleTheme)

--- a/src/input/keymap.rs
+++ b/src/input/keymap.rs
@@ -72,10 +72,12 @@ pub enum Action {
 }
 
 /// The composer facts the mapping depends on (dual-use keys: `home`/`^u`
-/// scroll when the draft is empty, edit when it isn't).
+/// scroll when the draft is empty, edit when it isn't; arrows keep browsing
+/// after a history entry makes the draft non-empty).
 #[derive(Debug, Clone, Copy, Default)]
 pub struct KeyCtx {
     pub input_empty: bool,
+    pub history_active: bool,
 }
 
 /// Classify one key event. `None` = unbound (ignored — unrecognized
@@ -180,8 +182,8 @@ pub fn classify(key: &KeyEvent, ctx: KeyCtx) -> Option<Action> {
         // Word hops: ⌥-arrows on macOS · ctrl-arrows on linux/windows.
         KeyCode::Left if alt || ctrl => WordLeft,
         KeyCode::Right if alt || ctrl => WordRight,
-        KeyCode::Up if ctx.input_empty => HistoryPrev,
-        KeyCode::Down if ctx.input_empty => HistoryNext,
+        KeyCode::Up if ctx.input_empty || ctx.history_active => HistoryPrev,
+        KeyCode::Down if ctx.input_empty || ctx.history_active => HistoryNext,
         KeyCode::Up => CursorUp,
         KeyCode::Down => CursorDown,
         KeyCode::Left => CursorLeft,

--- a/tests/unit/acp_term__tests.rs
+++ b/tests/unit/acp_term__tests.rs
@@ -1,5 +1,13 @@
 use super::*;
 
+fn true_command() -> &'static str {
+    if cfg!(target_os = "macos") {
+        "/usr/bin/true"
+    } else {
+        "/bin/true"
+    }
+}
+
 #[tokio::test]
 async fn piped_create_captures_output_and_exit() {
     let broker = TerminalBroker::new(std::env::temp_dir());
@@ -35,7 +43,7 @@ async fn wait_after_the_exit_notification_already_fired_returns() {
     // before the status re-check).
     let broker = TerminalBroker::new(std::env::temp_dir());
     let id = broker
-        .create("/bin/true", &[], None, &[], None)
+        .create(true_command(), &[], None, &[], None)
         .expect("spawn true");
     // Give the waiter thread time to reap and fire notify_waiters() with no
     // listeners registered.
@@ -51,7 +59,7 @@ async fn wait_after_the_exit_notification_already_fired_returns() {
 async fn concurrent_waiters_all_settle() {
     let broker = std::sync::Arc::new(TerminalBroker::new(std::env::temp_dir()));
     let id = broker
-        .create("/bin/true", &[], None, &[], None)
+        .create(true_command(), &[], None, &[], None)
         .expect("spawn true");
     let mut handles = Vec::new();
     for _ in 0..4 {
@@ -70,4 +78,3 @@ async fn concurrent_waiters_all_settle() {
     }
     broker.release(&id);
 }
-

--- a/tests/unit/app__mode_tests.rs
+++ b/tests/unit/app__mode_tests.rs
@@ -2982,6 +2982,61 @@ fn tab_completes_a_slash_argument_without_running_it() {
 }
 
 #[test]
+fn repeated_up_browses_older_history_after_the_first_recall() {
+    let (mut app, ctl, _rx) = test_app();
+    app.input
+        .history
+        .extend(["first prompt".into(), "second prompt".into()]);
+
+    app.handle_key(KeyEvent::new(KeyCode::Up, KeyModifiers::NONE), &ctl);
+    assert_eq!(app.input.buf(), "second prompt");
+
+    app.handle_key(KeyEvent::new(KeyCode::Up, KeyModifiers::NONE), &ctl);
+    assert_eq!(app.input.buf(), "first prompt");
+}
+
+#[test]
+fn down_leaves_history_and_restores_the_empty_prompt() {
+    let (mut app, ctl, _rx) = test_app();
+    app.input.history.push("previous prompt".into());
+
+    app.handle_key(KeyEvent::new(KeyCode::Up, KeyModifiers::NONE), &ctl);
+    assert_eq!(app.input.buf(), "previous prompt");
+
+    app.handle_key(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE), &ctl);
+    assert!(app.input.is_empty());
+    assert!(app.input.hist_pos.is_none());
+}
+
+#[test]
+fn up_at_the_top_of_a_multiline_draft_browses_history_and_down_restores_it() {
+    let (mut app, ctl, _rx) = test_app();
+    app.input.history.push("previous prompt".into());
+    app.input.set("hi\nfdff".into());
+    app.input.set_cursor_char(2);
+
+    app.handle_key(KeyEvent::new(KeyCode::Up, KeyModifiers::NONE), &ctl);
+    assert_eq!(app.input.buf(), "previous prompt");
+    assert_eq!(app.input.hist_pos, Some(0));
+
+    app.handle_key(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE), &ctl);
+    assert_eq!(app.input.buf(), "hi\nfdff");
+    assert!(app.input.hist_pos.is_none());
+}
+
+#[test]
+fn up_inside_a_multiline_draft_moves_the_cursor_before_browsing_history() {
+    let (mut app, ctl, _rx) = test_app();
+    app.input.history.push("previous prompt".into());
+    app.input.set("top\nbottom".into());
+
+    app.handle_key(KeyEvent::new(KeyCode::Up, KeyModifiers::NONE), &ctl);
+    assert_eq!(app.input.buf(), "top\nbottom");
+    assert_eq!(app.input.cursor_char(), 3);
+    assert!(app.input.hist_pos.is_none());
+}
+
+#[test]
 fn escape_dismisses_slash_completion_then_arrows_browse_history() {
     let (mut app, ctl, _rx) = test_app();
     app.input.history.push("previous prompt".into());

--- a/tests/unit/input__keymap__tests.rs
+++ b/tests/unit/input__keymap__tests.rs
@@ -10,11 +10,24 @@ const ALT: KeyModifiers = KeyModifiers::ALT;
 const SUPER: KeyModifiers = KeyModifiers::SUPER;
 
 fn empty() -> KeyCtx {
-    KeyCtx { input_empty: true }
+    KeyCtx {
+        input_empty: true,
+        history_active: false,
+    }
 }
 
 fn typing() -> KeyCtx {
-    KeyCtx { input_empty: false }
+    KeyCtx {
+        input_empty: false,
+        history_active: false,
+    }
+}
+
+fn browsing_history() -> KeyCtx {
+    KeyCtx {
+        input_empty: false,
+        history_active: true,
+    }
 }
 
 #[test]
@@ -122,7 +135,7 @@ fn agent_cycle_is_ctrl_shift_a_on_every_platform() {
 }
 
 #[test]
-fn arrows_move_inside_a_draft_and_only_browse_history_when_it_is_empty() {
+fn arrows_move_inside_a_draft_and_keep_browsing_active_history() {
     assert_eq!(
         classify(&key(KeyCode::Up, NONE), typing()),
         Some(Action::CursorUp)
@@ -137,6 +150,14 @@ fn arrows_move_inside_a_draft_and_only_browse_history_when_it_is_empty() {
     );
     assert_eq!(
         classify(&key(KeyCode::Down, NONE), empty()),
+        Some(Action::HistoryNext)
+    );
+    assert_eq!(
+        classify(&key(KeyCode::Up, NONE), browsing_history()),
+        Some(Action::HistoryPrev)
+    );
+    assert_eq!(
+        classify(&key(KeyCode::Down, NONE), browsing_history()),
         Some(Action::HistoryNext)
     );
 }
@@ -303,6 +324,7 @@ fn displayed_chords_resolve_to_their_action() {
                 &KeyEvent::new(*code, *mods),
                 KeyCtx {
                     input_empty: *empty,
+                    history_active: false,
                 },
             );
             assert_eq!(


### PR DESCRIPTION
## Summary

- keep repeated Up and Down presses in prompt-history mode after the recalled text makes the composer non-empty
- move within multiline and soft-wrapped drafts first, then stash the draft and enter history only when Up reaches the top boundary; Down restores the stashed draft
- keep queue editing isolated from prompt history
- atomically replace staged native executables so repeated macOS source-checkout builds do not reuse a stale Mach-O vnode signature cache
- use the platform-correct true executable in ACP terminal tests

## Verification

- cargo test --locked: 606 passed
- cargo check --locked --tests: passed
- npm test --prefix npm: 212 passed
- direct linked martty --demo PTY: second-line Up moved to the first line, top-boundary Up recalled history, repeated Up reached older history, and Down restored the multiline draft
- release and npm/vendor binaries have identical SHA-256 hashes; martty --version reports 0.2.29