### PR TITLE
chore(build): devlocal profile for fast local installs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ All notable changes to this project are documented here. The project follows
 
 ### Added
 
+- Fast local build profile `devlocal` (debug codegen, incremental) for
+  `scripts/devlocalinstall.sh`: the local install/build loop no longer
+  pays the fat-LTO release build (`DSH_TUI_CARGO_PROFILE=release`
+  restores the shipped config). The npm bundles keep the fat-LTO release
+  config untouched.
+
 - Standalone harness registry and discovery: `martty harness list` shows saved
   entries, the bundled DSH runtime, and executable `*-acp` / `*_acp` commands
   on `PATH`; `harness add` saves a named command and repeated arguments, while

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,3 +33,12 @@ image = { version = "0.25", default-features = false, features = ["png"] }
 [profile.release]
 lto = true
 strip = true
+
+# Fast local build profile for `scripts/devlocalinstall.sh` (and local
+# iterating): plain debug codegen — no optimizations, incremental — the
+# fastest turnaround for build/test loops; the shipped npm packages keep
+# [profile.release] (fat LTO, stripped) untouched. If the debug binary runs
+# too slow for a big workspace, DSH_TUI_CARGO_PROFILE=release falls back to
+# the shipped config.
+[profile.devlocal]
+inherits = "dev"

--- a/README.en.md
+++ b/README.en.md
@@ -167,6 +167,11 @@ From this checkout (need `cargo build --release` or `scripts/build-npm.sh`, bina
 MARTTY_BIN=$(pwd)/target/release/martty martty --agent dsh-acp
 ```
 
+For local iterating, `scripts/devlocalinstall.sh` builds with the fast
+`devlocal` Cargo profile (debug codegen, incremental — the quickest
+turnaround) and stages the binary into the running `dsh --profile <name>`
+setup; `DSH_TUI_CARGO_PROFILE=release` restores the shipped config.
+
 Third-party capabilities are ordinary Cordis plugins on the client tree: they
 declare the services they need, register contributions in `apply`, and retract
 them with the owning fiber. Themes, the root right rail, local commands,

--- a/scripts/devlocalinstall.sh
+++ b/scripts/devlocalinstall.sh
@@ -7,11 +7,16 @@ cd "$(dirname "${BASH_SOURCE[0]}")/.."
 # primary dev profile). Must match the `dsh --profile <name>` you run.
 PROFILE="${1:-${DSH_TUI_PROFILE:-martty}}"
 
-# 1. Build the release binary first so the installed copy always reflects
-#    the current source (cargo build --release --locked; lto is slow).
-BIN="target/release/martty"
-echo "building $BIN (cargo build --release --locked, lto is slow)…" >&2
-cargo build --release --locked
+# Cargo profile for the local build: devlocal (debug codegen) by default —
+# the fastest turnaround for build/test loops; release matches the shipped
+# npm bundles when the debug binary is too slow. The names map 1:1 to the
+# [profile.*] sections in Cargo.toml.
+CARGO_PROFILE="${DSH_TUI_CARGO_PROFILE:-devlocal}"
+
+# 1. Build first so the installed copy always reflects the current source.
+BIN="target/${CARGO_PROFILE}/martty"
+echo "building $BIN (cargo build --profile $CARGO_PROFILE --locked)…" >&2
+cargo build --profile "$CARGO_PROFILE" --locked
 
 # 2. Resolve exactly the binary `dsh --profile $PROFILE` runs — no hardcoded
 #    package names or home dirs:


### PR DESCRIPTION
## 背景

`scripts/devlocalinstall.sh` 之前固定 `cargo build --release`，fat-LTO 链接让每次本机安装/迭代都很慢。

## 改动

- **`Cargo.toml`**：新增 `[profile.devlocal]`（`inherits = "dev"`，debug codegen + 增量编译），发布链路 `[profile.release]`（fat LTO + strip）不变
- **`scripts/devlocalinstall.sh`**：默认 `cargo build --profile devlocal --locked`（二进制 `target/devlocal/martty`）；`DSH_TUI_CARGO_PROFILE=release` 可切回正式配置；安装/替换逻辑不变
- **文档**：`README.en.md`、`CHANGELOG.md` 同步

## 实测（本机）

| 场景 | 耗时 |
|---|---|
| devlocal 首次全量 | 2m26s |
| 二次构建（增量） | 0.7s |

对比：release fat-LTO 全量构建（分钟级 + 慢链接）。

## 说明

- 仅影响本机开发流程；npm 发布流水线仍用 `[profile.release]`（fat LTO）构建，产物不变