### PR TITLE
fix: resume ACP sessions without history replay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,11 @@ All notable changes to this project are documented here. The project follows
 
 ### Fixed
 
+- `/resume` now uses ACP `session/resume` when the agent advertises it, so long
+  sessions can continue without replaying their full transcript into the TUI.
+  Agents that only support the legacy `session/load` path keep working, and a
+  rejected resume request falls back to load when that capability is available.
+
 - `acpSessionStatus` now treats each standard ACP `session/prompt` response
   (success or error) as that request's terminal turn signal, returning to
   `idle` after every pending prompt and concurrent steer has settled. This

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -523,7 +523,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-harness-tui"
-version = "0.2.30"
+version = "0.2.31"
 dependencies = [
  "agent-client-protocol",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deepseek-harness-tui"
-version = "0.2.30"
+version = "0.2.31"
 edition = "2021"
 description = "Terminal-native ACP client UI with a Cordis client plugin tree"
 license = "MIT"

--- a/npm/package-lock.json
+++ b/npm/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@openma/deepseek-harness-acp": "0.4.26"
+        "@openma/deepseek-harness-acp": "0.4.27"
       },
       "bin": {
         "dsh-tui": "bin/martty.js",
@@ -5270,9 +5270,9 @@
       }
     },
     "node_modules/@openma/deepseek-harness-acp": {
-      "version": "0.4.26",
-      "resolved": "https://registry.npmjs.org/@openma/deepseek-harness-acp/-/deepseek-harness-acp-0.4.26.tgz",
-      "integrity": "sha512-fke1vS505m5ydlVAxml+OIyIr6O+kwjm3JsOsQXMfXIP41m0fExEO74VJ0rnJ3K1R1tD7bgMaun/O7d1iZVu1A==",
+      "version": "0.4.27",
+      "resolved": "https://registry.npmjs.org/@openma/deepseek-harness-acp/-/deepseek-harness-acp-0.4.27.tgz",
+      "integrity": "sha512-O3rQjdZVtqFzHMoCVziwZSTxL+dWFtCBA4bBSA+64puZDiW9GRJ4efmEjVjYbZZ4JncipAWwGfMiajvE99WTzQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@agentclientprotocol/sdk": "1.4.0",

--- a/npm/package-lock.json
+++ b/npm/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@openma/deepseek-harness-tui",
-  "version": "0.2.30",
+  "version": "0.2.31",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openma/deepseek-harness-tui",
-      "version": "0.2.30",
+      "version": "0.2.31",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/cordis": "^4.0.1",

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openma/deepseek-harness-tui",
-  "version": "0.2.30",
+  "version": "0.2.31",
   "description": "Terminal-native ACP client UI; Cordis client tree, any ACP agent",
   "license": "MIT",
   "repository": {

--- a/npm/package.json
+++ b/npm/package.json
@@ -75,7 +75,7 @@
   },
   "dependencies": {
     "@deepseek-ai/cordis": "^4.0.1",
-    "@openma/deepseek-harness-acp": "0.4.26"
+    "@openma/deepseek-harness-acp": "0.4.27"
   },
   "devDependencies": {
     "@deepseek-ai/dsh": "0.1.1-rc.2"

--- a/src/acp.rs
+++ b/src/acp.rs
@@ -1,6 +1,6 @@
 //! Official ACP client (`agent-client-protocol` 2.0).
 //!
-//! Speaks initialize / authenticate / session/new / session/load /
+//! Speaks initialize / authenticate / session/new / session/resume / session/load /
 //! session/list / prompt / cancel / set_config_option / set_mode.
 //! Transcript paint comes from `session/update`. Negotiated Cordis TUI
 //! compositor state arrives as `_dsh/cordis/tui/*` extension notifications.
@@ -22,9 +22,10 @@ use agent_client_protocol::schema::v1::{
     KillTerminalResponse, ListSessionsRequest, LoadSessionRequest, NewSessionRequest,
     PermissionOptionKind, PromptRequest, ReadTextFileRequest, ReadTextFileResponse,
     ReleaseTerminalRequest, ReleaseTerminalResponse, RequestPermissionOutcome,
-    RequestPermissionRequest, RequestPermissionResponse, ResourceLink, SelectedPermissionOutcome,
-    SessionConfigOptionValue, SessionConfigOptionsCapabilities, SessionId, SessionNotification,
-    SetSessionConfigOptionRequest, SetSessionModeRequest, TerminalOutputRequest,
+    RequestPermissionRequest, RequestPermissionResponse, ResourceLink, ResumeSessionRequest,
+    SelectedPermissionOutcome, SessionConfigOptionValue, SessionConfigOptionsCapabilities,
+    SessionId, SessionNotification, SetSessionConfigOptionRequest, SetSessionModeRequest,
+    TerminalOutputRequest,
     TerminalOutputResponse, WaitForTerminalExitRequest, WaitForTerminalExitResponse,
     WriteTextFileRequest, WriteTextFileResponse,
 };
@@ -611,6 +612,30 @@ fn load_session_supported(init: &Value) -> bool {
         .and_then(|caps| caps.get("loadSession").or_else(|| caps.get("load_session")))
         .and_then(Value::as_bool)
         == Some(true)
+}
+
+fn resume_session_supported(init: &Value) -> bool {
+    let resume = init
+        .get("agentCapabilities")
+        .or_else(|| init.get("agent_capabilities"))
+        .and_then(|caps| {
+            caps.get("sessionCapabilities")
+                .or_else(|| caps.get("session_capabilities"))
+        })
+        .and_then(|caps| caps.get("resume"));
+    matches!(resume, Some(Value::Object(_)) | Some(Value::Bool(true)))
+}
+
+fn list_session_supported(init: &Value) -> bool {
+    let list = init
+        .get("agentCapabilities")
+        .or_else(|| init.get("agent_capabilities"))
+        .and_then(|caps| {
+            caps.get("sessionCapabilities")
+                .or_else(|| caps.get("session_capabilities"))
+        })
+        .and_then(|caps| caps.get("list"));
+    matches!(list, Some(Value::Object(_)) | Some(Value::Bool(true)))
 }
 
 fn no_session() -> AcpError {
@@ -1409,7 +1434,15 @@ where
                 }
                 let load_session = init.agent_capabilities.load_session
                     || load_session_supported(&init_value);
-                let _ = bus.send(AppEvent::Ctl(CtlEvent::AgentCaps { load_session }));
+                let resume_session = resume_session_supported(&init_value);
+                // Before sessionCapabilities.list existed, Martty-compatible agents paired
+                // session/list with the top-level loadSession flag. Keep that legacy route.
+                let list_session = list_session_supported(&init_value) || load_session;
+                let _ = bus.send(AppEvent::Ctl(CtlEvent::AgentCaps {
+                    load_session,
+                    list_session,
+                    resume_session,
+                }));
                 let auth_raw = init_value
                     .get("authMethods")
                     .cloned()
@@ -2227,10 +2260,11 @@ where
                             }
                         }
                         Cmd::ListSessions { prefix } => {
-                            if !load_session {
+                            if !list_session {
                                 let _ = bus.send(AppEvent::Ctl(CtlEvent::SessionListUnavailable {
                                     prefix,
-                                    error: "agent did not advertise loadSession".into(),
+                                    error: "agent did not advertise sessionCapabilities.list"
+                                        .into(),
                                 }));
                                 continue;
                             }
@@ -2270,26 +2304,70 @@ where
                                 }
                             }
                         }
-                        Cmd::LoadSession { session_id: id } => {
+                        Cmd::ResumeSession { session_id: id } => {
                             let sid = SessionId::new(id.clone());
-                            match cx
-                                .send_request(LoadSessionRequest::new(sid.clone(), cwd.clone()))
-                                .block_task()
-                                .await
-                            {
-                                Ok(loaded) => {
+                            let restored = if resume_session {
+                                match cx
+                                    .send_request(ResumeSessionRequest::new(
+                                        sid.clone(),
+                                        cwd.clone(),
+                                    ))
+                                    .block_task()
+                                    .await
+                                {
+                                    Ok(resumed) => Ok((
+                                        serde_json::to_value(resumed).unwrap_or(Value::Null),
+                                        true,
+                                    )),
+                                    Err(err)
+                                        if load_session && !is_auth_required_error(&err) =>
+                                    {
+                                        cx.send_request(LoadSessionRequest::new(
+                                            sid.clone(),
+                                            cwd.clone(),
+                                        ))
+                                        .block_task()
+                                        .await
+                                        .map(|loaded| {
+                                            (
+                                                serde_json::to_value(loaded)
+                                                    .unwrap_or(Value::Null),
+                                                false,
+                                            )
+                                        })
+                                    }
+                                    Err(err) => Err(err),
+                                }
+                            } else {
+                                cx.send_request(LoadSessionRequest::new(sid.clone(), cwd.clone()))
+                                    .block_task()
+                                    .await
+                                    .map(|loaded| {
+                                        (
+                                            serde_json::to_value(loaded).unwrap_or(Value::Null),
+                                            false,
+                                        )
+                                    })
+                            };
+                            match restored {
+                                Ok((setup, resumed)) => {
                                     session_id = Some(sid.clone());
+                                    let notice = if resumed {
+                                        format!(
+                                            "⟲ resumed {id} — previous transcript was not replayed"
+                                        )
+                                    } else {
+                                        format!(
+                                            "⟲ loaded {id} — transcript from session/update"
+                                        )
+                                    };
                                     emit_session_bound(
                                         &bus,
                                         &sid,
-                                        Some(format!(
-                                            "⟲ loaded {id} — transcript from session/update"
-                                        )),
+                                        Some(notice),
                                     );
-                                    if let Ok(value) = serde_json::to_value(&loaded) {
-                                        let session = sid.to_string();
-                                        apply_setup(&value, Some(&session), &surface, &bus);
-                                    }
+                                    let session = sid.to_string();
+                                    apply_setup(&setup, Some(&session), &surface, &bus);
                                 }
                                 Err(err) if is_auth_required_error(&err) => {
                                     emit_needs_auth_open(
@@ -2301,7 +2379,7 @@ where
                                 }
                                 Err(err) => {
                                     let _ = bus.send(AppEvent::Ctl(CtlEvent::Error(format!(
-                                        "session/load: {err}"
+                                        "session/resume: {err}"
                                     ))));
                                 }
                             }

--- a/src/app.rs
+++ b/src/app.rs
@@ -1029,10 +1029,14 @@ pub struct App {
     pub chat_view: ChatView,
     /// Sessions offered by the open `/resume` picker (id → file lookup).
     resume_candidates: Vec<crate::sessions::SessionSummary>,
-    /// `/resume` picker rows came from ACP `session/list` (pick → `session/load`).
+    /// `/resume` picker rows came from ACP `session/list` (pick → resume/load).
     resume_via_acp: bool,
     /// Agent advertised `loadSession`.
     load_session: bool,
+    /// Agent advertised `sessionCapabilities.list` (or legacy `loadSession`).
+    list_session: bool,
+    /// Agent advertised `sessionCapabilities.resume`.
+    resume_session_cap: bool,
     /// Last ACP `session_info_update` title.
     session_title: Option<String>,
     pub slash_sel: usize,
@@ -1113,7 +1117,7 @@ pub struct App {
     pub demo: bool,
     /// A live ACP agent owns runtime, credentials, and its advertised catalog.
     pub attached: bool,
-    /// A real `session/new` or `session/load` has supplied this session id.
+    /// A real `session/new`, `session/resume`, or `session/load` supplied this id.
     /// Cached session options stay hidden until this becomes true.
     pub session_bound: bool,
     /// ACP initialize / authenticate status (live ACP only).
@@ -1436,6 +1440,8 @@ impl App {
             resume_candidates: Vec::new(),
             resume_via_acp: false,
             load_session: false,
+            list_session: false,
+            resume_session_cap: false,
             session_title: None,
             slash_sel: 0,
             file_menu: None,
@@ -2695,8 +2701,14 @@ impl App {
                     CtlEvent::OpenAuth => {
                         self.open_auth_surface(ctl);
                     }
-                    CtlEvent::AgentCaps { load_session } => {
+                    CtlEvent::AgentCaps {
+                        load_session,
+                        list_session,
+                        resume_session,
+                    } => {
                         self.load_session = load_session;
+                        self.list_session = list_session;
+                        self.resume_session_cap = resume_session;
                     }
                     CtlEvent::SessionBound { session_id, notice } => {
                         if self.session_id != session_id {
@@ -4426,7 +4438,7 @@ impl App {
                     PickerKind::Permission => self.set_permission(item.id, ctl),
                     PickerKind::Session => {
                         if self.resume_via_acp {
-                            self.load_acp_session(&item.id, ctl);
+                            self.resume_acp_session(&item.id, ctl);
                         } else {
                             self.resume_session(&item.id, ctl);
                         }
@@ -4730,13 +4742,13 @@ impl App {
     /// `/resume`: list this workspace's durable sessions in a picker
     /// (grok-build's session picker). Live ACP prefers `session/list`.
     fn open_resume_picker(&mut self, ctl: &Controller) {
-        if !self.demo && self.load_session {
+        if !self.demo && self.list_session {
             ctl.send(Cmd::ListSessions { prefix: None });
             self.show_tip("listing ACP sessions…");
             return;
         }
         if !self.demo {
-            self.show_tip("agent did not advertise loadSession — listing local JSONL");
+            self.show_tip("agent did not advertise session/list — listing local JSONL");
         }
         self.open_local_resume_picker();
     }
@@ -4910,14 +4922,14 @@ impl App {
         self.agent_selection = None;
     }
 
-    fn load_acp_session(&mut self, id: &str, ctl: &Controller) {
+    fn resume_acp_session(&mut self, id: &str, ctl: &Controller) {
         self.reset_session_ui();
         self.session_id = id.to_string();
         self.transcript.set_root_session(id.to_string());
-        ctl.send(Cmd::LoadSession {
+        ctl.send(Cmd::ResumeSession {
             session_id: id.to_string(),
         });
-        self.show_tip(format!("session/load {id} …"));
+        self.show_tip(format!("resuming {id} …"));
         self.needs_redraw = true;
     }
 
@@ -4933,7 +4945,7 @@ impl App {
         if let Some(prefix) = prefix.as_deref().filter(|p| !p.is_empty()) {
             match unique_session_list_match(&sessions, prefix) {
                 Ok(id) => {
-                    self.load_acp_session(&id, ctl);
+                    self.resume_acp_session(&id, ctl);
                     return;
                 }
                 Err(msg) => {
@@ -5000,15 +5012,15 @@ impl App {
             "session/list unavailable ({error}) — listing local JSONL"
         ));
         if let Some(prefix) = prefix.filter(|p| !p.is_empty()) {
-            if self.load_session {
-                self.load_acp_session(&prefix, ctl);
+            if self.resume_session_cap || self.load_session {
+                self.resume_acp_session(&prefix, ctl);
                 return;
             }
             self.resume_session(&prefix, ctl);
             return;
         }
         self.open_local_resume_picker();
-        if self.load_session {
+        if self.resume_session_cap || self.load_session {
             self.resume_via_acp = true;
         }
     }
@@ -5582,15 +5594,17 @@ impl App {
             "resume" => {
                 if arg.is_empty() {
                     self.open_resume_picker(ctl);
-                } else if !self.demo && self.load_session {
+                } else if !self.demo && self.list_session {
                     ctl.send(Cmd::ListSessions {
                         prefix: Some(arg.to_string()),
                     });
                     self.show_tip("listing ACP sessions…");
+                } else if !self.demo && (self.resume_session_cap || self.load_session) {
+                    self.resume_acp_session(arg, ctl);
                 } else {
                     if !self.demo {
                         self.show_tip(
-                            "agent did not advertise loadSession — replaying local JSONL",
+                            "agent did not advertise session/resume or loadSession — replaying local JSONL",
                         );
                     }
                     self.resume_session(arg, ctl);

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -118,9 +118,13 @@ pub enum CtlEvent {
     Auth(crate::acp_auth::AuthSnapshot),
     /// Open the client `/auth` surface (method picker or the one method).
     OpenAuth,
-    /// Agent advertised `loadSession` (`session/load`, usually with `session/list`).
-    AgentCaps { load_session: bool },
-    /// `session/new` or `session/load` resolved; the UI must use this id.
+    /// Agent-advertised session lifecycle capabilities.
+    AgentCaps {
+        load_session: bool,
+        list_session: bool,
+        resume_session: bool,
+    },
+    /// `session/new`, `session/resume`, or `session/load` resolved; the UI must use this id.
     SessionBound {
         session_id: String,
         notice: Option<String>,
@@ -396,8 +400,8 @@ pub enum Cmd {
     ListSessions {
         prefix: Option<String>,
     },
-    /// Live ACP `/resume` pick → `session/load`.
-    LoadSession {
+    /// Live ACP `/resume` pick → `session/resume`, with legacy `session/load` fallback.
+    ResumeSession {
         session_id: String,
     },
     Shutdown,

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -588,9 +588,10 @@ fn controller_loop(
                     "session/set_config_option needs a live ACP connection".into(),
                 )));
             }
-            Cmd::NewSession | Cmd::ListSessions { .. } | Cmd::LoadSession { .. } => {
+            Cmd::NewSession | Cmd::ListSessions { .. } | Cmd::ResumeSession { .. } => {
                 let _ = bus.send(AppEvent::Ctl(CtlEvent::TuiOpFailed(
-                    "session/new, session/list, and session/load need a live ACP connection".into(),
+                    "session/new, session/list, and session/resume need a live ACP connection"
+                        .into(),
                 )));
             }
             Cmd::QueueSnapshot { .. } | Cmd::AgentsSnapshot { .. } => {

--- a/tests/unit/acp__tests.rs
+++ b/tests/unit/acp__tests.rs
@@ -741,6 +741,30 @@ fn load_session_flag_reads_initialize_payload() {
     assert!(!load_session_supported(&json!({})));
 }
 
+#[test]
+fn resume_session_flag_reads_initialize_payload() {
+    assert!(resume_session_supported(&json!({
+        "agentCapabilities": { "sessionCapabilities": { "resume": {} } }
+    })));
+    assert!(resume_session_supported(&json!({
+        "agent_capabilities": { "session_capabilities": { "resume": {} } }
+    })));
+    assert!(!resume_session_supported(&json!({
+        "agentCapabilities": { "sessionCapabilities": { "resume": null } }
+    })));
+    assert!(!resume_session_supported(&json!({})));
+}
+
+#[test]
+fn list_session_flag_reads_initialize_payload() {
+    assert!(list_session_supported(&json!({
+        "agentCapabilities": { "sessionCapabilities": { "list": {} } }
+    })));
+    assert!(!list_session_supported(&json!({
+        "agentCapabilities": { "sessionCapabilities": { "list": null } }
+    })));
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn form_auth_stays_configured_when_the_startup_session_succeeds() {
     use agent_client_protocol::schema::v1::{
@@ -1246,13 +1270,16 @@ async fn client_tree_config_set_uses_standard_acp_and_folds_response_only_state(
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn load_session_binds_the_loaded_id_before_applying_its_initial_config() {
+async fn resume_session_prefers_resume_and_binds_before_applying_initial_config() {
     use agent_client_protocol::schema::v1::{
         AgentCapabilities, InitializeResponse, LoadSessionResponse, NewSessionResponse,
-        SessionConfigOption, SessionConfigSelectOption,
+        ResumeSessionRequest, ResumeSessionResponse, SessionCapabilities, SessionConfigOption,
+        SessionConfigSelectOption, SessionResumeCapabilities,
     };
+    use std::sync::atomic::{AtomicUsize, Ordering};
     use std::time::{Duration, Instant};
 
+    let load_calls = Arc::new(AtomicUsize::new(0));
     let agent = Agent
         .builder()
         .name("load-config-mock")
@@ -1260,7 +1287,14 @@ async fn load_session_binds_the_loaded_id_before_applying_its_initial_config() {
             async move |init: InitializeRequest, responder, _cx| {
                 responder.respond(
                     InitializeResponse::new(init.protocol_version)
-                        .agent_capabilities(AgentCapabilities::new().load_session(true))
+                        .agent_capabilities(
+                            AgentCapabilities::new()
+                                .load_session(true)
+                                .session_capabilities(
+                                    SessionCapabilities::new()
+                                        .resume(SessionResumeCapabilities::new()),
+                                ),
+                        )
                         .agent_info(Implementation::new("load-config-mock", "0")),
                 )
             },
@@ -1273,8 +1307,8 @@ async fn load_session_binds_the_loaded_id_before_applying_its_initial_config() {
             on_receive_request!(),
         )
         .on_receive_request(
-            async move |_req: LoadSessionRequest, responder, _cx| {
-                responder.respond(LoadSessionResponse::new().config_options(vec![
+            async move |_req: ResumeSessionRequest, responder, _cx| {
+                responder.respond(ResumeSessionResponse::new().config_options(vec![
                     SessionConfigOption::select(
                         "collaboration_mode",
                         "Collaboration mode",
@@ -1285,6 +1319,16 @@ async fn load_session_binds_the_loaded_id_before_applying_its_initial_config() {
                         ],
                     ),
                 ]))
+            },
+            on_receive_request!(),
+        )
+        .on_receive_request(
+            {
+                let load_calls = Arc::clone(&load_calls);
+                async move |_req: LoadSessionRequest, responder, _cx| {
+                    load_calls.fetch_add(1, Ordering::SeqCst);
+                    responder.respond(LoadSessionResponse::new())
+                }
             },
             on_receive_request!(),
         );
@@ -1315,10 +1359,10 @@ async fn load_session_binds_the_loaded_id_before_applying_its_initial_config() {
         }
     }
     cmd_tx
-        .send(Cmd::LoadSession {
+        .send(Cmd::ResumeSession {
             session_id: "s2".into(),
         })
-        .expect("load session");
+        .expect("resume session");
 
     let deadline = Instant::now() + Duration::from_secs(2);
     let mut order = Vec::new();
@@ -1339,6 +1383,120 @@ async fn load_session_binds_the_loaded_id_before_applying_its_initial_config() {
     }
 
     assert_eq!(order, ["bound", "plan"]);
+    assert_eq!(load_calls.load(Ordering::SeqCst), 0);
+    let _ = cmd_tx.send(Cmd::Shutdown);
+    let _ = client.await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn resume_session_falls_back_to_load_when_resume_is_rejected() {
+    use agent_client_protocol::schema::v1::{
+        AgentCapabilities, InitializeResponse, LoadSessionResponse, NewSessionResponse,
+        ResumeSessionRequest, SessionCapabilities, SessionResumeCapabilities,
+    };
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::time::{Duration, Instant};
+
+    let resume_calls = Arc::new(AtomicUsize::new(0));
+    let load_calls = Arc::new(AtomicUsize::new(0));
+    let agent = Agent
+        .builder()
+        .name("resume-fallback-mock")
+        .on_receive_request(
+            async move |init: InitializeRequest, responder, _cx| {
+                responder.respond(
+                    InitializeResponse::new(init.protocol_version)
+                        .agent_capabilities(
+                            AgentCapabilities::new()
+                                .load_session(true)
+                                .session_capabilities(
+                                    SessionCapabilities::new()
+                                        .resume(SessionResumeCapabilities::new()),
+                                ),
+                        )
+                        .agent_info(Implementation::new("resume-fallback-mock", "0")),
+                )
+            },
+            on_receive_request!(),
+        )
+        .on_receive_request(
+            async move |_req: NewSessionRequest, responder, _cx| {
+                responder.respond(NewSessionResponse::new(SessionId::new("s1")))
+            },
+            on_receive_request!(),
+        )
+        .on_receive_request(
+            {
+                let resume_calls = Arc::clone(&resume_calls);
+                async move |_req: ResumeSessionRequest, responder, _cx| {
+                    resume_calls.fetch_add(1, Ordering::SeqCst);
+                    responder.respond_with_error(AcpError::new(-32601, "resume unavailable"))
+                }
+            },
+            on_receive_request!(),
+        )
+        .on_receive_request(
+            {
+                let load_calls = Arc::clone(&load_calls);
+                async move |_req: LoadSessionRequest, responder, _cx| {
+                    load_calls.fetch_add(1, Ordering::SeqCst);
+                    responder.respond(LoadSessionResponse::new())
+                }
+            },
+            on_receive_request!(),
+        );
+    let cfg = RuntimeConfig {
+        bin: "demo".into(),
+        cordis: "demo".into(),
+        workspace: "/tmp".into(),
+        session_root: "/tmp".into(),
+        provider: "deepseek-official".into(),
+        model: "deepseek-v4-flash".into(),
+        max_tokens: None,
+        base_url: None,
+        api_key: None,
+    };
+    let (bus_tx, bus_rx) = std::sync::mpsc::channel();
+    let (cmd_tx, cmd_rx) = std::sync::mpsc::channel();
+    let client = tokio::spawn(async move { connect(agent, cfg, bus_tx, cmd_rx).await });
+
+    let startup_deadline = Instant::now() + Duration::from_secs(2);
+    while Instant::now() < startup_deadline {
+        match bus_rx.recv_timeout(Duration::from_millis(20)) {
+            Ok(AppEvent::Ctl(CtlEvent::SessionBound { session_id, .. })) if session_id == "s1" => {
+                break;
+            }
+            Ok(_) => {}
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {}
+            Err(err) => panic!("{err}"),
+        }
+    }
+    cmd_tx
+        .send(Cmd::ResumeSession {
+            session_id: "s2".into(),
+        })
+        .expect("resume session");
+
+    let deadline = Instant::now() + Duration::from_secs(2);
+    let mut bound_notice = None;
+    while Instant::now() < deadline && bound_notice.is_none() {
+        match bus_rx.recv_timeout(Duration::from_millis(20)) {
+            Ok(AppEvent::Ctl(CtlEvent::SessionBound { session_id, notice }))
+                if session_id == "s2" =>
+            {
+                bound_notice = notice
+            }
+            Ok(_) => {}
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {}
+            Err(err) => panic!("{err}"),
+        }
+    }
+
+    assert_eq!(resume_calls.load(Ordering::SeqCst), 1);
+    assert_eq!(load_calls.load(Ordering::SeqCst), 1);
+    assert!(bound_notice
+        .as_deref()
+        .is_some_and(|text| text.contains("loaded s2")));
     let _ = cmd_tx.send(Cmd::Shutdown);
     let _ = client.await;
 }

--- a/tests/unit/app__mode_tests.rs
+++ b/tests/unit/app__mode_tests.rs
@@ -1205,7 +1205,7 @@ fn agent_preset_event_updates_chrome_without_adding_a_transcript_row() {
 }
 
 #[test]
-fn acp_session_list_opens_picker_and_prefix_loads() {
+fn acp_session_list_opens_picker_and_prefix_resumes() {
     let (mut app, ctl, _rx) = test_app();
     app.demo = false;
     app.load_session = true;
@@ -1304,15 +1304,44 @@ fn agent_caps_gate_resume_to_session_list() {
     let (mut app, ctl, _rx) = test_app();
     app.demo = false;
     app.handle(
-        AppEvent::Ctl(CtlEvent::AgentCaps { load_session: true }),
+        AppEvent::Ctl(CtlEvent::AgentCaps {
+            load_session: true,
+            list_session: true,
+            resume_session: true,
+        }),
         &ctl,
     );
     assert!(app.load_session);
+    assert!(app.list_session);
+    assert!(app.resume_session_cap);
     app.run_slash("resume", "", &ctl);
     assert!(
         app.picker.is_none(),
         "live ACP /resume waits for session/list"
     );
+}
+
+#[test]
+fn resume_capability_can_restore_an_exact_id_without_load_or_list() {
+    let cfg = test_cfg();
+    let (tx, _rx) = std::sync::mpsc::channel::<AppEvent>();
+    let mut app = App::new(Some(Theme::dark()), cfg, "s-current".into(), false, true, tx);
+    let (ctl, commands) = crate::controller::tests::test_controller();
+    app.handle(
+        AppEvent::Ctl(CtlEvent::AgentCaps {
+            load_session: false,
+            list_session: false,
+            resume_session: true,
+        }),
+        &ctl,
+    );
+
+    app.run_slash("resume", "s-old", &ctl);
+
+    assert!(matches!(
+        commands.recv_timeout(std::time::Duration::from_millis(50)),
+        Ok(Cmd::ResumeSession { session_id }) if session_id == "s-old"
+    ));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- prefer ACP `session/resume` for `/resume`, avoiding transcript replay for long sessions
- keep `session/load` compatibility and fall back when resume is rejected
- honor independent `sessionCapabilities.list` and `sessionCapabilities.resume` flags
- bundle `@openma/deepseek-harness-acp` 0.4.27 and prepare Martty 0.2.31

## Verification
- `cargo test --locked` (616 unit tests plus integration tests)
- `cargo check --locked --tests`
- `npm test --prefix npm` (226 tests; temporary Python venv supplied `pexpect`)
- `node scripts/check-release-tag.mjs v0.2.31 npm/package.json Cargo.toml`
- `git diff --check`