### PR TITLE
fix: settle ACP status from prompt responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,13 @@ All notable changes to this project are documented here. The project follows
 
 ### Fixed
 
+- `acpSessionStatus` now treats each standard ACP `session/prompt` response
+  (success or error) as that request's terminal turn signal, returning to
+  `idle` after every pending prompt and concurrent steer has settled. This
+  keeps generic ACP V1 agents from leaving `/status` stuck on `starting` or
+  `running` when they do not emit Martty's optional `session.status`
+  extension; cancellation still waits for the original prompt response
+  required by ACP V1 (issue #25).
 - Prompt history now keeps browsing older/newer entries on repeated `↑`/`↓`
   presses after the first recall. In a non-empty draft, `↑` still moves by
   visual line until the cursor reaches the top, then stashes the draft and

--- a/docs/plugins.en.md
+++ b/docs/plugins.en.md
@@ -31,11 +31,12 @@ default consumer: it contributes the compact readout to
 ## Open: `acpSessionStatus`
 
 `acpSessionStatus` folds the non-statistics facts `/status` needs from standard
-ACP initialize / authenticate / session / session/update / session.event
-traffic: state (idle/starting/running), connection, server, authenticate state,
-session binding, model, effort, permission, plan, and agent preset. It exposes
-`current()` and `subscribe(listener)` and never accumulates tokens or timings —
-statistics have exactly one source, `acpSessionStats`.
+ACP initialize / authenticate / session / `session/prompt` response /
+`session/update` traffic, plus the optional Martty `session.status` /
+`session.event` extensions: state (idle/starting/running), connection, server,
+authenticate state, session binding, model, effort, permission, plan, and agent
+preset. It exposes `current()` and `subscribe(listener)` and never accumulates
+tokens or timings — statistics have exactly one source, `acpSessionStats`.
 
 The builtin `status-view` Client Plugin is its default consumer: it registers
 the local `/status` command and opens a markdown status view with

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -86,11 +86,13 @@ resume usage 更新折叠当前 Session 的 token、cache、turn、step、LLM、
 
 ## 当前可调用：`acpSessionStatus`
 
-`acpSessionStatus` 从标准 ACP initialize / authenticate / session / session/update /
-session.event 流量折叠 `/status` 需要的非统计运行状态：state（idle/starting/
-running）、connection、server、auth、session 绑定、model、effort、permission、
-plan 与 agent preset，提供 `current()` 和 `subscribe(listener)`。它**不**累计任何
-token 或耗时——统计只有 `acpSessionStats` 这一套口径。
+`acpSessionStatus` 从标准 ACP initialize / authenticate / session /
+`session/prompt` response / `session/update` 流量，以及可选的 Martty
+`session.status` / `session.event` 扩展，折叠 `/status` 需要的非统计运行状态：
+state（idle/starting/running）、connection、server、auth、session 绑定、model、
+effort、permission、plan 与 agent preset，提供 `current()` 和
+`subscribe(listener)`。它**不**累计任何 token 或耗时——统计只有
+`acpSessionStats` 这一套口径。
 
 内置 `status-view` Client Plugin 正是普通消费者：它注册本地 `/status` 命令，用
 `tuiOverlay.openView()` 打开一个 markdown 状态视图——运行状态事实取自

--- a/npm/lib/acp-session-status.js
+++ b/npm/lib/acp-session-status.js
@@ -16,9 +16,15 @@ export const inject = ['acpClientEvents', 'acpSessionConfig']
 const AUTH_REQUIRED_CODE = -32000
 const SETUP_METHODS = new Set(['session/new', 'session/load'])
 const RUNNING_UPDATE_TYPES = new Set([
+  'user_message_chunk',
   'agent_message_chunk',
   'agent_thought_chunk',
   'tool_call',
+  'tool_call_update',
+  'plan',
+  'plan_update',
+  'plan_removed',
+  'usage_update',
 ])
 
 class AcpSessionStatusService extends Service {
@@ -58,6 +64,7 @@ export function installAcpSessionStatus(ctx, options = {}) {
   let initializeId
   let pendingAuthenticate = new Set()
   const pendingSetup = new Map()
+  const pendingPrompts = new Map()
   let permissionPreset
   let sandboxMode
 
@@ -108,9 +115,15 @@ export function installAcpSessionStatus(ctx, options = {}) {
       )
       return
     }
-    if (message.method === 'session/prompt' && value.state === 'idle') {
-      value.state = 'starting'
-      publish()
+    if (message.method === 'session/prompt' && message.id !== undefined) {
+      pendingPrompts.set(
+        message.id,
+        readString(message.params, 'sessionId', 'session_id'),
+      )
+      if (value.state === 'idle') {
+        value.state = 'starting'
+        publish()
+      }
     }
   }
 
@@ -155,6 +168,21 @@ export function installAcpSessionStatus(ctx, options = {}) {
       publish()
       return
     }
+    if (response(message) && pendingPrompts.has(message.id)) {
+      pendingPrompts.delete(message.id)
+      let changed = false
+      if (message.error !== undefined && isAuthRequired(message.error)
+        && value.auth.status !== 'needs sign-in') {
+        value.auth.status = 'needs sign-in'
+        changed = true
+      }
+      if (pendingPrompts.size === 0 && value.state !== 'idle') {
+        value.state = 'idle'
+        changed = true
+      }
+      if (changed) publish()
+      return
+    }
     if (message.error !== undefined && isAuthRequired(message.error)) {
       value.auth.status = 'needs sign-in'
       publish()
@@ -163,7 +191,7 @@ export function installAcpSessionStatus(ctx, options = {}) {
 
     if (message.method === 'session.status' && object(message.params)) {
       const status = readString(message.params, 'status')
-      if (status === 'running' || status === 'idle') {
+      if (status === 'running' || (status === 'idle' && pendingPrompts.size === 0)) {
         value.state = status
         publish()
       }
@@ -200,12 +228,22 @@ export function installAcpSessionStatus(ctx, options = {}) {
       return
     }
     if (message.method !== 'session/update' || !object(message.params)) return
+    const sessionId = readString(message.params, 'sessionId', 'session_id')
     const update = object(message.params.update) ? message.params.update : undefined
     const type = readString(update, 'sessionUpdate', 'session_update')
-    if (value.state === 'starting' && RUNNING_UPDATE_TYPES.has(type)) {
+    if (value.state !== 'running' && hasPendingPrompt(sessionId)
+      && RUNNING_UPDATE_TYPES.has(type)) {
       value.state = 'running'
       publish()
     }
+  }
+
+  function hasPendingPrompt(sessionId) {
+    if (sessionId === undefined) return false
+    for (const pendingSessionId of pendingPrompts.values()) {
+      if (pendingSessionId === sessionId) return true
+    }
+    return false
   }
 
   function onConfigSnapshot(snapshot) {
@@ -269,6 +307,11 @@ function readString(value, ...keys) {
 
 function object(value) {
   return value !== null && typeof value === 'object' && !Array.isArray(value)
+}
+
+function response(message) {
+  return !Object.hasOwn(message, 'method')
+    && (Object.hasOwn(message, 'result') || Object.hasOwn(message, 'error'))
 }
 
 export function apply(ctx, options = {}) {

--- a/npm/lib/inspect.js
+++ b/npm/lib/inspect.js
@@ -683,7 +683,9 @@ export function statusInspectProvider(acpSessionStatus) {
             call: 'ctx.acpSessionStatus.subscribe((snapshot) => { ... })',
             returns: { type: 'function', role: 'dispose', idempotent: true },
           },
-          transport: 'standard ACP initialize, authenticate, session and session/update messages',
+          transport: 'standard ACP initialize, authenticate, session, session/prompt response, '
+            + 'and session/update messages, plus optional Martty session.status/session.event '
+            + 'extensions',
         },
         referencedTypes: ['SessionStatusSnapshot'],
       }

--- a/scripts/acp-session-status.test.mjs
+++ b/scripts/acp-session-status.test.mjs
@@ -3,6 +3,18 @@ import test from 'node:test'
 
 import { installAcpSessionStatus } from '../npm/lib/acp-session-status.js'
 
+const PROGRESS_UPDATE_TYPES = [
+  'user_message_chunk',
+  'agent_message_chunk',
+  'agent_thought_chunk',
+  'tool_call',
+  'tool_call_update',
+  'plan',
+  'plan_update',
+  'plan_removed',
+  'usage_update',
+]
+
 function makeCtx() {
   return {
     effect(setup) {
@@ -90,14 +102,16 @@ test('the status service folds connection, server, auth, and session facts', () 
   assert.equal(service.current().auth.status, 'configured')
 })
 
-test('the status service folds run state and session.event mode facts', () => {
+test('the status service keeps the session.status run-state extension', () => {
   const sessionConfig = makeSessionConfig()
   const service = installAcpSessionStatus(makeCtx(), {
     events: { register: () => () => {} },
     sessionConfig,
   })
 
-  service.observeClient({ jsonrpc: '2.0', id: 1, method: 'session/prompt', params: {} })
+  service.observeClient({
+    jsonrpc: '2.0', id: 1, method: 'session/prompt', params: { sessionId: 's-1' },
+  })
   assert.equal(service.current().state, 'starting')
   service.observeAgent({
     jsonrpc: '2.0',
@@ -114,7 +128,198 @@ test('the status service folds run state and session.event mode facts', () => {
     method: 'session.status',
     params: { sessionId: 's-1', status: 'idle' },
   })
+  assert.equal(service.current().state, 'running', 'idle waits for the prompt response')
+
+  service.observeAgent({
+    jsonrpc: '2.0',
+    method: 'session.status',
+    params: { sessionId: 's-1', status: 'running' },
+  })
+  assert.equal(service.current().state, 'running')
+
+  service.observeAgent({ jsonrpc: '2.0', id: 1, result: { stopReason: 'end_turn' } })
   assert.equal(service.current().state, 'idle')
+
+  service.observeAgent({
+    jsonrpc: '2.0',
+    method: 'session.status',
+    params: { sessionId: 's-1', status: 'running' },
+  })
+  assert.equal(service.current().state, 'running')
+  service.observeAgent({
+    jsonrpc: '2.0',
+    method: 'session.status',
+    params: { sessionId: 's-1', status: 'idle' },
+  })
+  assert.equal(service.current().state, 'idle')
+})
+
+test('prompt responses and errors settle standard ACP run state', () => {
+  const service = installAcpSessionStatus(makeCtx(), {
+    events: { register: () => () => {} },
+    sessionConfig: makeSessionConfig(),
+  })
+
+  service.observeClient({
+    jsonrpc: '2.0', id: 'prompt-1', method: 'session/prompt', params: { sessionId: 's-1' },
+  })
+  assert.equal(service.current().state, 'starting')
+
+  service.observeAgent({
+    jsonrpc: '2.0',
+    method: 'session/update',
+    params: {
+      sessionId: 'another-session',
+      update: { sessionUpdate: 'agent_message_chunk', content: { type: 'text', text: 'no' } },
+    },
+  })
+  assert.equal(service.current().state, 'starting', 'another session is unrelated')
+
+  service.observeAgent({
+    jsonrpc: '2.0',
+    method: 'session/update',
+    params: {
+      sessionId: 's-1',
+      update: { sessionUpdate: 'available_commands_update', availableCommands: [] },
+    },
+  })
+  assert.equal(service.current().state, 'starting', 'administrative updates are not progress')
+
+  service.observeAgent({
+    jsonrpc: '2.0',
+    method: 'session/update',
+    params: {
+      sessionId: 's-1',
+      update: { sessionUpdate: 'plan', entries: [] },
+    },
+  })
+  assert.equal(service.current().state, 'running', 'the first related progress update starts the run')
+
+  service.observeAgent({ jsonrpc: '2.0', id: 'prompt-1', result: { stopReason: 'end_turn' } })
+  assert.equal(service.current().state, 'idle')
+
+  service.observeClient({
+    jsonrpc: '2.0', id: 'prompt-2', method: 'session/prompt', params: { sessionId: 's-1' },
+  })
+  assert.equal(service.current().state, 'starting')
+  service.observeAgent({
+    jsonrpc: '2.0', id: 'prompt-2', error: { code: -32603, message: 'agent failed' },
+  })
+  assert.equal(service.current().state, 'idle')
+
+  service.observeClient({
+    jsonrpc: '2.0', id: 'prompt-auth', method: 'session/prompt', params: { sessionId: 's-1' },
+  })
+  service.observeAgent({
+    jsonrpc: '2.0', id: 'prompt-auth', error: { code: -32000, message: 'auth required' },
+  })
+  assert.equal(service.current().state, 'idle')
+  assert.equal(service.current().auth.status, 'needs sign-in')
+})
+
+test('standard prompt progress updates promote starting to running', () => {
+  for (const sessionUpdate of PROGRESS_UPDATE_TYPES) {
+    const service = installAcpSessionStatus(makeCtx(), {
+      events: { register: () => () => {} },
+      sessionConfig: makeSessionConfig(),
+    })
+    service.observeClient({
+      jsonrpc: '2.0',
+      id: `prompt-${sessionUpdate}`,
+      method: 'session/prompt',
+      params: { sessionId: 's-1' },
+    })
+    service.observeAgent({
+      jsonrpc: '2.0',
+      method: 'session/update',
+      params: { sessionId: 's-1', update: { sessionUpdate } },
+    })
+    assert.equal(service.current().state, 'running', sessionUpdate)
+  }
+})
+
+test('cancel and concurrent steer prompts stay active until every response settles', () => {
+  const service = installAcpSessionStatus(makeCtx(), {
+    events: { register: () => () => {} },
+    sessionConfig: makeSessionConfig(),
+  })
+
+  service.observeClient({
+    jsonrpc: '2.0', id: 7, method: 'session/prompt', params: { sessionId: 's-1' },
+  })
+  service.observeClient({
+    jsonrpc: '2.0', id: '7', method: 'session/prompt', params: { sessionId: 's-1' },
+  })
+  assert.equal(service.current().state, 'starting')
+
+  service.observeClient({
+    jsonrpc: '2.0', method: 'session/cancel', params: { sessionId: 's-1' },
+  })
+  assert.equal(service.current().state, 'starting', 'cancel is a notification, not completion')
+
+  service.observeAgent({
+    jsonrpc: '2.0',
+    method: 'session/update',
+    params: { sessionId: 's-1', update: { sessionUpdate: 'agent_thought_chunk' } },
+  })
+  assert.equal(service.current().state, 'running', 'post-cancel progress remains observable')
+
+  service.observeAgent({ jsonrpc: '2.0', id: '7', result: { stopReason: 'cancelled' } })
+  assert.equal(service.current().state, 'running', 'the original prompt is still pending')
+
+  service.observeAgent({
+    jsonrpc: '2.0',
+    method: 'session.status',
+    params: { sessionId: 's-1', status: 'idle' },
+  })
+  assert.equal(service.current().state, 'running', 'the extension cannot hide a pending prompt')
+
+  service.observeAgent({ jsonrpc: '2.0', id: 999, result: { stopReason: 'end_turn' } })
+  assert.equal(service.current().state, 'running', 'an unrelated response cannot settle the run')
+
+  service.observeAgent({ jsonrpc: '2.0', id: 7, result: { stopReason: 'cancelled' } })
+  assert.equal(service.current().state, 'idle')
+})
+
+test('only response envelopes settle prompt request ids', () => {
+  const service = installAcpSessionStatus(makeCtx(), {
+    events: { register: () => () => {} },
+    sessionConfig: makeSessionConfig(),
+  })
+
+  service.observeClient({
+    jsonrpc: '2.0', method: 'session/prompt', params: { sessionId: 's-1' },
+  })
+  assert.equal(service.current().state, 'idle', 'a notification has no response to await')
+
+  service.observeClient({
+    jsonrpc: '2.0', id: 0, method: 'session/prompt', params: { sessionId: 's-1' },
+  })
+  assert.equal(service.current().state, 'starting')
+
+  service.observeAgent({
+    jsonrpc: '2.0', id: 0, method: 'session/request_permission', params: {},
+  })
+  service.observeAgent({ jsonrpc: '2.0', id: 0 })
+  assert.equal(service.current().state, 'starting', 'agent requests and malformed envelopes do not settle')
+
+  service.observeAgent({ jsonrpc: '2.0', id: 0, result: 'non-object result' })
+  assert.equal(service.current().state, 'idle', 'the result payload shape does not change the boundary')
+
+  service.observeClient({
+    jsonrpc: '2.0', id: null, method: 'session/prompt', params: { sessionId: 's-1' },
+  })
+  assert.equal(service.current().state, 'starting')
+  service.observeAgent({ jsonrpc: '2.0', id: null, result: null })
+  assert.equal(service.current().state, 'idle')
+})
+
+test('the status service folds session.event mode facts', () => {
+  const sessionConfig = makeSessionConfig()
+  const service = installAcpSessionStatus(makeCtx(), {
+    events: { register: () => () => {} },
+    sessionConfig,
+  })
 
   service.observeAgent({
     jsonrpc: '2.0',


### PR DESCRIPTION
## Summary

- track each ID-bearing `session/prompt` request and correlate prompt progress to its ACP session
- promote `starting` to `running` only for matching-session turn-progress updates, including the stable ACP V1 variants and Martty's existing incremental plan updates
- settle pending work only from a genuine matching JSON-RPC response envelope; success, generic errors, and auth-required errors all release the request
- stay non-idle until every pending prompt or steer has settled, including after `session/cancel`
- preserve the optional Martty `session.status` extension while preventing an extension `idle` update from hiding standard ACP work that is still pending
- document the standard ACP response path separately from Martty's optional `session.status` / `session.event` extensions

## Why

ACP V1 ends a prompt turn with the response to the original `session/prompt` request. A generic ACP agent is not required to emit Martty's `session.status: idle` extension, so the current projection can remain stuck at `starting` or `running` after the turn has already completed.

The response-ID set also preserves Martty's in-flight steer behavior: numeric and string IDs remain distinct, unrelated responses cannot settle the run, cancellation waits for the original response, and the state returns to `idle` only after the final pending response.

Closes #25.

## Verification

- focused status and inspect suites: 49/49 passed
- independent targeted review suites: 58/58 passed
- JavaScript syntax and diff checks passed
- `cargo check --locked --tests` passed on Windows with only the four existing warnings
- Linux npm pretest: 4/4 passed
- Linux npm main suite on `/mnt/c`: 212/213 passed; the sole packaging test hit its 30-second suite timeout and then passed alone in 7.9 seconds on the same commit

The repository's Ubuntu PR job remains the authoritative full `cargo test --locked` gate.