### PR TITLE
feat(tui): multi-session parallel management with native session tabs (issue #94)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ All notable changes to this project are documented here. The project follows
 
 ### Fixed
 
+- Painter info popups (`/help`, `/keys`, `/session`, and the painter
+  `/status` fallback) and the `/plugins` / `/cordis-plugins` inventory tree
+  now follow their session across tabs like the ACP asks do: opening one,
+  clicking another tab, and returning restores the popup exactly as left
+  (scroll and tree selection included), instead of floating over the newly
+  viewed session. Compositor-owned plugin overlays (the live `/status`
+  view, plan views, select/slider modals) cannot ride along — they belong
+  to the client Plugin runtime's single-overlay slot — so a tab switch
+  cancels them with the same event Esc would send (the plugin releases its
+  slot; shipped plugins have no cancel side effects). A plugin's later
+  "overlay closed" ack no longer eats a painter popup restored by that
+  switch.
+
+- Session-bound ACP asks (permission and elicitation popups) now follow
+  their session across tabs instead of floating over whatever session is on
+  screen: an ask that arrives for a background session waits in that
+  session's tab (marked with a `?` in the tab strip) and only shows when
+  its own tab is viewed; switching away never cancels or answers it, and
+  answering or Esc-ing it works from its own tab only. Two asks on
+  different sessions no longer clobber each other (the displaced ask used
+  to auto-cancel, silently denying the agent's tool call).
+
 - The UI no longer freezes for minutes when an agent floods the connection
   with session updates — reproduced with dsh-acp's `session/load` replay of
   a long session, which re-emits every historical delta (a 10k-event log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ All notable changes to this project are documented here. The project follows
 
 ### Fixed
 
+- `/resume` over ACP (`session/load`) no longer leaves the welcome banner
+  covering the replayed transcript: the banner was only dismissed by the
+  first prompt send (and by the local JSONL resume path), so resuming
+  before ever sending a prompt hid every loaded message until the user
+  typed and sent something. `load_acp_session` now dismisses the banner
+  before the replay streams in, like `resume_session` already did.
+
 - Painter info popups (`/help`, `/keys`, `/session`, and the painter
   `/status` fallback) and the `/plugins` / `/cordis-plugins` inventory tree
   now follow their session across tabs like the ACP asks do: opening one,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,17 +25,15 @@ All notable changes to this project are documented here. The project follows
   drives several sessions concurrently. Once a second session exists, a
   native tab strip appears at the top — one tab per session with a running
   indicator (spinner on the viewed tab, `●` in the background) and a `✓`
-  completion badge for sessions that finished while in the background.
-  Left-click a tab to switch, the trailing `+` opens a fresh session, and
-  right-clicking a tab opens a local menu with "Close tab". `/new` and
-  `/resume` now park the current session instead of discarding it: switching
-  back restores its transcript, prompt queue, modes, and subagent panels
-  exactly as left, while background sessions keep folding their
-  `session/update` events into their own transcripts (the event router also
-  no longer lets foreign-session events leak into the viewed transcript).
-  Prompts, steers, interrupts, and per-session queues are addressed by
-  session id, so turns on different sessions run truly concurrently.
-  Closing a tab is local only (the ACP surface has no `session/close`).
+  completion badge for sessions that finished while in the background;
+  left-click a tab to switch. `/new` and `/resume` now park the current
+  session instead of discarding it: switching back restores its transcript,
+  prompt queue, modes, and subagent panels exactly as left, while background
+  sessions keep folding their `session/update` events into their own
+  transcripts (the event router also no longer lets foreign-session events
+  leak into the viewed transcript). Prompts, steers, interrupts, and
+  per-session queues are addressed by session id, so turns on different
+  sessions run truly concurrently.
 - `scripts/acp-multi-session.smoke.mjs`: opt-in smoke check that the
   spawned dsh-acp agent drives concurrent sessions over one ACP connection
   (consumes a small amount of model tokens; not part of `npm test`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,40 @@ All notable changes to this project are documented here. The project follows
 
 ## [Unreleased]
 
+### Fixed
+
+- The UI no longer freezes for minutes when an agent floods the connection
+  with session updates — reproduced with dsh-acp's `session/load` replay of
+  a long session, which re-emits every historical delta (a 10k-event log
+  arrived as ~258k notifications / 1.4 GB and saturated the event loop.
+  Two defenses: drained bursts of `session/update` notifications are now
+  coalesced before application (adjacent text deltas of one message are
+  concatenated; superseded bare `tool_call_update`s keep only the latest
+  state — lossless for the final transcript), and the per-event
+  queue/agents projection comparisons now use cheap fingerprints instead of
+  full snapshot clones. The composer stays responsive while such a storm
+  drains in the background.
+
 ### Added
+
+- Multi-session parallel management (issue #94): one ACP connection now
+  drives several sessions concurrently. Once a second session exists, a
+  native tab strip appears at the top — one tab per session with a running
+  indicator (spinner on the viewed tab, `●` in the background) and a `✓`
+  completion badge for sessions that finished while in the background.
+  Left-click a tab to switch, the trailing `+` opens a fresh session, and
+  right-clicking a tab opens a local menu with "Close tab". `/new` and
+  `/resume` now park the current session instead of discarding it: switching
+  back restores its transcript, prompt queue, modes, and subagent panels
+  exactly as left, while background sessions keep folding their
+  `session/update` events into their own transcripts (the event router also
+  no longer lets foreign-session events leak into the viewed transcript).
+  Prompts, steers, interrupts, and per-session queues are addressed by
+  session id, so turns on different sessions run truly concurrently.
+  Closing a tab is local only (the ACP surface has no `session/close`).
+- `scripts/acp-multi-session.smoke.mjs`: opt-in smoke check that the
+  spawned dsh-acp agent drives concurrent sessions over one ACP connection
+  (consumes a small amount of model tokens; not part of `npm test`).
 
 - Fast local build profile `devlocal` (debug codegen, incremental) for
   `scripts/devlocalinstall.sh`: the local install/build loop no longer

--- a/scripts/acp-multi-session.smoke.mjs
+++ b/scripts/acp-multi-session.smoke.mjs
@@ -1,0 +1,161 @@
+// Phase 0 smoke (issue #94): verify the dsh-acp ACP server supports multiple
+// concurrent sessions on ONE stdio connection:
+//   - two session/new sessions, prompted concurrently via bare sessionId
+//   - session/update notifications interleave, demultiplexed by sessionId
+//   - probe session/load (README says rejected) and session/resume
+//
+// Opt-in only — consumes a small amount of model tokens. Not part of npm test.
+// Usage: node scripts/acp-multi-session.smoke.mjs [path-to-dsh-acp]
+
+import { spawn } from 'node:child_process'
+import { mkdtempSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+
+const agent = process.argv[2]
+  ?? path.join(process.env.HOME, '.dsh/profiles/martty/node_modules/.bin/dsh-acp')
+const cwd = mkdtempSync(path.join(tmpdir(), 'martty-acp-multi-'))
+
+const child = spawn(agent, [], { stdio: ['pipe', 'pipe', 'inherit'] })
+let buf = ''
+let nextId = 1
+const pending = new Map()
+const updates = new Map() // sessionId -> { count, kinds: Map }
+const notifications = []
+
+function send(method, params) {
+  const id = nextId++
+  child.stdin.write(JSON.stringify({ jsonrpc: '2.0', id, method, params }) + '\n')
+  return new Promise((resolve, reject) => pending.set(id, { resolve, reject, method }))
+}
+
+function recordUpdate(params) {
+  const sid = params?.sessionId ?? '<none>'
+  const kind = params?.update?.sessionUpdate ?? '?'
+  if (!updates.has(sid)) updates.set(sid, { count: 0, kinds: new Map() })
+  const rec = updates.get(sid)
+  rec.count++
+  rec.kinds.set(kind, (rec.kinds.get(kind) ?? 0) + 1)
+}
+
+child.stdout.on('data', (chunk) => {
+  buf += chunk.toString('utf8')
+  for (;;) {
+    const nl = buf.indexOf('\n')
+    if (nl < 0) break
+    const line = buf.slice(0, nl).trim()
+    buf = buf.slice(nl + 1)
+    if (!line) continue
+    let msg
+    try { msg = JSON.parse(line) } catch { continue }
+    if (msg.id !== undefined && (msg.result !== undefined || msg.error !== undefined)) {
+      const p = pending.get(msg.id)
+      if (p) {
+        pending.delete(msg.id)
+        if (msg.error) p.reject(new Error(`${p.method}: ${msg.error.code} ${msg.error.message}`))
+        else p.resolve(msg.result)
+      }
+    } else if (msg.id !== undefined && msg.method) {
+      // Agent -> client request. Auto-approve permissions with the first
+      // allow option; answer anything else with a generic empty result.
+      if (msg.method === 'session/request_permission') {
+        const options = msg.params?.options ?? []
+        const allow = options.find((o) => String(o.kind ?? '').includes('allow')) ?? options[0]
+        child.stdin.write(JSON.stringify({
+          jsonrpc: '2.0', id: msg.id,
+          result: { outcome: { outcome: 'selected', optionId: allow?.optionId } },
+        }) + '\n')
+      } else {
+        child.stdin.write(JSON.stringify({ jsonrpc: '2.0', id: msg.id, result: {} }) + '\n')
+      }
+    } else if (msg.method === 'session/update') {
+      recordUpdate(msg.params)
+      notifications.push(msg.params)
+    }
+  }
+})
+
+function withTimeout(promise, ms, label) {
+  return Promise.race([
+    promise,
+    new Promise((_, reject) => setTimeout(() => reject(new Error(`${label}: timeout after ${ms}ms`)), ms)),
+  ])
+}
+
+const failures = []
+function check(name, cond, detail = '') {
+  console.log(`${cond ? 'PASS' : 'FAIL'}  ${name}${detail ? ` — ${detail}` : ''}`)
+  if (!cond) failures.push(name)
+}
+
+try {
+  const init = await withTimeout(send('initialize', {
+    protocolVersion: 1,
+    clientCapabilities: { fs: { readTextFile: false, writeTextFile: false }, terminal: false },
+  }), 30000, 'initialize')
+  console.log('initialize ok. agentCapabilities:', JSON.stringify(init.agentCapabilities ?? {}))
+  console.log('authMethods:', JSON.stringify(init.authMethods ?? []))
+
+  const s1 = await withTimeout(send('session/new', { cwd, mcpServers: [] }), 60000, 'session/new #1')
+  const s2 = await withTimeout(send('session/new', { cwd, mcpServers: [] }), 60000, 'session/new #2')
+  const sid1 = s1.sessionId
+  const sid2 = s2.sessionId
+  console.log(`sessions: ${sid1} / ${sid2}`)
+  check('two distinct sessions', sid1 && sid2 && sid1 !== sid2)
+
+  const marker1 = 'ALPHA_ONE'
+  const marker2 = 'BRAVO_TWO'
+  const prompt = (sessionId, marker) => send('session/prompt', {
+    sessionId,
+    prompt: [{ type: 'text', text: `Reply with exactly the token ${marker} and nothing else.` }],
+  })
+  const [r1, r2] = await withTimeout(
+    Promise.all([prompt(sid1, marker1), prompt(sid2, marker2)]),
+    180000, 'concurrent prompts',
+  )
+  console.log(`prompt responses: ${JSON.stringify(r1)} / ${JSON.stringify(r2)}`)
+
+  const u1 = updates.get(sid1)
+  const u2 = updates.get(sid2)
+  check('session #1 streamed updates on this connection', !!u1 && u1.count > 0,
+    u1 ? `${u1.count} updates: ${[...u1.kinds.entries()].map(([k, n]) => `${k}×${n}`).join(', ')}` : 'none')
+  check('session #2 streamed updates on this connection', !!u2 && u2.count > 0,
+    u2 ? `${u2.count} updates: ${[...u2.kinds.entries()].map(([k, n]) => `${k}×${n}`).join(', ')}` : 'none')
+  const foreign = [...updates.keys()].filter((k) => k !== sid1 && k !== sid2)
+  check('no updates tagged with unknown session ids', foreign.length === 0, foreign.join(','))
+
+  const text1 = notifications.filter((n) => n.sessionId === sid1)
+    .map((n) => n.update?.content?.text ?? '').join('')
+  const text2 = notifications.filter((n) => n.sessionId === sid2)
+    .map((n) => n.update?.content?.text ?? '').join('')
+  check('session #1 answered its own marker', text1.includes(marker1), JSON.stringify(text1.slice(0, 80)))
+  check('session #2 answered its own marker', text2.includes(marker2), JSON.stringify(text2.slice(0, 80)))
+
+  const list = await withTimeout(send('session/list', {}), 30000, 'session/list')
+  const listed = (list.sessions ?? []).map((s) => s.sessionId)
+  check('session/list contains both sessions', listed.includes(sid1) && listed.includes(sid2),
+    `${listed.length} listed`)
+
+  // Probes: record behavior, do not fail the smoke on the outcome.
+  try {
+    const r = await withTimeout(send('session/load', { sessionId: sid1, cwd, mcpServers: [] }), 30000, 'session/load')
+    console.log('probe session/load: SUCCEEDED', JSON.stringify(r))
+  } catch (err) {
+    console.log(`probe session/load: rejected — ${err.message}`)
+  }
+  try {
+    await withTimeout(send('session/close', { sessionId: sid2 }), 30000, 'session/close')
+    const r = await withTimeout(send('session/resume', { sessionId: sid2, cwd, mcpServers: [] }), 60000, 'session/resume')
+    console.log('probe session/resume after close: SUCCEEDED', JSON.stringify(r))
+  } catch (err) {
+    console.log(`probe session/resume: ${err.message}`)
+  }
+} catch (err) {
+  console.error(`smoke aborted: ${err.message}`)
+  failures.push('aborted')
+} finally {
+  child.kill('SIGTERM')
+}
+
+console.log(failures.length === 0 ? '\nSMOKE OK' : `\nSMOKE FAILED: ${failures.join(', ')}`)
+process.exit(failures.length === 0 ? 0 : 1)

--- a/scripts/collect-freeze-diag.sh
+++ b/scripts/collect-freeze-diag.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Collect diagnostics when the martty TUI looks frozen (issue: freeze after
+# tab switches). Run this in ANOTHER terminal while the TUI is still wedged,
+# then share /tmp/martty-freeze-diag.txt.
+set -u
+out=/tmp/martty-freeze-diag.txt
+: > "$out"
+
+pids=$(pgrep -f 'vendor/[^ ]*/martty|target/(devlocal|debug|release)/martty' || true)
+if [ -z "$pids" ]; then
+  pids=$(pgrep -xo martty || true)
+fi
+
+{
+  echo "== date: $(date -Is)"
+  echo "== candidate martty processes:"
+  if [ -z "$pids" ]; then
+    echo "(none found — is the TUI actually a martty process?)"
+  fi
+  for pid in $pids; do
+    echo
+    echo "== pid $pid: $(tr '\0' ' ' < /proc/$pid/cmdline 2>/dev/null)"
+    ps -o pid,ppid,stat,%cpu,%mem,etime -p "$pid" 2>/dev/null
+    echo "-- wchan: $(cat /proc/$pid/wchan 2>/dev/null)"
+    echo "-- threads: $(ls /proc/$pid/task 2>/dev/null | wc -l)"
+    if command -v rust-gdb >/dev/null 2>&1; then
+      echo "-- backtraces (rust-gdb):"
+      timeout 30 rust-gdb -batch -p "$pid" \
+        -ex 'set pagination off' -ex 'thread apply all bt' 2>/dev/null \
+        | grep -v '^\[Thread debugging' | head -160
+    else
+      echo "-- rust-gdb not found; install gdb for userspace backtraces"
+    fi
+  done
+} >> "$out" 2>&1
+
+echo "diagnostics written to $out"

--- a/scripts/tui-multi-session.e2e.mjs
+++ b/scripts/tui-multi-session.e2e.mjs
@@ -254,7 +254,7 @@ try {
   // 3. Open a second tab: the native tab strip appears on row 0.
   await type('/new')
   term.write('\r')
-  await waitFor(() => row0().includes('│') && row0().includes('+'), 30000, 'tab strip with 2 tabs')
+  await waitFor(() => row0().includes('│'), 30000, 'tab strip with 2 tabs')
   check('tab strip renders with ≥2 sessions', true)
 
   // 4. Prompt session B (instant answer) while A is still streaming.
@@ -303,13 +303,11 @@ try {
   check('✓ badge cleared after viewing tab A', badgeCleared, badgeCleared ? '' : `row0: ${row0()}`)
 
   // 8. Click session B's tab: compute its column from row 0's layout — the
-  //    region between the first │ separator and the next one (or the + cell).
+  //    region between the first │ separator and the next one (or the end).
   const strip = row0()
   const sep1 = strip.indexOf('│')
   const tabBStart = sep1 + 2 // 0-based index right after " │ "
   let tabBEnd = strip.indexOf('│', tabBStart)
-  const plus = strip.indexOf('+', tabBStart)
-  if (tabBEnd < 0 || (plus >= 0 && plus < tabBEnd)) tabBEnd = plus
   if (tabBEnd < 0) tabBEnd = strip.length
   const tabBCol = tabBStart + Math.max(1, Math.floor((tabBEnd - tabBStart) / 2)) + 1 // 1-based
   console.log(`tab B click target: col ${tabBCol} (strip: "${strip}")`)

--- a/scripts/tui-multi-session.e2e.mjs
+++ b/scripts/tui-multi-session.e2e.mjs
@@ -1,0 +1,338 @@
+// Issue #94 opt-in E2E: drive the real Rust TUI (debug bin) in a PTY against
+// the real dsh-acp agent and prove two sessions run concurrently through the
+// whole client stack — per-session inflight in acp.rs, parked-slot routing,
+// tab strip, click-to-switch, background progress.
+//
+// Assertions read a virtual terminal screen (100x34 character grid fed from
+// the PTY byte stream), not the raw bytes: ratatui only emits terminal diffs,
+// so a glyph drawn once (e.g. ● on the tab strip) never reappears in the
+// stream and raw-window searches are unreliable.
+//
+// Consumes model tokens. Not part of npm test / CI.
+// Usage: cargo build --locked && node scripts/tui-multi-session.e2e.mjs [path-to-martty-bin]
+
+import { mkdtempSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { createRequire } from 'node:module'
+
+const require = createRequire(import.meta.url)
+const pty = require('../npm/node_modules/node-pty')
+
+const COLS = 100
+const ROWS = 34
+
+// ---------------------------------------------------------------------------
+// Minimal VT100 screen model: a COLS×ROWS grid of glyphs fed by PTY output.
+// Handles what ratatui/crossterm actually emits: CUP (\x1b[r;cH, 1-based),
+// CR/LF/BS, printable text at the cursor with advance (wide CJK = 2 cells),
+// EL (\x1b[K), ED (\x1b[J), SGR (\x1b[...m, parsed and ignored). Everything
+// else (other CSI, private modes, OSC, charset switches) is consumed and
+// ignored. SGR mouse reports are outbound only.
+// ---------------------------------------------------------------------------
+class Screen {
+  constructor(cols, rows) {
+    this.cols = cols
+    this.rows = rows
+    this.grid = Array.from({ length: rows }, () => Array(cols).fill(' '))
+    this.r = 0
+    this.c = 0
+    this.buf = ''
+  }
+
+  static wide(cp) {
+    return (
+      (cp >= 0x1100 && cp <= 0x115f) || // Hangul Jamo
+      (cp >= 0x2e80 && cp <= 0xa4cf) || // CJK radicals … Yi
+      (cp >= 0xac00 && cp <= 0xd7a3) || // Hangul syllables
+      (cp >= 0xf900 && cp <= 0xfaff) || // CJK compat ideographs
+      (cp >= 0xfe30 && cp <= 0xfe4f) || // CJK compat forms
+      (cp >= 0xff00 && cp <= 0xff60) || // fullwidth forms
+      (cp >= 0xffe0 && cp <= 0xffe6) || // fullwidth signs
+      (cp >= 0x20000 && cp <= 0x3fffd) // CJK ext B+
+    )
+  }
+
+  blank() { return ' ' }
+
+  scrollUp() {
+    this.grid.shift()
+    this.grid.push(Array(this.cols).fill(' '))
+    this.r = this.rows - 1
+  }
+
+  newline() {
+    this.r += 1
+    if (this.r >= this.rows) this.scrollUp()
+  }
+
+  putChar(ch) {
+    const cp = ch.codePointAt(0)
+    const w = Screen.wide(cp) ? 2 : 1
+    if (this.c >= this.cols) {
+      this.c = 0
+      this.newline()
+    }
+    if (w === 2 && this.c === this.cols - 1) {
+      // Wide glyph at the right edge: drop into the last cell, no continuation.
+      this.grid[this.r][this.c] = ch
+      this.c += 1
+      return
+    }
+    this.grid[this.r][this.c] = ch
+    if (w === 2) this.grid[this.r][this.c + 1] = '' // continuation cell
+    this.c += w
+  }
+
+  eraseLine(mode) {
+    const row = this.grid[this.r]
+    if (mode === 1) {
+      for (let i = 0; i <= this.c && i < this.cols; i++) row[i] = ' '
+    } else if (mode === 2) {
+      row.fill(' ')
+    } else {
+      for (let i = this.c; i < this.cols; i++) row[i] = ' '
+    }
+  }
+
+  eraseDisplay(mode) {
+    if (mode === 1) {
+      for (let r = 0; r < this.r; r++) this.grid[r].fill(' ')
+      this.eraseLine(1)
+    } else if (mode === 2) {
+      for (const row of this.grid) row.fill(' ')
+    } else {
+      this.eraseLine(0)
+      for (let r = this.r + 1; r < this.rows; r++) this.grid[r].fill(' ')
+    }
+  }
+
+  csi(params, final) {
+    const nums = params.split(';').map((p) => (p === '' || p.startsWith('?') ? NaN : parseInt(p, 10)))
+    switch (final) {
+      case 'H':
+      case 'f': {
+        const r = Number.isNaN(nums[0]) ? 1 : nums[0]
+        const c = nums.length < 2 || Number.isNaN(nums[1]) ? 1 : nums[1]
+        this.r = Math.min(Math.max(r - 1, 0), this.rows - 1)
+        this.c = Math.min(Math.max(c - 1, 0), this.cols - 1)
+        break
+      }
+      case 'K':
+        this.eraseLine(Number.isNaN(nums[0]) ? 0 : nums[0])
+        break
+      case 'J':
+        this.eraseDisplay(Number.isNaN(nums[0]) ? 0 : nums[0])
+        break
+      default:
+        break // SGR and everything else: ignore
+    }
+  }
+
+  // Feed a chunk; an incomplete trailing escape is kept in `this.buf`.
+  feed(data) {
+    const s = this.buf + data
+    this.buf = ''
+    let i = 0
+    const n = s.length
+    outer: while (i < n) {
+      const ch = s[i]
+      if (ch === '\x1b') {
+        if (i + 1 >= n) break outer
+        const nxt = s[i + 1]
+        if (nxt === '[') {
+          // CSI: params/intermediates until final byte @-~
+          let j = i + 2
+          while (j < n && !(s[j] >= '@' && s[j] <= '~')) j++
+          if (j >= n) break outer
+          this.csi(s.slice(i + 2, j), s[j])
+          i = j + 1
+          continue
+        }
+        if (nxt === ']') {
+          // OSC: until BEL or ST (\x1b\\)
+          let j = i + 2
+          while (j < n && s[j] !== '\x07' && !(s[j] === '\x1b' && j + 1 < n && s[j + 1] === '\\')) j++
+          if (j >= n) break outer
+          i = s[j] === '\x07' ? j + 1 : j + 2
+          continue
+        }
+        if ('()*+#'.includes(nxt)) {
+          // Charset / line-size switches: ESC + one intermediate + one byte.
+          if (i + 2 >= n) break outer
+          i += 3
+          continue
+        }
+        // Two-byte escape (e.g. ESC=, ESC>, ESC7, ESCM): ignore.
+        i += 2
+        continue
+      }
+      if (ch === '\r') { this.c = 0; i++; continue }
+      if (ch === '\n' || ch === '\x0b' || ch === '\x0c') { this.newline(); i++; continue }
+      if (ch === '\x08') { this.c = Math.max(0, this.c - 1); i++; continue }
+      if (ch < ' ' || ch === '\x7f') { i++; continue } // other C0/DEL: ignore
+      this.putChar(ch)
+      i++
+    }
+    this.buf = s.slice(i)
+  }
+
+  rowText(r) { return this.grid[r].join('').replace(/\s+$/, '') }
+  screenText() { return this.grid.map((_, r) => this.rowText(r)).join('\n') }
+  /** Trimmed row exactly equals `text` (matches output lines, not composer echo). */
+  hasLine(text) {
+    return this.grid.some((_, r) => this.rowText(r).trim() === text)
+  }
+}
+
+// ---------------------------------------------------------------------------
+
+const bin = process.argv[2] ?? path.resolve('target/debug/martty')
+const agent = path.join(process.env.HOME, '.dsh/profiles/martty/node_modules/.bin/dsh-acp')
+const workspace = mkdtempSync(path.join(tmpdir(), 'martty-multi-e2e-'))
+
+const term = pty.spawn(bin, ['-w', workspace, '--agent', agent], {
+  name: 'xterm-256color',
+  cols: COLS,
+  rows: ROWS,
+  cwd: workspace,
+  env: { ...process.env, TERM: 'xterm-256color' },
+})
+
+const screen = new Screen(COLS, ROWS)
+term.onData((chunk) => screen.feed(chunk))
+
+const failures = []
+function check(name, cond, detail = '') {
+  console.log(`${cond ? 'PASS' : 'FAIL'}  ${name}${detail ? ` — ${detail}` : ''}`)
+  if (!cond) failures.push(name)
+}
+
+function waitFor(pred, ms, label) {
+  const start = Date.now()
+  return new Promise((resolve, reject) => {
+    const tick = () => {
+      if (pred()) return resolve()
+      if (Date.now() - start > ms) return reject(new Error(`timeout waiting for ${label}`))
+      setTimeout(tick, 200)
+    }
+    tick()
+  })
+}
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
+// Per-character with tiny pacing so the composer doesn't drop fast bursts.
+async function type(text) {
+  for (const ch of text) {
+    term.write(ch)
+    await sleep(4)
+  }
+}
+const SGR_CLICK = (col, row) => `\x1b[<0;${col};${row}M\x1b[<0;${col};${row}m`
+
+const row0 = () => screen.rowText(0)
+
+// Distinctive markers. Session A generates a long stream (stays busy while
+// session B answers); session B answers instantly.
+const PROMPT_A = 'Output the word ZEPHYR followed by a number, one per line, from "ZEPHYR 1" to "ZEPHYR 150". No other text, but think slowly between lines.'
+const PROMPT_B = 'Reply with exactly the word BRAVO and nothing else.'
+
+try {
+  // 1. Boot: wait for the welcome hero's hint line.
+  await waitFor(() => screen.screenText().includes('/help commands'), 90000, 'TUI boot')
+  console.log('boot ok')
+
+  // 2. Prompt session A (long stream). Wait for real output: the prompt text
+  //    itself (echo + user bubble) only mentions "ZEPHYR 1" and "ZEPHYR 150",
+  //    so any ZEPHYR 2..9 proves the model's stream started — regardless of
+  //    whether the model honors "one per line".
+  await type(PROMPT_A)
+  term.write('\r')
+  await waitFor(() => /ZEPHYR [2-9]\b/.test(screen.screenText()), 90000, 'session A streaming')
+  console.log('session A streaming')
+
+  // 3. Open a second tab: the native tab strip appears on row 0.
+  await type('/new')
+  term.write('\r')
+  await waitFor(() => row0().includes('│') && row0().includes('+'), 30000, 'tab strip with 2 tabs')
+  check('tab strip renders with ≥2 sessions', true)
+
+  // 4. Prompt session B (instant answer) while A is still streaming.
+  await type(PROMPT_B)
+  term.write('\r')
+  await waitFor(() => screen.hasLine('BRAVO'), 120000, 'BRAVO from session B')
+  check('session B answered (BRAVO) via its own session', true)
+
+  // 5. At this moment A's tab must show ● — still running in the background.
+  check('session A still background-running (● on its tab) when B answered',
+    row0().includes('●'), row0().includes('●') ? '' : `row0: ${row0()}`)
+
+  // 6. A's completion badge (✓) must appear on its tab while it is parked —
+  //    proof the background session kept running and its idle edge was tracked.
+  let badge = true
+  try {
+    await waitFor(() => row0().includes('✓'), 240000, '✓ completion badge on tab A')
+  } catch {
+    badge = false
+  }
+  check('background completion badge (✓) raised on session A tab', badge, badge ? '' : `row0: ${row0()}`)
+
+  // 7. Click session A's tab (first tab, row 1): transcript survived intact
+  //    and its full stream completed in the background.
+  term.write(SGR_CLICK(3, 1))
+  await waitFor(() => screen.screenText().includes('ZEPHYR'), 15000, 'switch to tab A')
+  check('click switches to session A; transcript intact', true)
+  let fullStream = true
+  try {
+    // The echoed user prompt also contains "ZEPHYR 150", so require the tail
+    // neighbor "ZEPHYR 149" too — only the real stream can produce it.
+    await waitFor(
+      () => screen.screenText().includes('ZEPHYR 149') && screen.screenText().includes('ZEPHYR 150'),
+      15000, 'ZEPHYR 149..150 visible')
+  } catch {
+    fullStream = false
+  }
+  check('session A completed its full stream (ZEPHYR 150)', fullStream)
+  // Viewing the tab clears the completion badge.
+  let badgeCleared = true
+  try {
+    await waitFor(() => !row0().includes('✓'), 10000, '✓ badge cleared on view')
+  } catch {
+    badgeCleared = false
+  }
+  check('✓ badge cleared after viewing tab A', badgeCleared, badgeCleared ? '' : `row0: ${row0()}`)
+
+  // 8. Click session B's tab: compute its column from row 0's layout — the
+  //    region between the first │ separator and the next one (or the + cell).
+  const strip = row0()
+  const sep1 = strip.indexOf('│')
+  const tabBStart = sep1 + 2 // 0-based index right after " │ "
+  let tabBEnd = strip.indexOf('│', tabBStart)
+  const plus = strip.indexOf('+', tabBStart)
+  if (tabBEnd < 0 || (plus >= 0 && plus < tabBEnd)) tabBEnd = plus
+  if (tabBEnd < 0) tabBEnd = strip.length
+  const tabBCol = tabBStart + Math.max(1, Math.floor((tabBEnd - tabBStart) / 2)) + 1 // 1-based
+  console.log(`tab B click target: col ${tabBCol} (strip: "${strip}")`)
+  term.write(SGR_CLICK(tabBCol, 1))
+  let bravoBack = true
+  try {
+    await waitFor(() => screen.hasLine('BRAVO'), 15000, 'switch back to tab B')
+  } catch {
+    bravoBack = false
+  }
+  check('switch back to session B keeps its answer', bravoBack)
+} catch (err) {
+  console.error(`e2e aborted: ${err.message}`)
+  failures.push('aborted')
+} finally {
+  term.write('\x03')
+  await sleep(500)
+  term.kill()
+}
+
+if (failures.length > 0) {
+  console.log('\n--- virtual screen at failure ---')
+  console.log(screen.grid.map((_, r) => `${String(r).padStart(2)}|${screen.rowText(r)}`).join('\n'))
+}
+console.log(failures.length === 0 ? '\nE2E OK' : `\nE2E FAILED: ${failures.join(', ')}`)
+process.exit(failures.length === 0 ? 0 : 1)

--- a/src/acp.rs
+++ b/src/acp.rs
@@ -5,7 +5,7 @@
 //! Transcript paint comes from `session/update`. Negotiated Cordis TUI
 //! compositor state arrives as `_dsh/cordis/tui/*` extension notifications.
 
-use std::collections::VecDeque;
+use std::collections::{HashMap, VecDeque};
 use std::sync::mpsc::{Receiver, Sender};
 use std::sync::{Arc, Mutex};
 
@@ -230,6 +230,73 @@ struct PromptFinish {
     parked_on_auth: ParkedPrompt,
 }
 
+/// Per-session turn state on one shared ACP connection. The server allows one
+/// in-flight `session/prompt` per session, so every bound session gets its own
+/// handle; completions are demultiplexed by the id inside `PromptFinish`.
+#[derive(Default)]
+struct SessionHandle {
+    /// Occupancy marker for the in-flight `session/prompt` task. The task
+    /// reports through the prompt-done channel, so the handle is only ever
+    /// cleared, never awaited.
+    inflight: Option<tokio::task::JoinHandle<()>>,
+    /// Follow-ups waiting for this session's active turn to settle.
+    queue: VecDeque<Cmd>,
+    /// `session/cancel` was sent for the in-flight prompt; its finish is
+    /// reported as an interruption, not a turn result.
+    turn_aborted: bool,
+}
+
+/// Resolve the session a command addresses: the id the UI carried, or the
+/// most recently bound session when the field is empty (backward compat).
+/// Before the first session exists, any carried id is a local placeholder
+/// with no server meaning yet, so it resolves to "no session" like an empty
+/// field. Once sessions exist, an id this connection never bound is rejected
+/// instead of silently rerouted to another session. `kind` names the command
+/// in the rejection so the UI notice says what was dropped.
+fn resolve_cmd_session(
+    sessions: &HashMap<String, SessionHandle>,
+    current: &Option<SessionId>,
+    cmd_session: &str,
+    kind: &str,
+) -> std::result::Result<Option<SessionId>, String> {
+    if cmd_session.is_empty() {
+        return Ok(current.clone());
+    }
+    if sessions.contains_key(cmd_session) {
+        return Ok(Some(SessionId::new(cmd_session)));
+    }
+    if sessions.is_empty() {
+        return Ok(None);
+    }
+    Err(format!("{kind}: unknown session {cmd_session}"))
+}
+
+/// Register a freshly created or loaded session, make it the fallback target
+/// for commands that arrive without a usable session id, and adopt any
+/// prompts that queued up before the first session existed.
+fn bind_session(
+    sessions: &mut HashMap<String, SessionHandle>,
+    current: &mut Option<SessionId>,
+    pending: &mut VecDeque<Cmd>,
+    sid: SessionId,
+) {
+    let handle = sessions.entry(sid.to_string()).or_default();
+    handle.queue.append(pending);
+    *current = Some(sid);
+}
+
+/// Point a prompt-like command at a freshly bound session: the id the UI
+/// carried was a pre-bind placeholder with no server meaning yet.
+fn retarget_session(cmd: &mut Cmd, sid: &SessionId) {
+    match cmd {
+        Cmd::Prompt { session_id, .. }
+        | Cmd::Steer { session_id, .. }
+        | Cmd::PromptImages { session_id, .. }
+        | Cmd::SteerImages { session_id, .. } => *session_id = sid.to_string(),
+        _ => {}
+    }
+}
+
 struct SteerFinish {
     message_id: u64,
     result: Result<agent_client_protocol::schema::v1::PromptResponse, AcpError>,
@@ -251,7 +318,8 @@ fn spawn_session_prompt(
     sid: SessionId,
     content: Vec<ContentBlock>,
     parked_on_auth: ParkedPrompt,
-) -> tokio::task::JoinHandle<PromptFinish> {
+    done: tokio::sync::mpsc::UnboundedSender<PromptFinish>,
+) -> tokio::task::JoinHandle<()> {
     tokio::spawn(async move {
         let _ = bus.send(AppEvent::Ui(crate::events::UiEvent::TurnStart {
             session: sid.to_string(),
@@ -268,11 +336,11 @@ fn spawn_session_prompt(
             .send_request(PromptRequest::new(sid.clone(), content))
             .block_task()
             .await;
-        PromptFinish {
+        let _ = done.send(PromptFinish {
             session_id: sid.to_string(),
             result,
             parked_on_auth,
-        }
+        });
     })
 }
 
@@ -295,6 +363,7 @@ fn spawn_steer_prompt(
     });
 }
 
+#[allow(clippy::too_many_arguments)]
 fn begin_prompt(
     cmd: Cmd,
     cx: &ConnectionTo<Agent>,
@@ -305,7 +374,8 @@ fn begin_prompt(
     selected: Option<&AuthMethodInfo>,
     surface: &Arc<Mutex<Surface>>,
     workspace: &str,
-) -> Option<tokio::task::JoinHandle<PromptFinish>> {
+    done: &tokio::sync::mpsc::UnboundedSender<PromptFinish>,
+) -> Option<tokio::task::JoinHandle<()>> {
     match cmd {
         Cmd::Prompt { text, .. } => {
             let Some(sid) = session_id.clone() else {
@@ -324,6 +394,7 @@ fn begin_prompt(
                 sid,
                 vec![text.clone().into()],
                 ParkedPrompt::Text(text),
+                done.clone(),
             ))
         }
         Cmd::Steer { text, .. } => {
@@ -343,6 +414,7 @@ fn begin_prompt(
                 sid,
                 vec![text.clone().into()],
                 ParkedPrompt::Text(text),
+                done.clone(),
             ))
         }
         Cmd::PromptImages { blocks, .. } => {
@@ -368,6 +440,7 @@ fn begin_prompt(
                     sid,
                     content,
                     parked_on_auth,
+                    done.clone(),
                 )),
                 Ok(_) => {
                     let _ = bus.send(AppEvent::Ctl(CtlEvent::Error("empty image prompt".into())));
@@ -402,6 +475,7 @@ fn begin_prompt(
                     sid,
                     content,
                     parked_on_auth,
+                    done.clone(),
                 )),
                 Ok(_) => {
                     let _ = bus.send(AppEvent::Ctl(CtlEvent::Error("empty image prompt".into())));
@@ -414,6 +488,52 @@ fn begin_prompt(
             }
         }
         _ => None,
+    }
+}
+
+/// Start queued prompts whose session is free. Each session runs at most one
+/// in-flight `session/prompt`; a busy session simply keeps its FIFO.
+#[allow(clippy::too_many_arguments)]
+fn drain_ready_sessions(
+    sessions: &mut HashMap<String, SessionHandle>,
+    cx: &ConnectionTo<Agent>,
+    bus: &Sender<AppEvent>,
+    parked: &mut Option<ParkedPrompt>,
+    methods: &[AuthMethodInfo],
+    selected: Option<&AuthMethodInfo>,
+    surface: &Arc<Mutex<Surface>>,
+    workspace: &str,
+    done: &tokio::sync::mpsc::UnboundedSender<PromptFinish>,
+) {
+    if parked.is_some() {
+        return;
+    }
+    let keys: Vec<String> = sessions.keys().cloned().collect();
+    for key in keys {
+        let Some(handle) = sessions.get_mut(&key) else {
+            continue;
+        };
+        if handle.inflight.is_some() {
+            continue;
+        }
+        let Some(next) = handle.queue.pop_front() else {
+            continue;
+        };
+        handle.inflight = begin_prompt(
+            next,
+            cx,
+            bus,
+            &Some(SessionId::new(key.as_str())),
+            parked,
+            methods,
+            selected,
+            surface,
+            workspace,
+            done,
+        );
+        if parked.is_some() {
+            return;
+        }
     }
 }
 
@@ -1442,7 +1562,16 @@ where
                     AuthStatus::None
                 });
                 let mut session_auth_pending = false;
-                let mut session_id = match create_prompt_session(
+                // One stdio connection drives many sessions: each bound id
+                // gets its own turn state, and `current` is only the fallback
+                // target for commands that arrive without a usable id.
+                let mut sessions = HashMap::<String, SessionHandle>::new();
+                let mut current: Option<SessionId> = None;
+                // Prompt-like commands that arrived before the first session
+                // existed (sign-in still pending). They adopt the first bound
+                // session, in arrival order behind the parked intent.
+                let mut pending = VecDeque::<Cmd>::new();
+                match create_prompt_session(
                     &cx,
                     &cwd,
                     &surface,
@@ -1452,18 +1581,16 @@ where
                 )
                 .await
                 {
-                    Ok(Some(sid)) => Some(sid),
+                    Ok(Some(sid)) => bind_session(&mut sessions, &mut current, &mut pending, sid),
                     Ok(None) => {
                         session_auth_pending = true;
-                        None
                     }
                     Err(err) => {
                         let _ = bus.send(AppEvent::Ctl(CtlEvent::Error(format!(
                             "session/new: {err}"
                         ))));
-                        None
                     }
-                };
+                }
                 let _ = bus.send(AppEvent::Ctl(CtlEvent::Ready { server: agent_name }));
                 let mut parked: Option<ParkedPrompt> = None;
 
@@ -1479,16 +1606,15 @@ where
                     })
                     .map_err(|err| AcpError::new(-32603, err.to_string()))?;
 
-                let mut inflight: Option<tokio::task::JoinHandle<PromptFinish>> = None;
-                let mut prompt_queue = VecDeque::<Cmd>::new();
+                let (prompt_done_tx, mut prompt_done_rx) =
+                    tokio::sync::mpsc::unbounded_channel::<PromptFinish>();
                 let (steer_done_tx, mut steer_done_rx) =
                     tokio::sync::mpsc::unbounded_channel::<SteerFinish>();
-                let mut turn_aborted = false;
                 loop {
                     tokio::select! {
                         cmd = fwd_rx.recv() => {
-                            let Some(cmd) = cmd else { break };
-                            if session_id.is_none()
+                            let Some(mut cmd) = cmd else { break };
+                            if current.is_none()
                                 && parked.is_none()
                                 && parked_prompt(&cmd).is_some()
                             {
@@ -1505,7 +1631,13 @@ where
                                     selected.as_ref(),
                                 ).await {
                                     Ok(Some(sid)) => {
-                                        session_id = Some(sid);
+                                        retarget_session(&mut cmd, &sid);
+                                        bind_session(
+                                            &mut sessions,
+                                            &mut current,
+                                            &mut pending,
+                                            sid,
+                                        );
                                         session_auth_pending = false;
                                     }
                                     Ok(None) => {
@@ -1522,152 +1654,219 @@ where
                                 }
                             }
                             match cmd {
-                        Cmd::Prompt { text, .. } => {
+                        Cmd::Prompt { session_id: cmd_session, text } => {
                             let next = Cmd::Prompt {
-                                session_id: String::new(),
+                                session_id: cmd_session.clone(),
                                 text,
                             };
-                            if inflight.is_some() || parked.is_some() {
-                                prompt_queue.push_back(next);
-                            } else {
-                                inflight = begin_prompt(
-                                    next,
-                                    &cx,
-                                    &bus,
-                                    &session_id,
-                                    &mut parked,
-                                    &methods,
-                                    selected.as_ref(),
-                                    &surface,
-                                    &cfg.workspace,
-                                );
-                            }
-                        }
-                        Cmd::Steer { message_id, text, .. } => {
-                            if inflight.is_some() {
-                                if let Some(sid) = session_id.clone() {
-                                    spawn_steer_prompt(
-                                        cx.clone(),
-                                        sid,
-                                        vec![text.into()],
-                                        message_id,
-                                        steer_done_tx.clone(),
-                                    );
-                                }
-                            } else if parked.is_some() {
-                                let _ = bus.send(AppEvent::Ctl(CtlEvent::SteerSettled {
-                                    message_id,
-                                    deferred: true,
-                                }));
-                            } else {
-                                inflight = begin_prompt(
-                                    Cmd::Steer {
-                                        session_id: String::new(),
-                                        message_id,
-                                        text,
-                                    },
-                                    &cx,
-                                    &bus,
-                                    &session_id,
-                                    &mut parked,
-                                    &methods,
-                                    selected.as_ref(),
-                                    &surface,
-                                    &cfg.workspace,
-                                );
-                                let _ = bus.send(AppEvent::Ctl(CtlEvent::SteerSettled {
-                                    message_id,
-                                    deferred: false,
-                                }));
-                            }
-                        }
-                        Cmd::PromptImages { blocks, .. } => {
-                            let next = Cmd::PromptImages {
-                                session_id: String::new(),
-                                blocks,
-                            };
-                            if inflight.is_some() || parked.is_some() {
-                                prompt_queue.push_back(next);
-                            } else {
-                                inflight = begin_prompt(
-                                    next,
-                                    &cx,
-                                    &bus,
-                                    &session_id,
-                                    &mut parked,
-                                    &methods,
-                                    selected.as_ref(),
-                                    &surface,
-                                    &cfg.workspace,
-                                );
-                            }
-                        }
-                        Cmd::SteerImages { message_id, blocks, .. } => {
-                            if inflight.is_some() {
-                                if let Some(sid) = session_id.clone() {
-                                    let prompt_image = surface
-                                        .lock()
-                                        .unwrap_or_else(|e| e.into_inner())
-                                        .prompt_image;
-                                    match prompt_content_blocks(blocks, prompt_image, &cfg.workspace) {
-                                        Ok(content) if !content.is_empty() => spawn_steer_prompt(
-                                            cx.clone(),
-                                            sid,
-                                            content,
-                                            message_id,
-                                            steer_done_tx.clone(),
-                                        ),
-                                        Ok(_) => {
-                                            let _ = bus.send(AppEvent::Ctl(CtlEvent::Error(
-                                                "empty image prompt".into(),
-                                            )));
-                                        }
-                                        Err(err) => {
-                                            let _ = bus.send(AppEvent::Ctl(CtlEvent::Error(err)));
-                                        }
+                            match resolve_cmd_session(&sessions, &current, &cmd_session, "prompt") {
+                                Ok(Some(sid)) => {
+                                    let handle = sessions.entry(sid.to_string()).or_default();
+                                    if handle.inflight.is_some() || parked.is_some() {
+                                        handle.queue.push_back(next);
+                                    } else {
+                                        handle.inflight = begin_prompt(
+                                            next,
+                                            &cx,
+                                            &bus,
+                                            &Some(sid),
+                                            &mut parked,
+                                            &methods,
+                                            selected.as_ref(),
+                                            &surface,
+                                            &cfg.workspace,
+                                            &prompt_done_tx,
+                                        );
                                     }
                                 }
-                            } else if parked.is_some() {
-                                let _ = bus.send(AppEvent::Ctl(CtlEvent::SteerSettled {
-                                    message_id,
-                                    deferred: true,
-                                }));
-                            } else {
-                                inflight = begin_prompt(
-                                    Cmd::SteerImages {
-                                        session_id: String::new(),
-                                        message_id,
-                                        blocks,
-                                    },
-                                    &cx,
-                                    &bus,
-                                    &session_id,
-                                    &mut parked,
-                                    &methods,
-                                    selected.as_ref(),
-                                    &surface,
-                                    &cfg.workspace,
-                                );
-                                let _ = bus.send(AppEvent::Ctl(CtlEvent::SteerSettled {
-                                    message_id,
-                                    deferred: false,
-                                }));
+                                Ok(None) => pending.push_back(next),
+                                Err(err) => {
+                                    let _ = bus.send(AppEvent::Ctl(CtlEvent::Error(err)));
+                                }
                             }
                         }
-                        Cmd::Interrupt { .. } => {
+                        Cmd::Steer { session_id: cmd_session, message_id, text } => {
+                            match resolve_cmd_session(&sessions, &current, &cmd_session, "steer") {
+                                Ok(Some(sid)) => {
+                                    let busy = sessions
+                                        .get(&sid.to_string())
+                                        .is_some_and(|handle| handle.inflight.is_some());
+                                    if busy {
+                                        spawn_steer_prompt(
+                                            cx.clone(),
+                                            sid,
+                                            vec![text.into()],
+                                            message_id,
+                                            steer_done_tx.clone(),
+                                        );
+                                    } else if parked.is_some() {
+                                        let _ = bus.send(AppEvent::Ctl(CtlEvent::SteerSettled {
+                                            message_id,
+                                            deferred: true,
+                                        }));
+                                    } else {
+                                        let handle = sessions.entry(sid.to_string()).or_default();
+                                        handle.inflight = begin_prompt(
+                                            Cmd::Steer {
+                                                session_id: cmd_session,
+                                                message_id,
+                                                text,
+                                            },
+                                            &cx,
+                                            &bus,
+                                            &Some(sid),
+                                            &mut parked,
+                                            &methods,
+                                            selected.as_ref(),
+                                            &surface,
+                                            &cfg.workspace,
+                                            &prompt_done_tx,
+                                        );
+                                        let _ = bus.send(AppEvent::Ctl(CtlEvent::SteerSettled {
+                                            message_id,
+                                            deferred: false,
+                                        }));
+                                    }
+                                }
+                                Ok(None) => {
+                                    let _ = bus.send(AppEvent::Ctl(CtlEvent::SteerSettled {
+                                        message_id,
+                                        deferred: true,
+                                    }));
+                                }
+                                Err(err) => {
+                                    let _ = bus.send(AppEvent::Ctl(CtlEvent::Error(err)));
+                                }
+                            }
+                        }
+                        Cmd::PromptImages { session_id: cmd_session, blocks } => {
+                            let next = Cmd::PromptImages {
+                                session_id: cmd_session.clone(),
+                                blocks,
+                            };
+                            match resolve_cmd_session(&sessions, &current, &cmd_session, "prompt_images") {
+                                Ok(Some(sid)) => {
+                                    let handle = sessions.entry(sid.to_string()).or_default();
+                                    if handle.inflight.is_some() || parked.is_some() {
+                                        handle.queue.push_back(next);
+                                    } else {
+                                        handle.inflight = begin_prompt(
+                                            next,
+                                            &cx,
+                                            &bus,
+                                            &Some(sid),
+                                            &mut parked,
+                                            &methods,
+                                            selected.as_ref(),
+                                            &surface,
+                                            &cfg.workspace,
+                                            &prompt_done_tx,
+                                        );
+                                    }
+                                }
+                                Ok(None) => pending.push_back(next),
+                                Err(err) => {
+                                    let _ = bus.send(AppEvent::Ctl(CtlEvent::Error(err)));
+                                }
+                            }
+                        }
+                        Cmd::SteerImages { session_id: cmd_session, message_id, blocks } => {
+                            match resolve_cmd_session(&sessions, &current, &cmd_session, "steer_images") {
+                                Ok(Some(sid)) => {
+                                    let busy = sessions
+                                        .get(&sid.to_string())
+                                        .is_some_and(|handle| handle.inflight.is_some());
+                                    if busy {
+                                        let prompt_image = surface
+                                            .lock()
+                                            .unwrap_or_else(|e| e.into_inner())
+                                            .prompt_image;
+                                        match prompt_content_blocks(blocks, prompt_image, &cfg.workspace) {
+                                            Ok(content) if !content.is_empty() => spawn_steer_prompt(
+                                                cx.clone(),
+                                                sid,
+                                                content,
+                                                message_id,
+                                                steer_done_tx.clone(),
+                                            ),
+                                            Ok(_) => {
+                                                let _ = bus.send(AppEvent::Ctl(CtlEvent::Error(
+                                                    "empty image prompt".into(),
+                                                )));
+                                            }
+                                            Err(err) => {
+                                                let _ = bus.send(AppEvent::Ctl(CtlEvent::Error(err)));
+                                            }
+                                        }
+                                    } else if parked.is_some() {
+                                        let _ = bus.send(AppEvent::Ctl(CtlEvent::SteerSettled {
+                                            message_id,
+                                            deferred: true,
+                                        }));
+                                    } else {
+                                        let handle = sessions.entry(sid.to_string()).or_default();
+                                        handle.inflight = begin_prompt(
+                                            Cmd::SteerImages {
+                                                session_id: cmd_session,
+                                                message_id,
+                                                blocks,
+                                            },
+                                            &cx,
+                                            &bus,
+                                            &Some(sid),
+                                            &mut parked,
+                                            &methods,
+                                            selected.as_ref(),
+                                            &surface,
+                                            &cfg.workspace,
+                                            &prompt_done_tx,
+                                        );
+                                        let _ = bus.send(AppEvent::Ctl(CtlEvent::SteerSettled {
+                                            message_id,
+                                            deferred: false,
+                                        }));
+                                    }
+                                }
+                                Ok(None) => {
+                                    let _ = bus.send(AppEvent::Ctl(CtlEvent::SteerSettled {
+                                        message_id,
+                                        deferred: true,
+                                    }));
+                                }
+                                Err(err) => {
+                                    let _ = bus.send(AppEvent::Ctl(CtlEvent::Error(err)));
+                                }
+                            }
+                        }
+                        Cmd::Interrupt { session_id: cmd_session } => {
                             // Only a live turn can be aborted. Setting the
                             // flag with no inflight prompt would poison the
                             // *next* prompt's finish (its result would be
                             // swallowed and the turn misreported as
                             // interrupted).
-                            if inflight.is_some() {
-                                abort_turn(&cx, &session_id, &bus);
-                                turn_aborted = true;
+                            match resolve_cmd_session(&sessions, &current, &cmd_session, "interrupt") {
+                                Ok(Some(sid)) => {
+                                    if let Some(handle) = sessions.get_mut(&sid.to_string()) {
+                                        if handle.inflight.is_some() {
+                                            abort_turn(&cx, &Some(sid), &bus);
+                                            handle.turn_aborted = true;
+                                        }
+                                    }
+                                }
+                                Ok(None) => {}
+                                Err(err) => {
+                                    let _ = bus.send(AppEvent::Ctl(CtlEvent::Error(err)));
+                                }
                             }
                         }
-                        Cmd::SelectModel { model, effort, .. } => {
-                            let Some(sid) = session_id.clone() else {
-                                continue;
+                        Cmd::SelectModel { session_id: cmd_session, model, effort, .. } => {
+                            let sid = match resolve_cmd_session(&sessions, &current, &cmd_session, "select_model") {
+                                Ok(Some(sid)) => sid,
+                                Ok(None) => continue,
+                                Err(err) => {
+                                    let _ = bus.send(AppEvent::Ctl(CtlEvent::Error(err)));
+                                    continue;
+                                }
                             };
                             if let Some(model) = model {
                                 let value = {
@@ -1938,9 +2137,14 @@ where
                                 default: efforts.first().cloned(),
                             }));
                         }
-                        Cmd::SetPermission { preset, .. } => {
-                            let Some(sid) = session_id.clone() else {
-                                continue;
+                        Cmd::SetPermission { session_id: cmd_session, preset } => {
+                            let sid = match resolve_cmd_session(&sessions, &current, &cmd_session, "set_permission") {
+                                Ok(Some(sid)) => sid,
+                                Ok(None) => continue,
+                                Err(err) => {
+                                    let _ = bus.send(AppEvent::Ctl(CtlEvent::Error(err)));
+                                    continue;
+                                }
                             };
                             match cx
                                 .send_request(SetSessionModeRequest::new(sid.clone(), preset.clone()))
@@ -1975,9 +2179,14 @@ where
                                 }
                             }
                         }
-                        Cmd::SetPreset { preset, .. } => {
-                            let Some(sid) = session_id.clone() else {
-                                continue;
+                        Cmd::SetPreset { session_id: cmd_session, preset } => {
+                            let sid = match resolve_cmd_session(&sessions, &current, &cmd_session, "set_preset") {
+                                Ok(Some(sid)) => sid,
+                                Ok(None) => continue,
+                                Err(err) => {
+                                    let _ = bus.send(AppEvent::Ctl(CtlEvent::Error(err)));
+                                    continue;
+                                }
                             };
                             let config_id = surface
                                 .lock()
@@ -2025,7 +2234,8 @@ where
                         Cmd::SetConfigOption {
                             config_id, value, ..
                         } => {
-                            let Some(sid) = session_id.clone() else {
+                            // Carries no session id; address the fallback session.
+                            let Some(sid) = current.clone() else {
                                 continue;
                             };
                             match cx
@@ -2114,7 +2324,7 @@ where
                             }
                             match cx.send_request(req).block_task().await {
                                 Ok(_) => {
-                                    if session_id.is_none() {
+                                    if current.is_none() {
                                         match create_prompt_session(
                                             &cx,
                                             &cwd,
@@ -2126,7 +2336,12 @@ where
                                         .await
                                         {
                                             Ok(Some(sid)) => {
-                                                session_id = Some(sid);
+                                                bind_session(
+                                                    &mut sessions,
+                                                    &mut current,
+                                                    &mut pending,
+                                                    sid,
+                                                );
                                                 session_auth_pending = false;
                                             }
                                             Ok(None) => {
@@ -2152,14 +2367,14 @@ where
                                             )));
                                         }
                                         Some(prompt) => {
-                                            let Some(sid) = session_id.clone() else {
+                                            let Some(sid) = current.clone() else {
                                                 parked = Some(prompt);
                                                 let _ = bus.send(AppEvent::Ctl(CtlEvent::TuiOpDone(
                                                     "signed in — resend from the composer".into(),
                                                 )));
                                                 continue;
                                             };
-                                            prompt_queue.push_front(match prompt {
+                                            let retry = match prompt {
                                                 ParkedPrompt::Text(text) => Cmd::Prompt {
                                                     session_id: sid.to_string(),
                                                     text,
@@ -2168,7 +2383,12 @@ where
                                                     session_id: sid.to_string(),
                                                     blocks,
                                                 },
-                                            });
+                                            };
+                                            sessions
+                                                .entry(sid.to_string())
+                                                .or_default()
+                                                .queue
+                                                .push_front(retry);
                                             let _ = bus.send(AppEvent::Ctl(CtlEvent::TuiOpDone(
                                                 "signed in — retried the parked prompt".into(),
                                             )));
@@ -2199,7 +2419,12 @@ where
                                 .await
                             {
                                 Ok(created) => {
-                                    session_id = Some(created.session_id.clone());
+                                    bind_session(
+                                        &mut sessions,
+                                        &mut current,
+                                        &mut pending,
+                                        created.session_id.clone(),
+                                    );
                                     session_auth_pending = false;
                                     apply_created(
                                         &created,
@@ -2278,7 +2503,12 @@ where
                                 .await
                             {
                                 Ok(loaded) => {
-                                    session_id = Some(sid.clone());
+                                    bind_session(
+                                        &mut sessions,
+                                        &mut current,
+                                        &mut pending,
+                                        sid.clone(),
+                                    );
                                     emit_session_bound(
                                         &bus,
                                         &sid,
@@ -2365,21 +2595,17 @@ where
                         }
                         Cmd::Shutdown => break,
                     }
-                            if inflight.is_none() && parked.is_none() {
-                                if let Some(next) = prompt_queue.pop_front() {
-                                    inflight = begin_prompt(
-                                        next,
-                                        &cx,
-                                        &bus,
-                                        &session_id,
-                                        &mut parked,
-                                        &methods,
-                                        selected.as_ref(),
-                                        &surface,
-                                        &cfg.workspace,
-                                    );
-                                }
-                            }
+                            drain_ready_sessions(
+                                &mut sessions,
+                                &cx,
+                                &bus,
+                                &mut parked,
+                                &methods,
+                                selected.as_ref(),
+                                &surface,
+                                &cfg.workspace,
+                                &prompt_done_tx,
+                            );
                         }
                         steer = steer_done_rx.recv() => {
                             if let Some(SteerFinish { message_id, result }) = steer {
@@ -2389,75 +2615,66 @@ where
                                     deferred,
                                 }));
                             }
-                            if inflight.is_none() && parked.is_none() {
-                                if let Some(next) = prompt_queue.pop_front() {
-                                    inflight = begin_prompt(
-                                        next,
-                                        &cx,
-                                        &bus,
-                                        &session_id,
-                                        &mut parked,
-                                        &methods,
-                                        selected.as_ref(),
-                                        &surface,
-                                        &cfg.workspace,
-                                    );
-                                }
-                            }
+                            drain_ready_sessions(
+                                &mut sessions,
+                                &cx,
+                                &bus,
+                                &mut parked,
+                                &methods,
+                                selected.as_ref(),
+                                &surface,
+                                &cfg.workspace,
+                                &prompt_done_tx,
+                            );
                         }
-                        finish = async {
-                            match &mut inflight {
-                                Some(h) => Some(h.await),
-                                None => std::future::pending().await,
+                        finish = prompt_done_rx.recv() => {
+                            let Some(done) = finish else { continue };
+                            let key = done.session_id.clone();
+                            let mut aborted = false;
+                            if let Some(handle) = sessions.get_mut(&key) {
+                                handle.inflight = None;
+                                aborted = std::mem::take(&mut handle.turn_aborted);
                             }
-                        } => {
-                            inflight = None;
-                            let aborted = std::mem::take(&mut turn_aborted);
                             if aborted {
-                                if let Some(sid) = &session_id {
-                                    let _ = bus.send(AppEvent::Ui(
-                                        crate::events::UiEvent::TurnEnd {
-                                            session: sid.to_string(),
-                                            kind: "interrupted".into(),
-                                        },
-                                    ));
-                                }
-                                let _ = bus.send(AppEvent::Ctl(CtlEvent::Interrupted));
-                            }
-                            match finish {
-                                Some(Ok(done)) if !aborted => apply_prompt_finish(
+                                let _ = bus.send(AppEvent::Ui(
+                                    crate::events::UiEvent::TurnEnd {
+                                        session: key.clone(),
+                                        kind: "interrupted".into(),
+                                    },
+                                ));
+                                let _ = bus.send(AppEvent::Ctl(CtlEvent::Interrupted {
+                                    session_id: key.clone(),
+                                }));
+                            } else {
+                                apply_prompt_finish(
                                     done,
                                     &mut parked,
                                     &bus,
                                     &methods,
                                     selected.as_ref(),
-                                ),
-                                Some(Ok(_)) => {}
-                                Some(Err(err)) if !aborted => {
-                                    let _ = bus.send(AppEvent::Ctl(CtlEvent::Error(format!(
-                                        "prompt task: {err}"
-                                    ))));
-                                }
-                                Some(Err(_)) | None => {}
+                                );
                             }
                             if parked.is_none() {
-                                if let Some(next) = prompt_queue.pop_front() {
-                                    inflight = begin_prompt(
-                                        next,
+                                let queued = sessions
+                                    .get(&key)
+                                    .is_some_and(|handle| !handle.queue.is_empty());
+                                if queued {
+                                    drain_ready_sessions(
+                                        &mut sessions,
                                         &cx,
                                         &bus,
-                                        &session_id,
                                         &mut parked,
                                         &methods,
                                         selected.as_ref(),
                                         &surface,
                                         &cfg.workspace,
+                                        &prompt_done_tx,
                                     );
-                                } else if let Some(sid) = &session_id {
+                                } else {
                                     let _ = bus.send(AppEvent::Rpc {
                                         method: "session.status".into(),
                                         params: json!({
-                                            "sessionId": sid.to_string(),
+                                            "sessionId": key,
                                             "status": "idle"
                                         }),
                                     });

--- a/src/acp.rs
+++ b/src/acp.rs
@@ -18,6 +18,7 @@ use agent_client_protocol::schema::v1::{
     ClientSessionCapabilities, ContentBlock, CreateElicitationRequest, CreateElicitationResponse,
     CreateTerminalRequest, CreateTerminalResponse, ElicitationAcceptAction, ElicitationAction,
     ElicitationCapabilities, ElicitationContentValue, ElicitationFormCapabilities,
+    ElicitationScope,
     FileSystemCapabilities, ImageContent, Implementation, InitializeRequest, KillTerminalRequest,
     KillTerminalResponse, ListSessionsRequest, LoadSessionRequest, NewSessionRequest,
     PermissionOptionKind, PromptRequest, ReadTextFileRequest, ReadTextFileResponse,
@@ -1190,6 +1191,7 @@ where
                 let (tx, rx) = tokio::sync::oneshot::channel();
                 if bus_p
                     .send(AppEvent::PermissionAsk {
+                        session_id: req.session_id.to_string(),
                         title,
                         options,
                         reply: tx,
@@ -1217,6 +1219,13 @@ where
         )
         .on_receive_request(
             async move |req: CreateElicitationRequest, responder, _cx| {
+                let session_id = match req.scope() {
+                    ElicitationScope::Session(scope) => Some(scope.session_id.to_string()),
+                    // Auth/config-phase elicitation (or a future scope kind)
+                    // has no session to attach to; the client shows it on
+                    // the live view.
+                    _ => None,
+                };
                 let form = match crate::elicitation::form_from_request(&req) {
                     Ok(form) => form,
                     Err(err) => {
@@ -1225,7 +1234,11 @@ where
                 };
                 let (tx, rx) = tokio::sync::oneshot::channel();
                 if bus_e
-                    .send(AppEvent::ElicitationAsk { form, reply: tx })
+                    .send(AppEvent::ElicitationAsk {
+                        session_id,
+                        form,
+                        reply: tx,
+                    })
                     .is_err()
                 {
                     return responder.respond(CreateElicitationResponse::new(
@@ -1306,6 +1319,7 @@ where
                 let bus = bus_write;
                 let workspace = workspace_write;
                 async move |req: WriteTextFileRequest, responder, _cx| {
+                    let session_id = req.session_id.to_string();
                     let path = crate::acp_fs::resolve_with_cwd(
                         &req.path,
                         std::path::Path::new(&workspace),
@@ -1317,7 +1331,7 @@ where
                         let allowed = if crate::acp_fs::is_inside_cwd(&path, &workspace) {
                             true
                         } else {
-                            crate::acp_fs::confirm_write_outside(&bus, &path).await
+                            crate::acp_fs::confirm_write_outside(&bus, &session_id, &path).await
                         };
                         let result = if allowed {
                             crate::acp_fs::write_text_file(&path, &content)

--- a/src/acp_fs.rs
+++ b/src/acp_fs.rs
@@ -85,7 +85,12 @@ pub fn write_text_file(path: &Path, content: &str) -> Result<(), AcpError> {
 }
 
 /// Ask through the existing permission overlay: AllowOnce vs reject.
-pub async fn confirm_write_outside(bus: &Sender<AppEvent>, path: &Path) -> bool {
+/// The ask is tagged with `session_id` so it follows that session's tab.
+pub async fn confirm_write_outside(
+    bus: &Sender<AppEvent>,
+    session_id: &str,
+    path: &Path,
+) -> bool {
     let (tx, rx) = tokio::sync::oneshot::channel();
     let options = vec![
         PermissionAskOption {
@@ -101,6 +106,7 @@ pub async fn confirm_write_outside(bus: &Sender<AppEvent>, path: &Path) -> bool 
     ];
     if bus
         .send(AppEvent::PermissionAsk {
+            session_id: session_id.into(),
             title: format!("write {} · outside workspace", path.display()),
             options,
             reply: tx,

--- a/src/app.rs
+++ b/src/app.rs
@@ -5642,6 +5642,11 @@ impl App {
     }
 
     fn load_acp_session(&mut self, id: &str, ctl: &Controller) {
+        // The welcome banner only ever paints instead of the transcript, so
+        // any path that (re)loads real history must dismiss it — the local
+        // `resume_session` does the same. Without this, a /resume before the
+        // first prompt left the banner covering the whole replayed chat.
+        self.show_banner = false;
         if self.session_id == id {
             // Reloading the viewed session: reset its UI and re-stream.
             self.reset_session_ui();

--- a/src/app.rs
+++ b/src/app.rs
@@ -792,18 +792,6 @@ pub struct SessionTab {
     pub current: bool,
 }
 
-/// Right-click tab popup. Phase 1 has a single Close item; new items extend
-/// [`TabMenuItem`] and the painter's item list together.
-pub(crate) struct TabMenu {
-    pub tab: usize,
-    pub at: (u16, u16),
-}
-
-#[derive(Clone, Copy, PartialEq, Eq)]
-pub(crate) enum TabMenuItem {
-    Close,
-}
-
 pub(crate) const AGENT_HISTORY_ID: &str = "__martty_internal__:agent-history";
 
 /// Overlay for one ACP `session/request_permission` ask.
@@ -1186,12 +1174,6 @@ pub struct App {
     awaiting_binds: VecDeque<String>,
     /// Tab strip hit-test rects, recorded by `ui::draw_session_tabs`.
     pub(crate) tab_rects: Vec<(ratatui::layout::Rect, usize)>,
-    /// The tab strip `+` cell's rect from the latest frame.
-    pub(crate) plus_rect: Option<ratatui::layout::Rect>,
-    /// Open right-click tab popup.
-    pub(crate) tab_menu: Option<TabMenu>,
-    /// The popup's frame rect from the latest draw (item hit-testing).
-    pub(crate) tab_menu_rect: Option<ratatui::layout::Rect>,
     pub cfg: RuntimeConfig,
     /// Model explicitly picked this session (`/model`); wins over
     /// `transcript.last_model` in the chip until a turn realizes it.
@@ -1578,9 +1560,6 @@ impl App {
             current: 0,
             awaiting_binds: VecDeque::new(),
             tab_rects: Vec::new(),
-            plus_rect: None,
-            tab_menu: None,
-            tab_menu_rect: None,
             cfg,
             selected_model: None,
             demo,
@@ -1742,39 +1721,6 @@ impl App {
         })
     }
 
-    /// Close a tab locally (issue #94): nothing is sent to the agent — ACP
-    /// has no session/close — the session simply stops being viewed and its
-    /// updates drop at the router. Never removes the last remaining tab.
-    fn close_session(&mut self, tab: usize) {
-        let total = self.parked.len() + 1;
-        if total < 2 || tab >= total {
-            return;
-        }
-        let doomed = if tab == self.current {
-            self.session_id.clone()
-        } else {
-            let pidx = if tab < self.current { tab } else { tab - 1 };
-            match self.parked.get(pidx) {
-                Some(slot) => slot.id.clone(),
-                None => return,
-            }
-        };
-        if tab == self.current {
-            // View a neighbor first; the doomed state parks at the old spot.
-            let neighbor = if tab + 1 < total { tab + 1 } else { tab - 1 };
-            self.switch_to_session(neighbor);
-        }
-        if let Some(pidx) = self.parked.iter().position(|slot| slot.id == doomed) {
-            self.parked.remove(pidx);
-            let removed_tab = if pidx < self.current { pidx } else { pidx + 1 };
-            if removed_tab < self.current {
-                self.current -= 1;
-            }
-        }
-        self.awaiting_binds.retain(|id| *id != doomed);
-        self.needs_redraw = true;
-    }
-
     /// Tab strip model: every session in tab order with the live tab
     /// spliced in at `current`. Native status chrome fed by session status
     /// facts (same source as `state_line`, never the palette/slot systems).
@@ -1822,25 +1768,6 @@ impl App {
                 col >= rect.x && col < rect.right() && row >= rect.y && row < rect.bottom()
             })
             .map(|(_, idx)| *idx)
-    }
-
-    /// Hit-test a screen cell against the tab strip `+` cell.
-    fn plus_hit(&self, col: u16, row: u16) -> bool {
-        self.plus_rect.is_some_and(|rect| {
-            col >= rect.x && col < rect.right() && row >= rect.y && row < rect.bottom()
-        })
-    }
-
-    /// Hit-test a screen cell against the open tab popup's items.
-    fn tab_menu_item_at(&self, col: u16, row: u16) -> Option<TabMenuItem> {
-        let rect = self.tab_menu_rect?;
-        if col < rect.x || col >= rect.right() {
-            return None;
-        }
-        match row.checked_sub(rect.y + 1) {
-            Some(0) => Some(TabMenuItem::Close),
-            _ => None,
-        }
     }
 
     /// Was this session mid-turn (live RunState, or a parked slot's running
@@ -3556,34 +3483,14 @@ impl App {
             }
             MouseEventKind::Down(MouseButton::Left) => {
                 self.needs_redraw = true;
-                // Session tab strip (issue #94): left-click a tab switches,
-                // `+` opens a fresh session, and an open tab popup consumes
-                // the click (item pick or dismiss).
+                // Session tab strip (issue #94): left-click a tab switches.
                 if let Some(tab) = self.tab_at(mouse.column, mouse.row) {
                     self.sel = None;
                     self.selecting = false;
                     self.last_click = None;
                     self.input_sel = None;
                     self.input_selecting = false;
-                    self.tab_menu = None;
                     self.switch_to_session(tab);
-                    return;
-                }
-                if self.plus_hit(mouse.column, mouse.row) {
-                    self.sel = None;
-                    self.selecting = false;
-                    self.last_click = None;
-                    self.input_sel = None;
-                    self.input_selecting = false;
-                    self.tab_menu = None;
-                    self.new_session_flow("", ctl);
-                    return;
-                }
-                if let Some(menu) = self.tab_menu.take() {
-                    if self.tab_menu_item_at(mouse.column, mouse.row) == Some(TabMenuItem::Close) {
-                        self.close_session(menu.tab);
-                    }
-                    self.needs_redraw = true;
                     return;
                 }
                 if let Some(action) = self
@@ -3714,19 +3621,6 @@ impl App {
             MouseEventKind::Up(MouseButton::Left) if self.input_selecting => {
                 self.input_selecting = false;
                 self.finish_input_selection();
-            }
-            MouseEventKind::Down(MouseButton::Right) => {
-                // Right-click a session tab: popup with local tab actions
-                // (Close; structured so more items slot in later).
-                if let Some(tab) = self.tab_at(mouse.column, mouse.row) {
-                    self.tab_menu = Some(TabMenu {
-                        tab,
-                        at: (mouse.column, mouse.row),
-                    });
-                } else {
-                    self.tab_menu = None;
-                }
-                self.needs_redraw = true;
             }
             MouseEventKind::Moved => {
                 // grok-style hover: track which inline chip the pointer is

--- a/src/app.rs
+++ b/src/app.rs
@@ -758,6 +758,22 @@ pub struct SessionSlot {
     pub next_subagent_starts_batch: bool,
     pub active_subagent: Option<String>,
     pub agent_selection: Option<String>,
+    /// A session-bound ACP ask (permission or elicitation) that arrived
+    /// while this session was out of view — or that was on screen when the
+    /// user switched away. Asks follow their session: only the live tab
+    /// renders and answers them, switching never cancels one, and the tab
+    /// strip marks a tab with a pending ask.
+    pub permission_ask: Option<PermissionAskOverlay>,
+    pub elicitation_ask: Option<ElicitationAskOverlay>,
+    /// Painter-owned info popup (`/help`, `/keys`, `/session`, painter
+    /// `/status` — `notify_plugin == false`) parked with its session: it
+    /// leaves the screen on a switch and resurfaces, scroll and all, when
+    /// the user returns. Compositor-owned plugin views never park — the
+    /// tab-click path cancels them instead (see `cancel_plugin_overlays`).
+    pub view_overlay: Option<ViewOverlay>,
+    /// `/plugins` / `/cordis-plugins` inventory tree (selection state
+    /// included) parked with its session like the info popups.
+    pub plugin_tree: Option<PluginTree>,
 }
 
 impl SessionSlot {
@@ -780,6 +796,10 @@ impl SessionSlot {
             next_subagent_starts_batch: true,
             active_subagent: None,
             agent_selection: None,
+            permission_ask: None,
+            elicitation_ask: None,
+            view_overlay: None,
+            plugin_tree: None,
         }
     }
 }
@@ -789,6 +809,9 @@ pub struct SessionTab {
     pub label: String,
     pub running: bool,
     pub completed_unseen: bool,
+    /// A session-bound ACP ask (permission/elicitation) is pending on this
+    /// tab — the agent is waiting for an answer only this tab can give.
+    pub ask_pending: bool,
     pub current: bool,
 }
 
@@ -1628,6 +1651,14 @@ impl App {
             next_subagent_starts_batch: std::mem::replace(&mut self.next_subagent_starts_batch, true),
             active_subagent: self.active_subagent.take(),
             agent_selection: self.agent_selection.take(),
+            permission_ask: self.permission_ask.take(),
+            elicitation_ask: self.elicitation_ask.take(),
+            // Painter info popups ride along with their session; plugin
+            // views are filtered out (a compositor overlay must never be
+            // resurrected stale on another tab — the tab-click path
+            // cancels it before the switch, anything left here is dropped).
+            view_overlay: self.view_overlay.take().filter(|view| !view.notify_plugin),
+            plugin_tree: self.plugin_tree.take(),
         }
     }
 
@@ -1649,6 +1680,14 @@ impl App {
         self.next_subagent_starts_batch = slot.next_subagent_starts_batch;
         self.active_subagent = slot.active_subagent;
         self.agent_selection = slot.agent_selection;
+        // A session-bound ask rides along with its session: an ask that was
+        // open when the user left this tab (or that arrived while parked)
+        // resurfaces here, untouched, ready to answer or Esc away.
+        self.permission_ask = slot.permission_ask;
+        self.elicitation_ask = slot.elicitation_ask;
+        // Painter popups and the /plugins tree resurface the same way.
+        self.view_overlay = slot.view_overlay;
+        self.plugin_tree = slot.plugin_tree;
         self.state = if slot.running || slot.prompt_pending {
             RunState::Running
         } else {
@@ -1736,6 +1775,7 @@ impl App {
                     .unwrap_or_else(|| short_id(&slot.id)),
                 running: slot.running || slot.prompt_pending,
                 completed_unseen: slot.completed_unseen,
+                ask_pending: slot.permission_ask.is_some() || slot.elicitation_ask.is_some(),
                 current: false,
             })
             .collect();
@@ -1749,6 +1789,7 @@ impl App {
                     .unwrap_or_else(|| short_id(&self.session_id)),
                 running: self.state != RunState::Idle || self.prompt_pending,
                 completed_unseen: false,
+                ask_pending: self.permission_ask.is_some() || self.elicitation_ask.is_some(),
                 current: true,
             },
         );
@@ -2840,9 +2881,20 @@ impl App {
                                 self.view_overlay = None;
                             }
                             None => {
+                                // The plugin's overlay closed (dispatch ack
+                                // or plugin-side close). Only compositor
+                                // surfaces go with it: a painter popup that
+                                // was parked/restored by a tab switch in the
+                                // meantime must survive the ack.
                                 self.slider_overlay = None;
                                 self.select_overlay = None;
-                                self.view_overlay = None;
+                                if self
+                                    .view_overlay
+                                    .as_ref()
+                                    .is_some_and(|view| view.notify_plugin)
+                                {
+                                    self.view_overlay = None;
+                                }
                             }
                         },
                         Ok(_) => {}
@@ -3213,19 +3265,19 @@ impl App {
                 self.needs_redraw = true;
             }
             AppEvent::PermissionAsk {
+                session_id,
                 title,
                 options,
                 reply,
             } => {
-                self.open_permission_ask(title, options, reply);
+                self.open_permission_ask(&session_id, title, options, reply);
             }
-            AppEvent::ElicitationAsk { form, reply } => {
-                self.elicitation_ask = Some(ElicitationAskOverlay {
-                    form: crate::elicitation::ElicitationFormState::new(form),
-                    scroll: 0,
-                    reply: Some(reply),
-                });
-                self.needs_redraw = true;
+            AppEvent::ElicitationAsk {
+                session_id,
+                form,
+                reply,
+            } => {
+                self.open_elicitation_ask(session_id.as_deref(), form, reply);
             }
             AppEvent::ShellDone { id, code, output } => {
                 if let Some(pos) = self.shell_pending.iter().position(|(sid, _)| *sid == id) {
@@ -3453,6 +3505,42 @@ impl App {
         }
     }
 
+    /// Cancel compositor-owned modals before a session switch, mirroring
+    /// the Esc paths of `handle_view_key` / `handle_select_key` /
+    /// `handle_slider_key` so the plugin releases its single-overlay slot
+    /// (its `current` clears and future overlay opens work again).
+    /// Painter-owned views (`notify_plugin == false`, i.e. `/help`, `/keys`,
+    /// `/session`, painter `/status`) are left alone — they park with their
+    /// session inside the switch and resurface on return.
+    fn cancel_plugin_overlays(&mut self, ctl: &Controller) {
+        if let Some(view) = self.view_overlay.take() {
+            if view.notify_plugin {
+                ctl.send(Cmd::PluginOverlayEvent {
+                    id: view.id,
+                    event: "cancel".into(),
+                    value: None,
+                });
+            } else {
+                self.view_overlay = Some(view);
+            }
+        }
+        if let Some(slider) = self.slider_overlay.take() {
+            ctl.send(Cmd::PluginOverlayEvent {
+                id: slider.id,
+                event: "cancel".into(),
+                value: Some(serde_json::json!(slider.value)),
+            });
+        }
+        if let Some(select) = self.select_overlay.take() {
+            let value = select.options[select.sel].value.clone();
+            ctl.send(Cmd::PluginOverlayEvent {
+                id: select.id,
+                event: "cancel".into(),
+                value: Some(serde_json::json!(value)),
+            });
+        }
+    }
+
     /// grok-build mouse semantics, scaled down: wheel scrolls; left-drag
     /// selects with a live highlight (auto-scrolling at the pane edges) and
     /// copies on release; double-click selects & copies a word. Shift+drag
@@ -3490,6 +3578,16 @@ impl App {
                     self.last_click = None;
                     self.input_sel = None;
                     self.input_selecting = false;
+                    if tab != self.current {
+                        // Compositor-owned modals (plugin view/select/
+                        // slider, e.g. live /status) cannot ride along to
+                        // another tab: leaving cancels them exactly like
+                        // Esc so the plugin releases its single-overlay
+                        // slot. Painter popups (/help, /keys, /session,
+                        // painter /status) park with the session inside
+                        // `switch_to_session`.
+                        self.cancel_plugin_overlays(ctl);
+                    }
                     self.switch_to_session(tab);
                     return;
                 }
@@ -4889,19 +4987,69 @@ impl App {
         self.needs_redraw = true;
     }
 
+    /// Route an incoming ACP permission ask to the session that owns it:
+    /// the live view when the owning tab is on screen, otherwise the
+    /// owning parked slot (the ask waits there and its tab is badged until
+    /// the user returns). An ask whose session the tab model does not know
+    /// falls back to the live view rather than silently cancelling the
+    /// agent's tool call. Dropping an unanswered overlay cancels it.
     fn open_permission_ask(
         &mut self,
+        session_id: &str,
         title: String,
         options: Vec<PermissionAskOption>,
         reply: tokio::sync::oneshot::Sender<PermissionAskReply>,
     ) {
         let sel = permission_ask_default_sel(&options);
-        self.permission_ask = Some(PermissionAskOverlay {
+        let overlay = PermissionAskOverlay {
             title,
             sel,
             options,
             reply: Some(reply),
-        });
+        };
+        if session_id == self.session_id {
+            self.permission_ask = Some(overlay);
+        } else if let Some(slot) = self.parked.iter_mut().find(|slot| slot.id == session_id) {
+            // A parked session asked while out of view: keep the ask on its
+            // tab — it must not float over the tab on screen.
+            slot.permission_ask = Some(overlay);
+        } else {
+            self.show_tip("permission ask from an unknown session — shown here");
+            self.permission_ask = Some(overlay);
+        }
+        self.needs_redraw = true;
+    }
+
+    /// Route an ACP elicitation form like [`Self::open_permission_ask`].
+    /// `None` sessions are request-scoped elicitations (auth/config phase)
+    /// with no tab to belong to — they surface on the live view.
+    fn open_elicitation_ask(
+        &mut self,
+        session_id: Option<&str>,
+        form: crate::elicitation::ElicitationForm,
+        reply: tokio::sync::oneshot::Sender<crate::elicitation::ElicitationReply>,
+    ) {
+        let overlay = ElicitationAskOverlay {
+            form: crate::elicitation::ElicitationFormState::new(form),
+            scroll: 0,
+            reply: Some(reply),
+        };
+        let for_live = match session_id {
+            None => true,
+            Some(sid) => sid == self.session_id,
+        };
+        if for_live {
+            self.elicitation_ask = Some(overlay);
+        } else if let Some(slot) = self
+            .parked
+            .iter_mut()
+            .find(|slot| Some(slot.id.as_str()) == session_id)
+        {
+            slot.elicitation_ask = Some(overlay);
+        } else {
+            self.show_tip("elicitation from an unknown session — shown here");
+            self.elicitation_ask = Some(overlay);
+        }
         self.needs_redraw = true;
     }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -736,6 +736,74 @@ pub struct SubagentView {
     pub transcript: Transcript,
 }
 
+/// One non-live session's full state while another tab is viewed (issue
+/// #94). The App's own fields always describe the viewed session; a tab
+/// switch moves them into a slot and loads the target slot in their place.
+pub struct SessionSlot {
+    pub id: String,
+    pub title: Option<String>,
+    pub transcript: Transcript,
+    /// Authoritative per-session running bit (folded from `SessionStatus`
+    /// and turn lifecycle events).
+    pub running: bool,
+    /// Finished while parked → tab badge until the user views the tab.
+    pub completed_unseen: bool,
+    pub prompt_queue: VecDeque<ClientQueuedPrompt>,
+    pub prompt_pending: bool,
+    pub modes: Modes,
+    pub session_bound: bool,
+    pub pending_steer_cells: HashMap<u64, PendingSteer>,
+    pub subagents: Vec<SubagentView>,
+    pub current_subagents: HashSet<String>,
+    pub next_subagent_starts_batch: bool,
+    pub active_subagent: Option<String>,
+    pub agent_selection: Option<String>,
+}
+
+impl SessionSlot {
+    /// A fresh, empty session tab. `bound` is true only when the id is
+    /// already a real session id (demo, local JSONL resume).
+    fn fresh(id: String, bound: bool) -> Self {
+        SessionSlot {
+            transcript: Transcript::new(id.clone()),
+            id,
+            title: None,
+            running: false,
+            completed_unseen: false,
+            prompt_queue: VecDeque::new(),
+            prompt_pending: false,
+            modes: Modes::default(),
+            session_bound: bound,
+            pending_steer_cells: HashMap::new(),
+            subagents: Vec::new(),
+            current_subagents: HashSet::new(),
+            next_subagent_starts_batch: true,
+            active_subagent: None,
+            agent_selection: None,
+        }
+    }
+}
+
+/// One row of the session tab strip (native chrome, `ui::draw_session_tabs`).
+pub struct SessionTab {
+    pub label: String,
+    pub running: bool,
+    pub completed_unseen: bool,
+    pub current: bool,
+}
+
+/// Right-click tab popup. Phase 1 has a single Close item; new items extend
+/// [`TabMenuItem`] and the painter's item list together.
+pub(crate) struct TabMenu {
+    pub tab: usize,
+    pub at: (u16, u16),
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum TabMenuItem {
+    Close,
+}
+
 pub(crate) const AGENT_HISTORY_ID: &str = "__martty_internal__:agent-history";
 
 /// Overlay for one ACP `session/request_permission` ask.
@@ -1106,6 +1174,24 @@ pub struct App {
     pub ambient_tip_at: Instant,
     ctrl_c_armed: Option<CtrlCQuitChord>,
     pub session_id: String,
+    /// Parked sessions — every session except the viewed one (issue #94).
+    /// Conceptual tab order is this list with the live session spliced in
+    /// at `current`; the App's own fields above always mirror the live tab.
+    parked: Vec<SessionSlot>,
+    /// Tab index of the live session (`0..=parked.len()`).
+    current: usize,
+    /// Ids of tabs awaiting their `SessionBound`, FIFO: `/new` placeholders
+    /// and `session/load` targets. The bind lands on the tab that asked,
+    /// even if the user switched away while it resolved.
+    awaiting_binds: VecDeque<String>,
+    /// Tab strip hit-test rects, recorded by `ui::draw_session_tabs`.
+    pub(crate) tab_rects: Vec<(ratatui::layout::Rect, usize)>,
+    /// The tab strip `+` cell's rect from the latest frame.
+    pub(crate) plus_rect: Option<ratatui::layout::Rect>,
+    /// Open right-click tab popup.
+    pub(crate) tab_menu: Option<TabMenu>,
+    /// The popup's frame rect from the latest draw (item hit-testing).
+    pub(crate) tab_menu_rect: Option<ratatui::layout::Rect>,
     pub cfg: RuntimeConfig,
     /// Model explicitly picked this session (`/model`); wins over
     /// `transcript.last_model` in the chip until a turn realizes it.
@@ -1175,6 +1261,23 @@ fn ui_session(event: &crate::events::UiEvent) -> Option<&str> {
     }
 }
 
+/// Register (or revive) the view for a started subagent in `views`.
+fn upsert_subagent_view(views: &mut Vec<SubagentView>, parent: &str, child: &str) {
+    if let Some(view) = views.iter_mut().find(|view| view.id == child) {
+        view.running = true;
+        view.failed = false;
+    } else {
+        views.push(SubagentView {
+            id: child.to_string(),
+            parent: parent.to_string(),
+            label: format!("subagent {}", views.len() + 1),
+            running: true,
+            failed: false,
+            transcript: Transcript::new(child.to_string()),
+        });
+    }
+}
+
 /// Draft pieces after stripping `[image n]` chips, still in reading order.
 #[derive(Clone)]
 enum StagedBlock {
@@ -1182,7 +1285,7 @@ enum StagedBlock {
     Image(crate::attachments::Attachment),
 }
 
-struct ClientQueuedPrompt {
+pub(crate) struct ClientQueuedPrompt {
     id: u64,
     blocks: Vec<StagedBlock>,
 }
@@ -1200,7 +1303,7 @@ pub(crate) struct QueuePreview {
     pub(crate) editing: bool,
 }
 
-struct PendingSteer {
+pub(crate) struct PendingSteer {
     cells: Vec<usize>,
     blocks: Vec<StagedBlock>,
     /// Queue-head retries keep their original FIFO position when deferred.
@@ -1471,6 +1574,13 @@ impl App {
             ambient_tip_at: Instant::now(),
             ctrl_c_armed: None,
             session_id,
+            parked: Vec::new(),
+            current: 0,
+            awaiting_binds: VecDeque::new(),
+            tab_rects: Vec::new(),
+            plus_rect: None,
+            tab_menu: None,
+            tab_menu_rect: None,
             cfg,
             selected_model: None,
             demo,
@@ -1517,6 +1627,324 @@ impl App {
             return &mut self.subagents[index].transcript;
         }
         &mut self.transcript
+    }
+
+    /// Move the live session's per-session state out of the App fields into
+    /// a parking slot, leaving cheap placeholders behind. Always paired with
+    /// [`Self::put_live_slot`] before anything reads the fields again.
+    fn take_live_slot(&mut self) -> SessionSlot {
+        SessionSlot {
+            id: std::mem::take(&mut self.session_id),
+            title: self.session_title.take(),
+            transcript: std::mem::replace(&mut self.transcript, Transcript::new(String::new())),
+            running: self.state != RunState::Idle || self.prompt_pending,
+            completed_unseen: false,
+            prompt_queue: std::mem::take(&mut self.prompt_queue),
+            prompt_pending: std::mem::take(&mut self.prompt_pending),
+            modes: std::mem::take(&mut self.modes),
+            session_bound: std::mem::take(&mut self.session_bound),
+            pending_steer_cells: std::mem::take(&mut self.pending_steer_cells),
+            subagents: std::mem::take(&mut self.subagents),
+            current_subagents: std::mem::take(&mut self.current_subagents),
+            next_subagent_starts_batch: std::mem::replace(&mut self.next_subagent_starts_batch, true),
+            active_subagent: self.active_subagent.take(),
+            agent_selection: self.agent_selection.take(),
+        }
+    }
+
+    /// Load a slot's state into the App fields — the inverse of
+    /// [`Self::take_live_slot`]. RunState is recomputed from the slot's
+    /// authoritative `running` bit; the elapsed timer restarts.
+    fn put_live_slot(&mut self, slot: SessionSlot) {
+        self.session_id = slot.id;
+        self.session_title = slot.title;
+        self.transcript = slot.transcript;
+        self.queued = slot.prompt_queue.len();
+        self.prompt_queue = slot.prompt_queue;
+        self.prompt_pending = slot.prompt_pending;
+        self.modes = slot.modes;
+        self.session_bound = slot.session_bound;
+        self.pending_steer_cells = slot.pending_steer_cells;
+        self.subagents = slot.subagents;
+        self.current_subagents = slot.current_subagents;
+        self.next_subagent_starts_batch = slot.next_subagent_starts_batch;
+        self.active_subagent = slot.active_subagent;
+        self.agent_selection = slot.agent_selection;
+        self.state = if slot.running || slot.prompt_pending {
+            RunState::Running
+        } else {
+            RunState::Idle
+        };
+        self.run_started = None;
+        self.state_note.clear();
+    }
+
+    /// Per-view caches that must not leak across a tab switch.
+    fn after_switch(&mut self) {
+        self.chat_view = ChatView::default();
+        self.scroll_up = 0;
+        self.sel = None;
+        self.selecting = false;
+        self.last_click = None;
+        self.input_sel = None;
+        self.input_selecting = false;
+        self.picker = None;
+        self.queue_selection = None;
+        self.queue_edit = None;
+        // The incoming transcript's own model is the truth for the chip.
+        self.selected_model = None;
+        self.needs_redraw = true;
+    }
+
+    /// Switch the view to tab `tab` (conceptual index, live spliced in at
+    /// `current`): park the live state into its slot, load the target.
+    pub fn switch_to_session(&mut self, tab: usize) {
+        if tab == self.current || tab > self.parked.len() {
+            return;
+        }
+        let pidx = if tab < self.current { tab } else { tab - 1 };
+        let live = self.take_live_slot();
+        let mut target = self.parked.remove(pidx);
+        target.completed_unseen = false;
+        // The parked copy takes the live tab's conceptual position.
+        let park_at = if self.current < tab {
+            self.current
+        } else {
+            self.current - 1
+        };
+        self.parked.insert(park_at, live);
+        self.current = tab;
+        self.put_live_slot(target);
+        self.after_switch();
+    }
+
+    /// Park the live session and open a fresh tab for `id` at the end.
+    /// `bound` is true only when the id is already a real session id.
+    fn open_new_session(&mut self, id: String, bound: bool) {
+        let live = self.take_live_slot();
+        self.parked.insert(self.current, live);
+        self.current = self.parked.len();
+        self.put_live_slot(SessionSlot::fresh(id, bound));
+        self.after_switch();
+    }
+
+    /// Conceptual tab index of the session with this id (live or parked).
+    fn tab_index_of(&self, id: &str) -> Option<usize> {
+        if self.session_id == id {
+            return Some(self.current);
+        }
+        self.parked.iter().position(|slot| slot.id == id).map(|pidx| {
+            if pidx < self.current {
+                pidx
+            } else {
+                pidx + 1
+            }
+        })
+    }
+
+    /// Close a tab locally (issue #94): nothing is sent to the agent — ACP
+    /// has no session/close — the session simply stops being viewed and its
+    /// updates drop at the router. Never removes the last remaining tab.
+    fn close_session(&mut self, tab: usize) {
+        let total = self.parked.len() + 1;
+        if total < 2 || tab >= total {
+            return;
+        }
+        let doomed = if tab == self.current {
+            self.session_id.clone()
+        } else {
+            let pidx = if tab < self.current { tab } else { tab - 1 };
+            match self.parked.get(pidx) {
+                Some(slot) => slot.id.clone(),
+                None => return,
+            }
+        };
+        if tab == self.current {
+            // View a neighbor first; the doomed state parks at the old spot.
+            let neighbor = if tab + 1 < total { tab + 1 } else { tab - 1 };
+            self.switch_to_session(neighbor);
+        }
+        if let Some(pidx) = self.parked.iter().position(|slot| slot.id == doomed) {
+            self.parked.remove(pidx);
+            let removed_tab = if pidx < self.current { pidx } else { pidx + 1 };
+            if removed_tab < self.current {
+                self.current -= 1;
+            }
+        }
+        self.awaiting_binds.retain(|id| *id != doomed);
+        self.needs_redraw = true;
+    }
+
+    /// Tab strip model: every session in tab order with the live tab
+    /// spliced in at `current`. Native status chrome fed by session status
+    /// facts (same source as `state_line`, never the palette/slot systems).
+    pub fn session_tabs(&self) -> Vec<SessionTab> {
+        let mut tabs: Vec<SessionTab> = self
+            .parked
+            .iter()
+            .map(|slot| SessionTab {
+                label: slot
+                    .title
+                    .clone()
+                    .filter(|title| !title.trim().is_empty())
+                    .unwrap_or_else(|| short_id(&slot.id)),
+                running: slot.running || slot.prompt_pending,
+                completed_unseen: slot.completed_unseen,
+                current: false,
+            })
+            .collect();
+        tabs.insert(
+            self.current,
+            SessionTab {
+                label: self
+                    .session_title
+                    .clone()
+                    .filter(|title| !title.trim().is_empty())
+                    .unwrap_or_else(|| short_id(&self.session_id)),
+                running: self.state != RunState::Idle || self.prompt_pending,
+                completed_unseen: false,
+                current: true,
+            },
+        );
+        tabs
+    }
+
+    /// Number of session tabs (parked + live).
+    pub fn session_tab_count(&self) -> usize {
+        self.parked.len() + 1
+    }
+
+    /// Hit-test a screen cell against the tab rects recorded by the painter.
+    fn tab_at(&self, col: u16, row: u16) -> Option<usize> {
+        self.tab_rects
+            .iter()
+            .find(|(rect, _)| {
+                col >= rect.x && col < rect.right() && row >= rect.y && row < rect.bottom()
+            })
+            .map(|(_, idx)| *idx)
+    }
+
+    /// Hit-test a screen cell against the tab strip `+` cell.
+    fn plus_hit(&self, col: u16, row: u16) -> bool {
+        self.plus_rect.is_some_and(|rect| {
+            col >= rect.x && col < rect.right() && row >= rect.y && row < rect.bottom()
+        })
+    }
+
+    /// Hit-test a screen cell against the open tab popup's items.
+    fn tab_menu_item_at(&self, col: u16, row: u16) -> Option<TabMenuItem> {
+        let rect = self.tab_menu_rect?;
+        if col < rect.x || col >= rect.right() {
+            return None;
+        }
+        match row.checked_sub(rect.y + 1) {
+            Some(0) => Some(TabMenuItem::Close),
+            _ => None,
+        }
+    }
+
+    /// Was this session mid-turn (live RunState, or a parked slot's running
+    /// bit)? Read just before folding a `SessionStatus` event.
+    fn session_was_running(&self, session: &str) -> bool {
+        if session == self.session_id {
+            matches!(self.state, RunState::Running)
+        } else {
+            self.parked
+                .iter()
+                .any(|slot| slot.id == session && slot.running)
+        }
+    }
+
+    /// Fold an event addressed to a parked session into its slot: the same
+    /// mode/status facts the live path folds, plus the running → idle edge
+    /// that raises the tab's completion badge. Live UI state is untouched.
+    fn apply_to_slot(slot: &mut SessionSlot, ui: crate::events::UiEvent) {
+        use crate::events::UiEvent as E;
+        let mut apply_to_transcript = true;
+        match &ui {
+            E::PlanMode { active, .. } => {
+                if slot.modes.plan == *active {
+                    apply_to_transcript = false;
+                } else {
+                    slot.modes.plan = *active;
+                }
+            }
+            E::SandboxMode { mode, .. } => slot.modes.sandbox = Some(mode.clone()),
+            E::ApprovalPolicy { policy, .. } => slot.modes.approval = Some(policy.clone()),
+            E::PermissionPreset { preset, .. } => slot.modes.permission = Some(preset.clone()),
+            E::AgentPreset { preset, .. } => {
+                slot.modes.agent_preset = Some(preset.clone());
+                apply_to_transcript = false;
+            }
+            E::ReasoningEffort { effort, .. } => {
+                slot.modes.effort = Some(effort.clone());
+                apply_to_transcript = false;
+            }
+            E::SessionTitle { title, .. } => slot.title = Some(title.clone()),
+            _ => {}
+        }
+        match &ui {
+            E::SessionStatus { running, .. } => {
+                if slot.running && !running {
+                    slot.completed_unseen = true;
+                }
+                slot.running = *running;
+                if !running {
+                    slot.prompt_pending = false;
+                }
+            }
+            E::TurnStart { .. } => slot.running = true,
+            E::TurnEnd { .. } => {
+                if slot.running {
+                    slot.completed_unseen = true;
+                }
+                slot.running = false;
+                slot.prompt_pending = false;
+            }
+            _ => {}
+        }
+        if apply_to_transcript {
+            slot.transcript.apply(ui);
+        }
+    }
+
+    /// Dispatch the head of one session's queue — the live session takes
+    /// the existing path; a parked session echoes into its own transcript
+    /// and sends addressed by its own id (acp.rs fans in per session).
+    fn dispatch_session_queue(&mut self, session: &str, ctl: &Controller) {
+        if session == self.session_id {
+            self.dispatch_next_queued(ctl);
+            return;
+        }
+        let Some(slot) = self.parked.iter_mut().find(|slot| slot.id == session) else {
+            return;
+        };
+        let Some(prompt) = slot.prompt_queue.pop_front() else {
+            return;
+        };
+        for block in &prompt.blocks {
+            match block {
+                StagedBlock::Text(text) => slot.transcript.push_user(text.clone(), false),
+                StagedBlock::Image(att) => slot.transcript.push_image(
+                    att.name.clone(),
+                    String::new(),
+                    att.path.clone(),
+                    att.data.clone(),
+                    false,
+                ),
+            }
+        }
+        slot.prompt_pending = true;
+        match prompt.blocks.as_slice() {
+            [StagedBlock::Text(text)] => ctl.send(Cmd::Prompt {
+                session_id: session.to_string(),
+                text: text.clone(),
+            }),
+            _ => ctl.send(Cmd::PromptImages {
+                session_id: session.to_string(),
+                blocks: prompt_blocks_from_staged(prompt.blocks),
+            }),
+        }
     }
 
     /// Re-detect the workspace git branch for the composer cap label. One
@@ -2168,8 +2596,12 @@ impl App {
     }
 
     pub fn handle(&mut self, ev: AppEvent, ctl: &Controller) {
-        let queue_before = (!self.demo).then(|| self.queue_snapshot());
-        let agents_before = (!self.demo).then(|| self.agents_snapshot());
+        // Cheap fingerprints instead of full snapshot clones: chatty agents
+        // can stream hundreds of thousands of session updates (issue #94 —
+        // a session/load replay storm), and cloning every queue/agents
+        // snapshot per event multiplies that into a UI-melting alloc storm.
+        let queue_before = (!self.demo).then(|| self.queue_fingerprint());
+        let agents_before = (!self.demo).then(|| self.agents_fingerprint());
         self.handle_inner(ev, ctl);
         // A turn ran on the picked model → the stream is the truth again.
         if self.selected_model.is_some()
@@ -2178,17 +2610,77 @@ impl App {
             self.selected_model = None;
         }
         if let Some(before) = queue_before {
-            let after = self.queue_snapshot();
-            if after != before {
-                ctl.send(Cmd::QueueSnapshot { snapshot: after });
+            if self.queue_fingerprint() != before {
+                ctl.send(Cmd::QueueSnapshot {
+                    snapshot: self.queue_snapshot(),
+                });
             }
         }
         if let Some(before) = agents_before {
-            let after = self.agents_snapshot();
-            if after != before {
-                ctl.send(Cmd::AgentsSnapshot { snapshot: after });
+            if self.agents_fingerprint() != before {
+                ctl.send(Cmd::AgentsSnapshot {
+                    snapshot: self.agents_snapshot(),
+                });
             }
         }
+    }
+
+    /// Identity of everything `queue_snapshot` projects, without the summary
+    /// strings: ordered prompt ids (order captures reordering) plus the
+    /// selection/edit/confirm flags. A summary edit always passes through an
+    /// `editing_id` transition, so text changes are covered too.
+    fn queue_fingerprint(&self) -> (Vec<u64>, Option<u64>, Option<u64>, bool) {
+        (
+            self.prompt_queue.iter().map(|prompt| prompt.id).collect(),
+            self.queue_selection
+                .and_then(|index| self.prompt_queue.get(index))
+                .map(|prompt| prompt.id),
+            self.queue_edit.as_ref().map(|edit| edit.prompt_id),
+            self.queue_delete_confirming(),
+        )
+    }
+
+    /// Identity of everything `agents_snapshot` projects, without label
+    /// strings: root running bit, per-view id/status/current, the history
+    /// count, and the active/selected ids. Labels are assigned at view
+    /// creation, so they cannot change without the id set changing.
+    fn agents_fingerprint(&self) -> (String, Option<String>, bool, Vec<(String, u8, bool)>, usize) {
+        let active_id = match self.active_subagent.as_deref() {
+            Some(id) if !self.subagent_in_current_batch(id) => AGENT_HISTORY_ID.into(),
+            Some(id) => id.into(),
+            None => self.session_id.clone(),
+        };
+        let root_running = !matches!(self.state, RunState::Idle) || self.prompt_pending;
+        let views: Vec<(String, u8, bool)> = self
+            .subagents
+            .iter()
+            .map(|view| {
+                let status = if view.running {
+                    0
+                } else if view.failed {
+                    1
+                } else {
+                    2
+                };
+                (
+                    view.id.clone(),
+                    status,
+                    self.subagent_in_current_batch(&view.id),
+                )
+            })
+            .collect();
+        let history_count = self
+            .subagents
+            .iter()
+            .filter(|view| !self.subagent_in_current_batch(&view.id))
+            .count();
+        let selected_id = self.agent_selection.as_ref().and_then(|selected| {
+            (self.subagents.iter().any(|view| view.id == *selected)
+                || *selected == self.session_id
+                || (history_count > 0 && selected == AGENT_HISTORY_ID))
+                .then(|| selected.clone())
+        });
+        (active_id, selected_id, root_running, views, history_count)
     }
 
     fn queue_snapshot(&self) -> crate::bus::QueueSnapshot {
@@ -2282,14 +2774,16 @@ impl App {
             }
             AppEvent::Term(term) => self.handle_term(term, ctl),
             AppEvent::Ui(ui) => {
-                let became_idle = matches!(
-                    &ui,
-                    crate::events::UiEvent::SessionStatus { session, running: false }
-                        if session == &self.session_id
-                ) && matches!(self.state, RunState::Running);
+                let idle_session = match &ui {
+                    crate::events::UiEvent::SessionStatus {
+                        session,
+                        running: false,
+                    } if self.session_was_running(session) => Some(session.clone()),
+                    _ => None,
+                };
                 self.apply_ui(ui);
-                if became_idle {
-                    self.dispatch_next_queued(ctl);
+                if let Some(session) = idle_session {
+                    self.dispatch_session_queue(&session, ctl);
                 }
             }
             AppEvent::Rpc { method, params } => {
@@ -2447,14 +2941,16 @@ impl App {
                     return;
                 }
                 for ui in parse_notification(&method, &params) {
-                    let became_idle = matches!(
-                        &ui,
-                        crate::events::UiEvent::SessionStatus { session, running: false }
-                            if session == &self.session_id
-                    ) && matches!(self.state, RunState::Running);
+                    let idle_session = match &ui {
+                        crate::events::UiEvent::SessionStatus {
+                            session,
+                            running: false,
+                        } if self.session_was_running(session) => Some(session.clone()),
+                        _ => None,
+                    };
                     self.apply_ui(ui);
-                    if became_idle {
-                        self.dispatch_next_queued(ctl);
+                    if let Some(session) = idle_session {
+                        self.dispatch_session_queue(&session, ctl);
                     }
                 }
                 self.needs_redraw = true;
@@ -2469,6 +2965,14 @@ impl App {
                 self.queue_selection = None;
                 self.queue_edit = None;
                 self.pending_steer_cells.clear();
+                for slot in &mut self.parked {
+                    // The dead runtime owned every session's delivery state,
+                    // not just the viewed one.
+                    slot.running = false;
+                    slot.prompt_pending = false;
+                    slot.prompt_queue.clear();
+                    slot.pending_steer_cells.clear();
+                }
                 if self.state != RunState::Idle {
                     self.state = RunState::Idle;
                     self.run_started = None;
@@ -2539,15 +3043,28 @@ impl App {
                         self.state_note = "cancelling".into();
                         self.transcript.cancel_open_work();
                     }
-                    CtlEvent::Interrupted => {
-                        self.prompt_pending = false;
-                        self.state = RunState::Idle;
-                        self.run_started = None;
-                        self.state_note.clear();
-                        self.transcript.cancel_open_work();
-                        self.transcript
-                            .push_notice(NoticeLevel::Warn, "interrupted — turn cancelled".into());
-                        self.dispatch_next_queued(ctl);
+                    CtlEvent::Interrupted { session_id } => {
+                        // One connection can run turns for several sessions;
+                        // settle whichever session the interruption names —
+                        // the viewed one, or a parked slot.
+                        if session_id == self.session_id {
+                            self.prompt_pending = false;
+                            self.state = RunState::Idle;
+                            self.run_started = None;
+                            self.state_note.clear();
+                            self.transcript.cancel_open_work();
+                            self.transcript
+                                .push_notice(NoticeLevel::Warn, "interrupted — turn cancelled".into());
+                        } else if let Some(slot) =
+                            self.parked.iter_mut().find(|slot| slot.id == session_id)
+                        {
+                            slot.prompt_pending = false;
+                            slot.running = false;
+                            slot.transcript.cancel_open_work();
+                            slot.transcript
+                                .push_notice(NoticeLevel::Warn, "interrupted — turn cancelled".into());
+                        }
+                        self.dispatch_session_queue(&session_id, ctl);
                     }
                     CtlEvent::Skills { skills } => {
                         self.skills = skills;
@@ -2699,14 +3216,63 @@ impl App {
                         self.load_session = load_session;
                     }
                     CtlEvent::SessionBound { session_id, notice } => {
-                        if self.session_id != session_id {
-                            self.reset_subagent_views();
+                        // The session that just bound, for the queue dispatch
+                        // below (prompts submitted while the tab was unbound
+                        // are held in its queue — acp.rs rejects unbound ids).
+                        let mut just_bound: Option<String> = None;
+                        if let Some(awaiting) = self.awaiting_binds.pop_front() {
+                            // The tab that asked for session/new (placeholder
+                            // id) or session/load (target id) owns this bind —
+                            // the user may have switched away while it
+                            // resolved, so rebind by the awaiting id, not by
+                            // which tab happens to be live.
+                            if self.session_id == awaiting {
+                                self.session_id = session_id.clone();
+                                self.transcript.set_root_session(session_id.clone());
+                                self.session_bound = true;
+                                if let Some(notice) = notice {
+                                    self.transcript.push_notice(NoticeLevel::Info, notice);
+                                }
+                                just_bound = Some(self.session_id.clone());
+                            } else if let Some(slot) =
+                                self.parked.iter_mut().find(|slot| slot.id == awaiting)
+                            {
+                                slot.id = session_id.clone();
+                                slot.transcript.set_root_session(session_id.clone());
+                                slot.session_bound = true;
+                                if let Some(notice) = notice {
+                                    slot.transcript.push_notice(NoticeLevel::Info, notice);
+                                }
+                                just_bound = Some(slot.id.clone());
+                            } else {
+                                self.show_tip(format!(
+                                    "session {session_id} bound after its tab was closed"
+                                ));
+                            }
+                        } else if let Some(slot) =
+                            self.parked.iter_mut().find(|slot| slot.id == session_id)
+                        {
+                            // A session/load for a parked tab resolved.
+                            slot.session_bound = true;
+                            if let Some(notice) = notice {
+                                slot.transcript.push_notice(NoticeLevel::Info, notice);
+                            }
+                            just_bound = Some(slot.id.clone());
+                        } else {
+                            // Startup / reconnect: rebind the viewed session.
+                            if self.session_id != session_id {
+                                self.reset_subagent_views();
+                            }
+                            self.session_id = session_id.clone();
+                            self.transcript.set_root_session(session_id);
+                            self.session_bound = true;
+                            if let Some(notice) = notice {
+                                self.transcript.push_notice(NoticeLevel::Info, notice);
+                            }
+                            just_bound = Some(self.session_id.clone());
                         }
-                        self.session_id = session_id.clone();
-                        self.transcript.set_root_session(session_id);
-                        self.session_bound = true;
-                        if let Some(notice) = notice {
-                            self.transcript.push_notice(NoticeLevel::Info, notice);
+                        if let Some(bound) = just_bound {
+                            self.dispatch_session_queue(&bound, ctl);
                         }
                         ctl.send(Cmd::FetchSkills);
                     }
@@ -2759,24 +3325,33 @@ impl App {
         }
 
         if let E::SubagentStarted { parent, child } = &ui {
+            if parent != &self.session_id && !self.subagents.iter().any(|view| view.id == *parent)
+            {
+                // A parked session's subagent tree: register the child in
+                // its slot and fold the event into the slot's transcripts.
+                for slot in &mut self.parked {
+                    if slot.id == *parent {
+                        upsert_subagent_view(&mut slot.subagents, parent, child);
+                        slot.transcript.apply(ui);
+                        self.needs_redraw = true;
+                        return;
+                    }
+                    if let Some(view) = slot.subagents.iter_mut().find(|view| view.id == *parent) {
+                        view.transcript.apply(ui);
+                        self.needs_redraw = true;
+                        return;
+                    }
+                }
+                // Unknown parent: a session this client never opened (or
+                // already closed) — drop it, never leak it into live state.
+                return;
+            }
             if self.next_subagent_starts_batch {
                 self.current_subagents.clear();
                 self.next_subagent_starts_batch = false;
             }
             self.current_subagents.insert(child.clone());
-            if let Some(view) = self.subagents.iter_mut().find(|view| view.id == *child) {
-                view.running = true;
-                view.failed = false;
-            } else {
-                self.subagents.push(SubagentView {
-                    id: child.clone(),
-                    parent: parent.clone(),
-                    label: format!("subagent {}", self.subagents.len() + 1),
-                    running: true,
-                    failed: false,
-                    transcript: Transcript::new(child.clone()),
-                });
-            }
+            upsert_subagent_view(&mut self.subagents, parent, child);
             if parent == &self.session_id {
                 self.transcript.apply(ui);
             } else if let Some(view) = self.subagents.iter_mut().find(|view| view.id == *parent) {
@@ -2787,6 +3362,27 @@ impl App {
         }
 
         if let E::SubagentFinished { child, failed } = &ui {
+            if !self.subagents.iter().any(|view| view.id == *child) {
+                // A parked session's subagent: settle it inside its slot.
+                for slot in &mut self.parked {
+                    if let Some(view) = slot.subagents.iter_mut().find(|view| view.id == *child) {
+                        view.running = false;
+                        view.failed = *failed;
+                        let parent = view.parent.clone();
+                        if parent == slot.id {
+                            slot.transcript.apply(ui);
+                        } else if let Some(pview) =
+                            slot.subagents.iter_mut().find(|view| view.id == parent)
+                        {
+                            pview.transcript.apply(ui);
+                        }
+                        self.needs_redraw = true;
+                        return;
+                    }
+                }
+                // Unknown child — drop (same guard as SubagentStarted).
+                return;
+            }
             let parent = self
                 .subagents
                 .iter_mut()
@@ -2823,6 +3419,15 @@ impl App {
                     self.needs_redraw = true;
                     return;
                 }
+                if let Some(slot) = self.parked.iter_mut().find(|slot| slot.id == session) {
+                    Self::apply_to_slot(slot, ui);
+                    self.needs_redraw = true;
+                    return;
+                }
+                // A session this client never opened (or already closed):
+                // drop the event. Foreign-session facts must never fall
+                // through into the live transcript (issue #94 leak guard).
+                return;
             }
         }
 
@@ -2951,6 +3556,36 @@ impl App {
             }
             MouseEventKind::Down(MouseButton::Left) => {
                 self.needs_redraw = true;
+                // Session tab strip (issue #94): left-click a tab switches,
+                // `+` opens a fresh session, and an open tab popup consumes
+                // the click (item pick or dismiss).
+                if let Some(tab) = self.tab_at(mouse.column, mouse.row) {
+                    self.sel = None;
+                    self.selecting = false;
+                    self.last_click = None;
+                    self.input_sel = None;
+                    self.input_selecting = false;
+                    self.tab_menu = None;
+                    self.switch_to_session(tab);
+                    return;
+                }
+                if self.plus_hit(mouse.column, mouse.row) {
+                    self.sel = None;
+                    self.selecting = false;
+                    self.last_click = None;
+                    self.input_sel = None;
+                    self.input_selecting = false;
+                    self.tab_menu = None;
+                    self.new_session_flow("", ctl);
+                    return;
+                }
+                if let Some(menu) = self.tab_menu.take() {
+                    if self.tab_menu_item_at(mouse.column, mouse.row) == Some(TabMenuItem::Close) {
+                        self.close_session(menu.tab);
+                    }
+                    self.needs_redraw = true;
+                    return;
+                }
                 if let Some(action) = self
                     .slot_actions
                     .iter()
@@ -3079,6 +3714,19 @@ impl App {
             MouseEventKind::Up(MouseButton::Left) if self.input_selecting => {
                 self.input_selecting = false;
                 self.finish_input_selection();
+            }
+            MouseEventKind::Down(MouseButton::Right) => {
+                // Right-click a session tab: popup with local tab actions
+                // (Close; structured so more items slot in later).
+                if let Some(tab) = self.tab_at(mouse.column, mouse.row) {
+                    self.tab_menu = Some(TabMenu {
+                        tab,
+                        at: (mouse.column, mouse.row),
+                    });
+                } else {
+                    self.tab_menu = None;
+                }
+                self.needs_redraw = true;
             }
             MouseEventKind::Moved => {
                 // grok-style hover: track which inline chip the pointer is
@@ -4827,22 +5475,36 @@ impl App {
             }
         };
 
-        self.session_id = session.id.clone();
-        self.reset_subagent_views();
-        self.transcript.clear();
-        self.transcript.set_root_session(session.id.clone());
-        // Replay folds the session's own authoritative mode facts from empty.
-        self.modes = Modes::default();
+        if self.session_id != session.id {
+            if let Some(tab) = self.tab_index_of(&session.id) {
+                // Already open in a tab — switching to it is the resume.
+                self.switch_to_session(tab);
+                self.resume_candidates = Vec::new();
+                self.transcript.push_notice(
+                    NoticeLevel::Info,
+                    format!("⟲ {} is already open — switched to its tab", session.id),
+                );
+                return;
+            }
+            // Park the live session and replay into a fresh tab (issue #94).
+            self.open_new_session(session.id.clone(), true);
+        } else {
+            self.reset_subagent_views();
+            self.transcript.clear();
+            self.transcript.set_root_session(session.id.clone());
+            // Replay folds the session's own authoritative mode facts from empty.
+            self.modes = Modes::default();
+            self.queued = 0;
+            self.prompt_queue.clear();
+            self.queue_selection = None;
+            self.queue_edit = None;
+            self.pending_steer_cells.clear();
+            self.prompt_pending = false;
+            self.sel = None;
+        }
         // The resumed stream's own model is the truth for the chip.
         self.selected_model = None;
         self.show_banner = false;
-        self.queued = 0;
-        self.prompt_queue.clear();
-        self.queue_selection = None;
-        self.queue_edit = None;
-        self.pending_steer_cells.clear();
-        self.prompt_pending = false;
-        self.sel = None;
         let mut replayed = 0usize;
         for ev in &events {
             if ev.get("type").and_then(serde_json::Value::as_str) == Some("session") {
@@ -4880,6 +5542,33 @@ impl App {
         self.needs_redraw = true;
     }
 
+    /// The `/new` flow, shared by the slash command and the tab strip `+`
+    /// cell: park the live session and open a fresh tab (issue #94).
+    fn new_session_flow(&mut self, arg: &str, ctl: &Controller) {
+        if self.demo {
+            let id = if arg.is_empty() {
+                format!("dsh-{}", timestamp())
+            } else {
+                arg.to_string()
+            };
+            self.open_new_session(id.clone(), true);
+            ctl.send(Cmd::FetchSkills);
+            self.transcript.push_notice(
+                NoticeLevel::Info,
+                format!("new session · {id} — /agent picks its agent preset"),
+            );
+        } else {
+            // A local placeholder ids the tab until session/new resolves —
+            // the same shape main.rs seeds the startup session with. The
+            // real id lands on this tab via `awaiting_binds` at SessionBound.
+            let placeholder = format!("dsh-{}", timestamp());
+            self.open_new_session(placeholder.clone(), false);
+            self.awaiting_binds.push_back(placeholder);
+            ctl.send(Cmd::NewSession);
+            self.show_tip("session/new …");
+        }
+    }
+
     fn reset_session_ui(&mut self) {
         self.reset_subagent_views();
         self.transcript.clear();
@@ -4911,9 +5600,22 @@ impl App {
     }
 
     fn load_acp_session(&mut self, id: &str, ctl: &Controller) {
-        self.reset_session_ui();
-        self.session_id = id.to_string();
-        self.transcript.set_root_session(id.to_string());
+        if self.session_id == id {
+            // Reloading the viewed session: reset its UI and re-stream.
+            self.reset_session_ui();
+            self.session_id = id.to_string();
+            self.transcript.set_root_session(id.to_string());
+        } else if let Some(tab) = self.tab_index_of(id) {
+            // Already open — its transcript is intact; re-loading would
+            // duplicate it, so switching tabs is the whole resume.
+            self.switch_to_session(tab);
+            return;
+        } else {
+            // Park the live session; the transcript streams in via
+            // session/update tagged with this id, as today.
+            self.open_new_session(id.to_string(), false);
+            self.awaiting_binds.push_back(id.to_string());
+        }
         ctl.send(Cmd::LoadSession {
             session_id: id.to_string(),
         });
@@ -5553,29 +6255,7 @@ impl App {
                     self.set_mode(arg.to_string(), ctl);
                 }
             }
-            "new" => {
-                if self.demo {
-                    let id = if arg.is_empty() {
-                        format!("dsh-{}", timestamp())
-                    } else {
-                        arg.to_string()
-                    };
-                    self.reset_subagent_views();
-                    self.session_id = id.clone();
-                    self.transcript.set_root_session(id.clone());
-                    self.modes = Modes::default();
-                    self.session_title = None;
-                    ctl.send(Cmd::FetchSkills);
-                    self.transcript.push_notice(
-                        NoticeLevel::Info,
-                        format!("new session · {id} — /agent picks its agent preset"),
-                    );
-                } else {
-                    self.reset_session_ui();
-                    ctl.send(Cmd::NewSession);
-                    self.show_tip("session/new …");
-                }
-            }
+            "new" => self.new_session_flow(arg, ctl),
             "session" => self.push_session_info(),
             "status" => self.push_status_info(),
             "auth" => self.start_auth(arg, ctl),
@@ -6224,7 +6904,13 @@ impl App {
     /// passthroughs like /plan).
     fn send_agent_text(&mut self, text: String, ctl: &Controller) {
         self.show_banner = false;
-        let running = self.state == RunState::Running || self.prompt_pending || self.queued > 0;
+        // An unbound tab (placeholder id awaiting session/new·load) must not
+        // send: acp.rs rejects ids it never bound. Hold the prompt in the
+        // queue; the SessionBound handler dispatches it with the real id.
+        let running = self.state == RunState::Running
+            || self.prompt_pending
+            || self.queued > 0
+            || !self.session_bound;
         if running {
             let id = self.next_prompt_id();
             self.prompt_queue.push_back(ClientQueuedPrompt {
@@ -6288,6 +6974,13 @@ impl App {
     /// Empty Enter promotes the FIFO head into the active turn. If the agent
     /// cannot accept the steer, settlement restores the item to the front.
     fn send_queue_head_now(&mut self, ctl: &Controller) {
+        if !self.session_bound {
+            self.show_tip(self.locale.tr(
+                "session still binding — prompt stays queued",
+                "会话仍在绑定中 —— 消息保留在队列里",
+            ));
+            return;
+        }
         if !self.input.is_empty()
             || !self.pending_images.is_empty()
             || self.queue_selection.is_some()
@@ -6864,6 +7557,10 @@ pub(crate) fn word_span(line: &str, col: usize) -> Option<(usize, usize, String)
 #[cfg(test)]
 #[path = "../tests/unit/app__resume_tests.rs"]
 mod resume_tests;
+
+#[cfg(test)]
+#[path = "../tests/unit/app__session_tabs_tests.rs"]
+mod session_tabs_tests;
 
 #[cfg(test)]
 #[path = "../tests/unit/app__selection_tests.rs"]

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -20,14 +20,20 @@ pub enum AppEvent {
     Ctl(CtlEvent),
     /// ACP `session/request_permission`: UI picks an option, then replies
     /// on the oneshot. The ACP task waits; the UI thread does not.
+    /// `session_id` names the owning session so the ask can follow its tab
+    /// instead of floating over whatever session is on screen.
     PermissionAsk {
+        session_id: String,
         title: String,
         options: Vec<PermissionAskOption>,
         reply: tokio::sync::oneshot::Sender<PermissionAskReply>,
     },
     /// ACP `elicitation/create` form: the UI owns the modal and answers the
     /// request through this oneshot without blocking session updates.
+    /// Request-scoped elicitations (auth/config phases, no session yet)
+    /// carry `None` and surface on the live view.
     ElicitationAsk {
+        session_id: Option<String>,
         form: crate::elicitation::ElicitationForm,
         reply: tokio::sync::oneshot::Sender<crate::elicitation::ElicitationReply>,
     },

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -86,7 +86,9 @@ pub enum CtlEvent {
     /// is on the wire. The in-flight `session/prompt` has not unwound yet.
     CancelRequested,
     /// Backchat `session.cancelled`: the prompt future settled after abort.
-    Interrupted,
+    /// `session_id` names the session whose turn was interrupted; one
+    /// connection can run turns for several sessions concurrently.
+    Interrupted { session_id: String },
     /// Host model catalog + advertised composition select.
     Catalog {
         models: Vec<CatalogModel>,

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -244,7 +244,9 @@ fn controller_loop(
                         let _ =
                             rt.request("session/interrupt", Some(params), Duration::from_secs(10));
                     }
-                    let _ = bus.send(AppEvent::Ctl(CtlEvent::Interrupted));
+                    let _ = bus.send(AppEvent::Ctl(CtlEvent::Interrupted {
+                        session_id: session_id.clone(),
+                    }));
                     continue;
                 }
                 // The kill itself happens in interrupt_now(); this is the
@@ -254,7 +256,7 @@ fn controller_loop(
                 if let Some(rt) = guard.take() {
                     rt.kill();
                 }
-                let _ = bus.send(AppEvent::Ctl(CtlEvent::Interrupted));
+                let _ = bus.send(AppEvent::Ctl(CtlEvent::Interrupted { session_id }));
             }
             Cmd::SelectModel {
                 session_id,
@@ -802,7 +804,9 @@ fn handle_prompt(
                         rt.kill();
                         *runtime.lock().unwrap() = None;
                         if interrupted.swap(false, Ordering::SeqCst) {
-                            let _ = bus.send(AppEvent::Ctl(CtlEvent::Interrupted));
+                            let _ = bus.send(AppEvent::Ctl(CtlEvent::Interrupted {
+                                session_id: session_id.to_string(),
+                            }));
                         } else {
                             let _ = bus.send(AppEvent::Ctl(CtlEvent::Error(format!(
                                 "initialize failed: {err:#}"
@@ -833,7 +837,9 @@ fn handle_prompt(
         }
         Err(err) => {
             if interrupted.swap(false, Ordering::SeqCst) {
-                let _ = bus.send(AppEvent::Ctl(CtlEvent::Interrupted));
+                let _ = bus.send(AppEvent::Ctl(CtlEvent::Interrupted {
+                    session_id: session_id.to_string(),
+                }));
             } else {
                 let _ = bus.send(AppEvent::Ctl(CtlEvent::Error(format!(
                     "session/prompt failed: {err:#}"

--- a/src/events.rs
+++ b/src/events.rs
@@ -980,6 +980,106 @@ fn u64_field(v: &Value, key: &str) -> Option<u64> {
     v.get(key).and_then(Value::as_u64)
 }
 
+/// Coalesce a burst of drained bus events before they reach `App::handle`.
+///
+/// ACP agents may stream session updates at extreme rates — the dsh-acp
+/// `session/load` replay re-emits every historical delta of a long session
+/// (a 10k-event log became 258k notifications / 1.4 GB, melting the UI loop
+/// for minutes; issue #94 freeze). Deltas are append-only and tool-call
+/// updates are state-replacing, so merging adjacent ones is lossless for the
+/// final transcript:
+///
+/// - consecutive text chunks (`agent_message_chunk` / `agent_thought_chunk`)
+///   for the same session and message are concatenated; a trailing `_meta`
+///   (model attribution on the final chunk) is preserved;
+/// - consecutive *bare* `tool_call_update`s for the same session and call
+///   keep only the latest state. Updates carrying `content`, `rawOutput`,
+///   or `_meta` (diff blocks, terminal streams) are never dropped.
+///
+/// `tool_call` (turn start of a call) is a different kind and never merges,
+/// so the tool start/result frame boundary in the drain loop is untouched.
+pub fn coalesce_session_updates(events: &mut Vec<crate::bus::AppEvent>) {
+    use crate::bus::AppEvent;
+    if events.len() < 2 {
+        return;
+    }
+    let mut out: Vec<AppEvent> = Vec::with_capacity(events.len());
+    for ev in events.drain(..) {
+        if let (
+            Some(AppEvent::Rpc {
+                method: prev_method,
+                params: prev_params,
+            }),
+            AppEvent::Rpc { method, params },
+        ) = (out.last_mut(), &ev)
+        {
+            if prev_method == "session/update" && method == "session/update" {
+                match merge_update(prev_params, params) {
+                    MergeOutcome::Merged => continue,
+                    MergeOutcome::Keep => {}
+                }
+            }
+        }
+        out.push(ev);
+    }
+    *events = out;
+}
+
+enum MergeOutcome {
+    Merged,
+    Keep,
+}
+
+fn merge_update(prev: &mut Value, new: &Value) -> MergeOutcome {
+    let same_str = |a: &Value, b: &Value, key: &str| a.get(key).and_then(Value::as_str) == b.get(key).and_then(Value::as_str);
+    if !same_str(prev, new, "sessionId") {
+        return MergeOutcome::Keep;
+    }
+    let (Some(prev_update), Some(new_update)) = (prev.get_mut("update"), new.get("update")) else {
+        return MergeOutcome::Keep;
+    };
+    if !same_str(prev_update, new_update, "sessionUpdate") {
+        return MergeOutcome::Keep;
+    }
+    let kind = new_update
+        .get("sessionUpdate")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    match kind {
+        "agent_message_chunk" | "agent_thought_chunk" => {
+            if !same_str(prev_update, new_update, "messageId") {
+                return MergeOutcome::Keep;
+            }
+            let Some(new_text) = new_update.pointer("/content/text").and_then(Value::as_str) else {
+                return MergeOutcome::Keep;
+            };
+            match prev_update.pointer_mut("/content/text") {
+                Some(Value::String(buf)) => buf.push_str(new_text),
+                _ => return MergeOutcome::Keep,
+            }
+            // The final chunk of a message carries the model attribution.
+            if let Some(meta) = new_update.get("_meta") {
+                prev_update["_meta"] = meta.clone();
+            }
+            MergeOutcome::Merged
+        }
+        "tool_call_update" => {
+            if !same_str(prev_update, new_update, "toolCallId") {
+                return MergeOutcome::Keep;
+            }
+            let bare = |u: &Value| {
+                u.get("content").is_none() && u.get("rawOutput").is_none() && u.get("_meta").is_none()
+            };
+            if !bare(prev_update) || !bare(new_update) {
+                return MergeOutcome::Keep;
+            }
+            *prev_update = new_update.clone();
+            MergeOutcome::Merged
+        }
+        _ => MergeOutcome::Keep,
+    }
+}
+
 #[cfg(test)]
 #[path = "../tests/unit/events__tests.rs"]
 mod tests;

--- a/src/main.rs
+++ b/src/main.rs
@@ -488,12 +488,23 @@ fn main() -> Result<()> {
                     // background tools can otherwise begin and finish inside
                     // the same receive burst, making the request invisible.
                     if !render_boundary {
+                        // Buffer the burst and coalesce adjacent session
+                        // deltas first: agents may stream updates at extreme
+                        // rates (session/load replay storm, issue #94), and
+                        // applying each delta individually melts the loop.
+                        // The buffer stops right after a frame-boundary
+                        // event, preserving the original drain semantics.
+                        let mut burst: Vec<bus::AppEvent> = Vec::new();
                         while let Ok(ev) = bus_rx.try_recv() {
-                            let render_boundary = event_requires_immediate_frame(&ev);
-                            app.handle(ev, &controller);
-                            if render_boundary {
+                            let boundary = event_requires_immediate_frame(&ev);
+                            burst.push(ev);
+                            if boundary {
                                 break;
                             }
+                        }
+                        crate::events::coalesce_session_updates(&mut burst);
+                        for ev in burst {
+                            app.handle(ev, &controller);
                         }
                     }
                 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -159,7 +159,6 @@ pub fn draw(f: &mut Frame, app: &mut App) {
     let theme = app.theme;
     app.slot_actions.clear();
     app.tab_rects.clear();
-    app.plus_rect = None;
     app.pet_want = None;
     app.caret_cell = None;
     // The mouse-only expand button's frame rect is rebuilt by
@@ -372,7 +371,6 @@ pub fn draw(f: &mut Frame, app: &mut App) {
         // composer (drawn last so it tops the menu-free chat area).
         draw_attachment_preview(f, app, composer, area);
     }
-    draw_tab_menu(f, app, area);
     draw_model_picker(f, app, area);
     draw_plugin_tree(f, app, area);
     draw_plugin_slider(f, app, area);
@@ -1055,47 +1053,7 @@ fn draw_session_tabs(f: &mut Frame, app: &mut App, area: Rect) {
         spans.push(Span::styled(format!("{label} "), label_style));
         x += width;
     }
-    if x + 6 <= right {
-        spans.push(Span::styled(" │ ", Style::default().fg(theme.border)));
-        x += 3;
-        app.plus_rect = Some(Rect::new(x as u16, area.y, 3, 1));
-        spans.push(Span::styled(" + ", Style::default().fg(theme.caption)));
-    }
     f.render_widget(Paragraph::new(Line::from(spans)), area);
-}
-
-/// The right-click tab popup (issue #94) — local tab actions only; nothing
-/// here is sent to the agent. Phase 1 carries Close; new items extend
-/// `TabMenuItem` and this list together. The rect is recorded for
-/// `App::tab_menu_item_at` hit-testing.
-fn draw_tab_menu(f: &mut Frame, app: &mut App, area: Rect) {
-    app.tab_menu_rect = None;
-    let Some(menu) = &app.tab_menu else {
-        return;
-    };
-    let theme = app.theme;
-    let items = [app.locale.tr("Close tab", "关闭标签页")];
-    let width = items
-        .iter()
-        .map(|item| item.width())
-        .max()
-        .unwrap_or(0) as u16
-        + 4;
-    let height = items.len() as u16 + 2;
-    let x = menu.at.0.min(area.width.saturating_sub(width));
-    let y = menu.at.1.saturating_add(1).min(area.height.saturating_sub(height));
-    let rect = Rect::new(x, y, width, height);
-    app.tab_menu_rect = Some(rect);
-    let lines: Vec<Line> = items
-        .iter()
-        .map(|item| Line::from(Span::styled(format!(" {item} "), Style::default().fg(theme.fg))))
-        .collect();
-    let block = Block::default()
-        .borders(Borders::ALL)
-        .border_type(BorderType::Rounded)
-        .border_style(Style::default().fg(theme.border))
-        .style(Style::default().bg(theme.panel).fg(theme.fg));
-    f.render_widget(Paragraph::new(lines).block(block), rect);
 }
 
 fn draw_child_navigation(f: &mut Frame, app: &App, area: Rect) {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -158,6 +158,8 @@ pub fn draw(f: &mut Frame, app: &mut App) {
     let area = f.area();
     let theme = app.theme;
     app.slot_actions.clear();
+    app.tab_rects.clear();
+    app.plus_rect = None;
     app.pet_want = None;
     app.caret_cell = None;
     // The mouse-only expand button's frame rect is rebuilt by
@@ -181,7 +183,21 @@ pub fn draw(f: &mut Frame, app: &mut App) {
         return;
     }
 
-    let (main, right) = shell_areas(area, app);
+    // Session tab strip (issue #94): one native chrome row at the very top,
+    // only when more than one session is open — a single session keeps the
+    // frame layout byte-identical to before.
+    let tabs_h = if app.session_tab_count() > 1 { 1 } else { 0 };
+    let body = Rect::new(
+        area.x,
+        area.y + tabs_h,
+        area.width,
+        area.height - tabs_h,
+    );
+    if tabs_h > 0 {
+        draw_session_tabs(f, app, Rect::new(area.x, area.y, area.width, 1));
+    }
+
+    let (main, right) = shell_areas(body, app);
 
     // Composer card: one rounded box wrapping the cap row (dock / tip /
     // · workspace title) and the native input surface (input well on top,
@@ -356,6 +372,7 @@ pub fn draw(f: &mut Frame, app: &mut App) {
         // composer (drawn last so it tops the menu-free chat area).
         draw_attachment_preview(f, app, composer, area);
     }
+    draw_tab_menu(f, app, area);
     draw_model_picker(f, app, area);
     draw_plugin_tree(f, app, area);
     draw_plugin_slider(f, app, area);
@@ -980,6 +997,105 @@ fn draw_right_slot(f: &mut Frame, app: &App, area: Rect) {
         ))
         .style(Style::default().bg(theme.surface).fg(theme.fg));
     f.render_widget(Paragraph::new(lines).block(block), area);
+}
+
+/// The session tab strip (issue #94) — native status chrome fed by
+/// per-session running facts, the same source as `state_line`. Per tab: a
+/// running indicator (spinner live, ● parked), a ✓ completion badge for a
+/// session that finished while parked, and a title/short-id label; the
+/// trailing `+` cell opens a fresh session. Tab rects are recorded for
+/// `App::tab_at` mouse hit-testing.
+fn draw_session_tabs(f: &mut Frame, app: &mut App, area: Rect) {
+    let theme = app.theme;
+    let tabs = app.session_tabs();
+    let spinner = app.spinner();
+    let right = area.right() as usize;
+    let mut spans: Vec<Span> = Vec::new();
+    let mut x = area.x as usize;
+    for (idx, tab) in tabs.iter().enumerate() {
+        if idx > 0 {
+            if x + 3 > right {
+                break;
+            }
+            spans.push(Span::styled(" │ ", Style::default().fg(theme.border)));
+            x += 3;
+        }
+        let label = crate::transcript::clamp_str(&tab.label, 16);
+        let (indicator, indicator_style) = if tab.running {
+            (
+                if tab.current {
+                    spinner.to_string()
+                } else {
+                    "●".to_string()
+                },
+                Style::default().fg(theme.brand),
+            )
+        } else if tab.completed_unseen {
+            ("✓".to_string(), Style::default().fg(theme.warn_soft()))
+        } else {
+            ("·".to_string(), Style::default().fg(theme.caption))
+        };
+        let label_style = if tab.current {
+            Style::default().fg(theme.fg).add_modifier(Modifier::BOLD)
+        } else {
+            Style::default().fg(theme.fg_tertiary)
+        };
+        let width = indicator.width() + label.width() + 3;
+        if x + width > right {
+            break;
+        }
+        app.tab_rects.push((
+            Rect::new(x as u16, area.y, width as u16, 1),
+            idx,
+        ));
+        spans.push(Span::styled(
+            format!(" {indicator} ",),
+            indicator_style,
+        ));
+        spans.push(Span::styled(format!("{label} "), label_style));
+        x += width;
+    }
+    if x + 6 <= right {
+        spans.push(Span::styled(" │ ", Style::default().fg(theme.border)));
+        x += 3;
+        app.plus_rect = Some(Rect::new(x as u16, area.y, 3, 1));
+        spans.push(Span::styled(" + ", Style::default().fg(theme.caption)));
+    }
+    f.render_widget(Paragraph::new(Line::from(spans)), area);
+}
+
+/// The right-click tab popup (issue #94) — local tab actions only; nothing
+/// here is sent to the agent. Phase 1 carries Close; new items extend
+/// `TabMenuItem` and this list together. The rect is recorded for
+/// `App::tab_menu_item_at` hit-testing.
+fn draw_tab_menu(f: &mut Frame, app: &mut App, area: Rect) {
+    app.tab_menu_rect = None;
+    let Some(menu) = &app.tab_menu else {
+        return;
+    };
+    let theme = app.theme;
+    let items = [app.locale.tr("Close tab", "关闭标签页")];
+    let width = items
+        .iter()
+        .map(|item| item.width())
+        .max()
+        .unwrap_or(0) as u16
+        + 4;
+    let height = items.len() as u16 + 2;
+    let x = menu.at.0.min(area.width.saturating_sub(width));
+    let y = menu.at.1.saturating_add(1).min(area.height.saturating_sub(height));
+    let rect = Rect::new(x, y, width, height);
+    app.tab_menu_rect = Some(rect);
+    let lines: Vec<Line> = items
+        .iter()
+        .map(|item| Line::from(Span::styled(format!(" {item} "), Style::default().fg(theme.fg))))
+        .collect();
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .border_style(Style::default().fg(theme.border))
+        .style(Style::default().bg(theme.panel).fg(theme.fg));
+    f.render_widget(Paragraph::new(lines).block(block), rect);
 }
 
 fn draw_child_navigation(f: &mut Frame, app: &App, area: Rect) {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -999,10 +999,11 @@ fn draw_right_slot(f: &mut Frame, app: &App, area: Rect) {
 
 /// The session tab strip (issue #94) — native status chrome fed by
 /// per-session running facts, the same source as `state_line`. Per tab: a
-/// running indicator (spinner live, ● parked), a ✓ completion badge for a
-/// session that finished while parked, and a title/short-id label; the
-/// trailing `+` cell opens a fresh session. Tab rects are recorded for
-/// `App::tab_at` mouse hit-testing.
+/// status indicator, a ✓ completion badge for a session that finished
+/// while parked, and a title/short-id label. A `?` indicator (warn color)
+/// marks a tab whose session has an unanswered ACP ask (permission or
+/// elicitation) — the agent is waiting on that tab. Tab rects are recorded
+/// for `App::tab_at` mouse hit-testing.
 fn draw_session_tabs(f: &mut Frame, app: &mut App, area: Rect) {
     let theme = app.theme;
     let tabs = app.session_tabs();
@@ -1019,7 +1020,11 @@ fn draw_session_tabs(f: &mut Frame, app: &mut App, area: Rect) {
             x += 3;
         }
         let label = crate::transcript::clamp_str(&tab.label, 16);
-        let (indicator, indicator_style) = if tab.running {
+        let (indicator, indicator_style) = if tab.ask_pending {
+            // A session-bound ask outranks every other badge: the agent is
+            // blocked until this tab answers.
+            ("?".to_string(), Style::default().fg(theme.warn))
+        } else if tab.running {
             (
                 if tab.current {
                     spinner.to_string()

--- a/tests/unit/acp__tests.rs
+++ b/tests/unit/acp__tests.rs
@@ -899,7 +899,12 @@ async fn elicitation_create_waits_for_the_tui_form_reply() {
     let mut form_reply = None;
     while Instant::now() < deadline {
         match bus_rx.recv_timeout(Duration::from_millis(20)) {
-            Ok(AppEvent::ElicitationAsk { form, reply }) => {
+            Ok(AppEvent::ElicitationAsk {
+                session_id,
+                form,
+                reply,
+            }) => {
+                assert_eq!(session_id.as_deref(), Some("s1"));
                 assert_eq!(form.fields[0].title, "Target");
                 form_reply = Some(reply);
                 break;

--- a/tests/unit/acp__tests.rs
+++ b/tests/unit/acp__tests.rs
@@ -1678,7 +1678,7 @@ async fn auth_failure_parks_prompts_but_reports_steers_back_to_the_client() {
     for text in ["first", "second"] {
         cmd_tx
             .send(Cmd::Prompt {
-                session_id: "local-draft".into(),
+                session_id: "s1".into(),
                 text: text.into(),
             })
             .expect("prompt");
@@ -1709,13 +1709,13 @@ async fn auth_failure_parks_prompts_but_reports_steers_back_to_the_client() {
     assert!(needs_auth, "the active prompt requests sign-in");
     cmd_tx
         .send(Cmd::Prompt {
-            session_id: "local-draft".into(),
+            session_id: "s1".into(),
             text: "third".into(),
         })
         .expect("prompt entered while auth is unresolved");
     cmd_tx
         .send(Cmd::PromptImages {
-            session_id: "local-draft".into(),
+            session_id: "s1".into(),
             blocks: vec![crate::bus::PromptBlock::Text(
                 "image group during auth".into(),
             )],
@@ -1723,14 +1723,14 @@ async fn auth_failure_parks_prompts_but_reports_steers_back_to_the_client() {
         .expect("image prompt entered while auth is unresolved");
     cmd_tx
         .send(Cmd::Steer {
-            session_id: "local-draft".into(),
+            session_id: "s1".into(),
             message_id: 7,
             text: "steer during auth".into(),
         })
         .expect("steer entered while auth is unresolved");
     cmd_tx
         .send(Cmd::SteerImages {
-            session_id: "local-draft".into(),
+            session_id: "s1".into(),
             message_id: 8,
             blocks: vec![crate::bus::PromptBlock::Text(
                 "image steer during auth".into(),
@@ -2066,7 +2066,7 @@ async fn late_steer_rejection_is_not_retried_by_the_transport_after_auth() {
 
     cmd_tx
         .send(Cmd::Prompt {
-            session_id: "local-draft".into(),
+            session_id: "s1".into(),
             text: "first".into(),
         })
         .expect("first prompt");
@@ -2079,7 +2079,7 @@ async fn late_steer_rejection_is_not_retried_by_the_transport_after_auth() {
     );
     cmd_tx
         .send(Cmd::Steer {
-            session_id: "local-draft".into(),
+            session_id: "s1".into(),
             message_id: 9,
             text: "steer".into(),
         })
@@ -2303,7 +2303,7 @@ async fn steer_sends_a_concurrent_prompt_without_interrupting_the_turn() {
     );
     while let Ok(event) = bus_rx.try_recv() {
         assert!(
-            !matches!(event, AppEvent::Ctl(CtlEvent::Interrupted)),
+            !matches!(event, AppEvent::Ctl(CtlEvent::Interrupted { .. })),
             "steer is part of the active turn, not an interruption"
         );
     }
@@ -2640,4 +2640,320 @@ async fn attach_fd_socketpair_reads_without_eagain() {
         .await
         .expect("read should not be EAGAIN");
     assert_eq!(&buf, b"hello\n");
+}
+
+#[test]
+fn cmd_session_resolution_honors_carried_id_falls_back_and_rejects_unknown() {
+    let mut sessions = HashMap::<String, SessionHandle>::new();
+    sessions.insert("s1".into(), SessionHandle::default());
+    let current = Some(SessionId::new("s1"));
+
+    // An empty field falls back to the most recently bound session.
+    let fallback = resolve_cmd_session(&sessions, &current, "", "prompt").expect("fallback");
+    assert_eq!(fallback.expect("current session").to_string(), "s1");
+
+    // A bound id is honored exactly as carried.
+    let carried = resolve_cmd_session(&sessions, &current, "s1", "prompt").expect("carried");
+    assert_eq!(carried.expect("bound session").to_string(), "s1");
+
+    // An id this connection never bound is rejected, not rerouted.
+    let err = resolve_cmd_session(&sessions, &current, "ghost", "prompt").expect_err("unknown id");
+    assert!(err.contains("ghost"), "error names the id: {err}");
+
+    // Before the first session exists, any carried id is a local placeholder
+    // with no server meaning yet; it resolves to "no session" like "".
+    let empty = HashMap::<String, SessionHandle>::new();
+    assert!(resolve_cmd_session(&empty, &None, "dsh-draft", "prompt")
+        .expect("placeholder")
+        .is_none());
+    assert!(resolve_cmd_session(&empty, &None, "", "prompt")
+        .expect("no session")
+        .is_none());
+}
+
+#[test]
+fn bind_session_registers_current_and_adopts_pending_prompts() {
+    let mut sessions = HashMap::<String, SessionHandle>::new();
+    let mut current = None;
+    let mut pending = VecDeque::from([Cmd::Prompt {
+        session_id: "dsh-draft".into(),
+        text: "early".into(),
+    }]);
+
+    bind_session(
+        &mut sessions,
+        &mut current,
+        &mut pending,
+        SessionId::new("s1"),
+    );
+
+    assert_eq!(current.expect("current").to_string(), "s1");
+    assert!(pending.is_empty(), "pending prompts move into the session");
+    let handle = sessions.get("s1").expect("registered");
+    assert!(handle.inflight.is_none());
+    assert_eq!(handle.queue.len(), 1);
+    assert!(matches!(
+        handle.queue.front(),
+        Some(Cmd::Prompt { text, .. }) if text == "early"
+    ));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn sessions_run_concurrent_prompts_on_one_connection() {
+    use agent_client_protocol::schema::v1::{
+        AgentCapabilities, InitializeRequest, InitializeResponse, NewSessionRequest,
+        NewSessionResponse, PromptResponse, StopReason,
+    };
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::time::{Duration, Instant};
+
+    let new_calls = Arc::new(AtomicUsize::new(0));
+    let (arrived_tx, mut arrived_rx) = tokio::sync::mpsc::unbounded_channel::<String>();
+    let (release_s1_tx, release_s1_rx) = tokio::sync::oneshot::channel::<()>();
+    let release_s1_tx = Arc::new(Mutex::new(Some(release_s1_tx)));
+    let release_s1_rx = Arc::new(Mutex::new(Some(release_s1_rx)));
+
+    let agent = Agent
+        .builder()
+        .name("multi-session-mock")
+        .on_receive_request(
+            async move |init: InitializeRequest, responder, _cx| {
+                responder.respond(
+                    InitializeResponse::new(init.protocol_version)
+                        .agent_capabilities(AgentCapabilities::new())
+                        .agent_info(Implementation::new("multi-session-mock", "0")),
+                )
+            },
+            on_receive_request!(),
+        )
+        .on_receive_request(
+            {
+                let new_calls = Arc::clone(&new_calls);
+                async move |_req: NewSessionRequest, responder, _cx| {
+                    let n = new_calls.fetch_add(1, Ordering::SeqCst);
+                    responder.respond(NewSessionResponse::new(SessionId::new(format!(
+                        "s{}",
+                        n + 1
+                    ))))
+                }
+            },
+            on_receive_request!(),
+        )
+        .on_receive_request(
+            {
+                let release_s1_tx = Arc::clone(&release_s1_tx);
+                let release_s1_rx = Arc::clone(&release_s1_rx);
+                async move |req: PromptRequest, responder, cx| {
+                    let sid = req.session_id.to_string();
+                    let _ = arrived_tx.send(sid.clone());
+                    if sid == "s1" {
+                        // Hold s1's response until s2's prompt also arrived:
+                        // with a single connection-level in-flight prompt this
+                        // would deadlock, so completing proves the demux.
+                        let release = release_s1_rx.lock().unwrap().take();
+                        cx.spawn(async move {
+                            if let Some(release) = release {
+                                let _ = release.await;
+                            }
+                            let _ = responder.respond(PromptResponse::new(StopReason::EndTurn));
+                            Ok(())
+                        })?;
+                        Ok(())
+                    } else {
+                        if let Some(tx) = release_s1_tx.lock().unwrap().take() {
+                            let _ = tx.send(());
+                        }
+                        responder.respond(PromptResponse::new(StopReason::EndTurn))
+                    }
+                }
+            },
+            on_receive_request!(),
+        );
+    let cfg = RuntimeConfig {
+        bin: "demo".into(),
+        cordis: "demo".into(),
+        workspace: "/tmp".into(),
+        session_root: "/tmp".into(),
+        provider: "deepseek-official".into(),
+        model: "deepseek-v4-flash".into(),
+        max_tokens: None,
+        base_url: None,
+        api_key: None,
+    };
+    let (bus_tx, bus_rx) = std::sync::mpsc::channel();
+    let (cmd_tx, cmd_rx) = std::sync::mpsc::channel();
+    let client = tokio::spawn(async move { connect(agent, cfg, bus_tx, cmd_rx).await });
+
+    // Startup binds s1; /new binds s2 and becomes the fallback session.
+    cmd_tx.send(Cmd::NewSession).expect("new session");
+    let deadline = Instant::now() + Duration::from_secs(2);
+    let mut bound = std::collections::HashSet::new();
+    while Instant::now() < deadline && !bound.contains("s2") {
+        match bus_rx.recv_timeout(Duration::from_millis(20)) {
+            Ok(AppEvent::Ctl(CtlEvent::SessionBound { session_id, .. })) => {
+                bound.insert(session_id);
+            }
+            Ok(_) => {}
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {}
+            Err(err) => panic!("{err}"),
+        }
+    }
+    assert!(bound.contains("s2"), "second session bound: {bound:?}");
+
+    // Prompt s1 explicitly even though s2 is the most recently bound session.
+    cmd_tx
+        .send(Cmd::Prompt {
+            session_id: "s1".into(),
+            text: "a".into(),
+        })
+        .expect("prompt s1");
+    assert_eq!(
+        tokio::time::timeout(Duration::from_secs(2), arrived_rx.recv())
+            .await
+            .expect("s1 prompt reaches the agent")
+            .as_deref(),
+        Some("s1"),
+        "the carried session id addresses the prompt, not the fallback",
+    );
+    cmd_tx
+        .send(Cmd::Prompt {
+            session_id: "s2".into(),
+            text: "b".into(),
+        })
+        .expect("prompt s2");
+    assert_eq!(
+        tokio::time::timeout(Duration::from_secs(2), arrived_rx.recv())
+            .await
+            .expect("s2 prompt reaches the agent while s1 is still in flight")
+            .as_deref(),
+        Some("s2"),
+    );
+
+    let deadline = Instant::now() + Duration::from_secs(2);
+    let mut turn_ends = std::collections::HashSet::new();
+    while Instant::now() < deadline && turn_ends.len() < 2 {
+        match bus_rx.recv_timeout(Duration::from_millis(20)) {
+            Ok(AppEvent::Ui(crate::events::UiEvent::TurnEnd { session, kind }))
+                if kind == "completed" =>
+            {
+                turn_ends.insert(session);
+            }
+            Ok(_) => {}
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {}
+            Err(err) => panic!("{err}"),
+        }
+    }
+    assert_eq!(
+        turn_ends,
+        std::collections::HashSet::from(["s1".to_string(), "s2".to_string()]),
+        "each session's completion is tagged with its own id",
+    );
+
+    let _ = cmd_tx.send(Cmd::Shutdown);
+    let _ = client.await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn prompt_for_an_unbound_session_is_rejected_not_rerouted() {
+    use agent_client_protocol::schema::v1::{
+        AgentCapabilities, InitializeRequest, InitializeResponse, NewSessionRequest,
+        NewSessionResponse, PromptResponse, StopReason,
+    };
+    use std::time::{Duration, Instant};
+
+    let (prompt_tx, mut prompt_rx) = tokio::sync::mpsc::unbounded_channel::<String>();
+    let agent = Agent
+        .builder()
+        .name("unknown-session-mock")
+        .on_receive_request(
+            async move |init: InitializeRequest, responder, _cx| {
+                responder.respond(
+                    InitializeResponse::new(init.protocol_version)
+                        .agent_capabilities(AgentCapabilities::new())
+                        .agent_info(Implementation::new("unknown-session-mock", "0")),
+                )
+            },
+            on_receive_request!(),
+        )
+        .on_receive_request(
+            async move |_req: NewSessionRequest, responder, _cx| {
+                responder.respond(NewSessionResponse::new(SessionId::new("s1")))
+            },
+            on_receive_request!(),
+        )
+        .on_receive_request(
+            async move |req: PromptRequest, responder, _cx| {
+                let _ = prompt_tx.send(req.session_id.to_string());
+                responder.respond(PromptResponse::new(StopReason::EndTurn))
+            },
+            on_receive_request!(),
+        );
+    let cfg = RuntimeConfig {
+        bin: "demo".into(),
+        cordis: "demo".into(),
+        workspace: "/tmp".into(),
+        session_root: "/tmp".into(),
+        provider: "deepseek-official".into(),
+        model: "deepseek-v4-flash".into(),
+        max_tokens: None,
+        base_url: None,
+        api_key: None,
+    };
+    let (bus_tx, bus_rx) = std::sync::mpsc::channel();
+    let (cmd_tx, cmd_rx) = std::sync::mpsc::channel();
+    let client = tokio::spawn(async move { connect(agent, cfg, bus_tx, cmd_rx).await });
+
+    let deadline = Instant::now() + Duration::from_secs(2);
+    while Instant::now() < deadline {
+        match bus_rx.recv_timeout(Duration::from_millis(20)) {
+            Ok(AppEvent::Ctl(CtlEvent::SessionBound { .. })) => break,
+            Ok(_) => {}
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {}
+            Err(err) => panic!("{err}"),
+        }
+    }
+
+    cmd_tx
+        .send(Cmd::Prompt {
+            session_id: "ghost".into(),
+            text: "boo".into(),
+        })
+        .expect("prompt for an unbound session");
+    let deadline = Instant::now() + Duration::from_secs(2);
+    let mut rejection = None;
+    while Instant::now() < deadline && rejection.is_none() {
+        match bus_rx.recv_timeout(Duration::from_millis(20)) {
+            Ok(AppEvent::Ctl(CtlEvent::Error(err))) if err.contains("unknown session") => {
+                rejection = Some(err);
+            }
+            Ok(_) => {}
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {}
+            Err(err) => panic!("{err}"),
+        }
+    }
+    assert_eq!(rejection.as_deref(), Some("prompt: unknown session ghost"));
+    assert!(
+        tokio::time::timeout(Duration::from_millis(200), prompt_rx.recv())
+            .await
+            .is_err(),
+        "an unbound session id must not be rerouted to the fallback session",
+    );
+
+    // The bound session keeps working after the rejection.
+    cmd_tx
+        .send(Cmd::Prompt {
+            session_id: "s1".into(),
+            text: "real".into(),
+        })
+        .expect("prompt for the bound session");
+    assert_eq!(
+        tokio::time::timeout(Duration::from_secs(2), prompt_rx.recv())
+            .await
+            .expect("bound session still prompts")
+            .as_deref(),
+        Some("s1"),
+    );
+
+    let _ = cmd_tx.send(Cmd::Shutdown);
+    let _ = client.await;
 }

--- a/tests/unit/app__mode_tests.rs
+++ b/tests/unit/app__mode_tests.rs
@@ -3978,6 +3978,7 @@ fn acp_permission_ask_enter_selects_option_id() {
     let (tx, rx) = tokio::sync::oneshot::channel();
     app.handle(
         AppEvent::PermissionAsk {
+            session_id: "dsh-test".into(),
             title: "bash".into(),
             options: ask_options(),
             reply: tx,
@@ -4002,6 +4003,7 @@ fn acp_permission_ask_esc_cancels() {
     let (tx, rx) = tokio::sync::oneshot::channel();
     app.handle(
         AppEvent::PermissionAsk {
+            session_id: "dsh-test".into(),
             title: "bash".into(),
             options: ask_options(),
             reply: tx,
@@ -4028,6 +4030,7 @@ fn acp_elicitation_form_opens_and_returns_the_selected_value() {
     let (tx, rx) = tokio::sync::oneshot::channel();
     app.handle(
         AppEvent::ElicitationAsk {
+            session_id: Some("dsh-test".into()),
             form: ElicitationForm {
                 message: "The agent needs your input.".into(),
                 fields: vec![ElicitationField {

--- a/tests/unit/app__mode_tests.rs
+++ b/tests/unit/app__mode_tests.rs
@@ -1174,12 +1174,17 @@ fn preset_ack_folds_the_chip_and_new_session_waits_for_the_host_mode() {
 }
 
 #[test]
-fn live_acp_new_does_not_invent_a_local_id() {
+fn live_acp_new_parks_the_current_session_and_binds_the_new_tab() {
     let (mut app, ctl, _rx) = test_app();
     app.demo = false;
     let before = app.session_id.clone();
     app.run_slash("new", "fresh", &ctl);
-    assert_eq!(app.session_id, before, "ACP /new waits for session/new");
+    assert_ne!(
+        app.session_id, before,
+        "ACP /new switches to a fresh placeholder tab"
+    );
+    assert_eq!(app.parked.len(), 1, "previous session parked, not dropped");
+    assert_eq!(app.parked[0].id, before);
     app.handle(
         AppEvent::Ctl(CtlEvent::SessionBound {
             session_id: "acp-9".into(),
@@ -1187,7 +1192,8 @@ fn live_acp_new_does_not_invent_a_local_id() {
         }),
         &ctl,
     );
-    assert_eq!(app.session_id, "acp-9");
+    assert_eq!(app.session_id, "acp-9", "the new tab gets the real id");
+    assert_eq!(app.parked[0].id, before, "the parked session keeps its id");
 }
 
 #[test]
@@ -1741,7 +1747,9 @@ fn terminal_lifecycle_events_release_a_pending_first_prompt() {
     let events = vec![
         AppEvent::RuntimeExited(None),
         AppEvent::Ctl(CtlEvent::Error("failed".into())),
-        AppEvent::Ctl(CtlEvent::Interrupted),
+        AppEvent::Ctl(CtlEvent::Interrupted {
+            session_id: "dsh-test".into(),
+        }),
         AppEvent::Ui(crate::events::UiEvent::SessionStatus {
             session: "dsh-test".into(),
             running: false,
@@ -1904,7 +1912,12 @@ fn interrupted_advances_one_client_followup_and_queues_later_input_behind_it() {
     app.state = RunState::Running;
     app.state_note = "cancelling".into();
     app.send_agent_text("first followup".into(), &ctl);
-    app.handle(AppEvent::Ctl(CtlEvent::Interrupted), &ctl);
+    app.handle(
+        AppEvent::Ctl(CtlEvent::Interrupted {
+            session_id: "dsh-test".into(),
+        }),
+        &ctl,
+    );
     assert!(matches!(app.state, RunState::Starting));
     assert_eq!(app.queued, 0);
     assert!(matches!(
@@ -1933,7 +1946,12 @@ fn interrupted_turn_renders_one_specific_terminal_notice() {
         }),
         &ctl,
     );
-    app.handle(AppEvent::Ctl(CtlEvent::Interrupted), &ctl);
+    app.handle(
+        AppEvent::Ctl(CtlEvent::Interrupted {
+            session_id: "dsh-test".into(),
+        }),
+        &ctl,
+    );
 
     let notices = app
         .transcript
@@ -1954,7 +1972,12 @@ fn staged_input_joins_a_surviving_fifo_after_interrupt() {
     let (mut app, ctl, _rx) = test_app();
     app.state = RunState::Running;
     app.send_agent_text("first followup".into(), &ctl);
-    app.handle(AppEvent::Ctl(CtlEvent::Interrupted), &ctl);
+    app.handle(
+        AppEvent::Ctl(CtlEvent::Interrupted {
+            session_id: "dsh-test".into(),
+        }),
+        &ctl,
+    );
 
     app.send_staged(
         vec![StagedBlock::Image(crate::attachments::Attachment {
@@ -1982,7 +2005,12 @@ fn send_now_can_steer_while_a_surviving_fifo_is_advancing() {
     let (mut app, ctl, _rx) = test_app();
     app.state = RunState::Running;
     app.send_agent_text("ordinary followup".into(), &ctl);
-    app.handle(AppEvent::Ctl(CtlEvent::Interrupted), &ctl);
+    app.handle(
+        AppEvent::Ctl(CtlEvent::Interrupted {
+            session_id: "dsh-test".into(),
+        }),
+        &ctl,
+    );
     app.input.set("urgent correction".into());
 
     app.send_now(&ctl);
@@ -2110,7 +2138,12 @@ fn interrupted_turn_releases_one_client_queued_prompt() {
     app.send_agent_text("first followup".into(), &ctl);
     app.send_agent_text("second followup".into(), &ctl);
 
-    app.handle(AppEvent::Ctl(CtlEvent::Interrupted), &ctl);
+    app.handle(
+        AppEvent::Ctl(CtlEvent::Interrupted {
+            session_id: "dsh-test".into(),
+        }),
+        &ctl,
+    );
 
     assert!(matches!(
         commands.recv_timeout(std::time::Duration::from_secs(1)),

--- a/tests/unit/app__resume_tests.rs
+++ b/tests/unit/app__resume_tests.rs
@@ -277,3 +277,24 @@ fn picker_page_keys_jump_a_screenful_and_home_end_pin_the_ends() {
     assert_eq!(app.picker.as_ref().unwrap().sel, 39, "↑ still wraps");
     let _ = std::fs::remove_dir_all(&root);
 }
+
+#[test]
+fn acp_resume_dismisses_the_welcome_banner_before_the_replay_streams() {
+    let root = tmp_root("banner");
+    let (mut app, ctl) = test_app_with_root(root.to_str().unwrap(), "/w");
+
+    // A fresh app starts on the welcome banner; a /resume that loads real
+    // history must dismiss it — draw_chat only ever paints the banner or
+    // the transcript, never both (the local JSONL path already did this;
+    // the ACP session/load path did not, hiding every replayed message
+    // until the first prompt+send cleared the banner).
+    assert!(app.show_banner, "fresh app shows the welcome banner");
+    app.load_acp_session("acp-old", &ctl);
+
+    assert!(
+        !app.show_banner,
+        "ACP resume hides the banner so the loaded transcript paints"
+    );
+    assert_eq!(app.session_id, "acp-old", "switched to the loaded session");
+    let _ = std::fs::remove_dir_all(&root);
+}

--- a/tests/unit/app__resume_tests.rs
+++ b/tests/unit/app__resume_tests.rs
@@ -146,6 +146,9 @@ fn acp_resume_usage_snapshot_reaches_the_footer_once() {
     let root = tmp_root("acp-usage");
     let (mut app, ctl) = test_app_with_root(root.to_str().unwrap(), "/w");
 
+    // Multi-session routing (issue #94): updates only reach the footer of
+    // the session they are tagged with, so load the session first.
+    app.load_acp_session("dsh-loaded", &ctl);
     app.handle(
         AppEvent::Rpc {
             method: "session/update".into(),

--- a/tests/unit/app__session_tabs_tests.rs
+++ b/tests/unit/app__session_tabs_tests.rs
@@ -218,37 +218,11 @@ fn parked_session_idle_dispatches_its_own_queue() {
 }
 
 #[test]
-fn closing_tabs_keeps_the_rest_in_order() {
-    let (mut app, ctl, _rx) = test_app();
-    app.run_slash("new", "s-two", &ctl);
-    app.run_slash("new", "s-three", &ctl);
-    // Tabs: [dsh-test, s-two, s-three]; viewing s-three.
-    assert_eq!(app.session_tab_count(), 3);
-    assert_eq!(app.session_id, "s-three");
-
-    // Closing the viewed tab moves to the left neighbor (it was last).
-    app.close_session(2);
-    assert_eq!(app.session_id, "s-two");
-    let labels: Vec<String> = app.session_tabs().into_iter().map(|t| t.label).collect();
-    assert_eq!(labels, ["dsh-test", "s-two"]);
-
-    // Closing a parked tab left of the live one keeps the view put.
-    app.close_session(0);
-    assert_eq!(app.session_id, "s-two");
-    assert_eq!(app.session_tab_count(), 1);
-
-    // The last remaining session is never closed.
-    app.close_session(0);
-    assert_eq!(app.session_id, "s-two");
-    assert_eq!(app.session_tab_count(), 1);
-}
-
-#[test]
 fn tab_strip_renders_only_with_multiple_sessions() {
     let (mut app, ctl, _rx) = test_app();
     let single = crate::ui::dump_frame(&mut app, 100, 30);
     assert!(
-        !single.lines().next().unwrap_or_default().contains('+'),
+        !single.lines().next().unwrap_or_default().contains("· dsh-test"),
         "one session renders no tab strip:\n{single}"
     );
 
@@ -257,7 +231,7 @@ fn tab_strip_renders_only_with_multiple_sessions() {
     let row0 = frame.lines().next().unwrap_or_default();
     assert!(row0.contains("dsh-test"), "parked tab label:\n{frame}");
     assert!(row0.contains("s-two"), "live tab label:\n{frame}");
-    assert!(row0.contains('+'), "plus cell:\n{frame}");
+    assert!(row0.contains('│'), "tab separator:\n{frame}");
 }
 
 #[test]

--- a/tests/unit/app__session_tabs_tests.rs
+++ b/tests/unit/app__session_tabs_tests.rs
@@ -1,0 +1,304 @@
+use super::*;
+use std::sync::mpsc::Receiver;
+
+/// Unique session root per call — keeps persisted UI fixtures isolated.
+fn fresh_root() -> String {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static N: AtomicU64 = AtomicU64::new(0);
+    let dir = std::env::temp_dir().join(format!(
+        "dsh-tui-tabs-{}-{}",
+        std::process::id(),
+        N.fetch_add(1, Ordering::Relaxed),
+    ));
+    let _ = std::fs::create_dir_all(&dir);
+    dir.to_string_lossy().into_owned()
+}
+
+fn test_cfg() -> RuntimeConfig {
+    RuntimeConfig {
+        bin: "demo".into(),
+        cordis: "demo".into(),
+        workspace: "/tmp".into(),
+        session_root: fresh_root(),
+        provider: "deepseek-official".into(),
+        model: "deepseek-v4-flash".into(),
+        max_tokens: None,
+        base_url: None,
+        api_key: None,
+    }
+}
+
+fn test_app() -> (App, Controller, Receiver<AppEvent>) {
+    let cfg = test_cfg();
+    let (tx, rx) = std::sync::mpsc::channel::<AppEvent>();
+    let ctl = Controller::start(cfg.clone(), true, None, tx.clone());
+    let app = App::new(Some(Theme::dark()), cfg, "dsh-test".into(), true, false, tx);
+    (app, ctl, rx)
+}
+
+fn transcript_text(transcript: &mut Transcript) -> String {
+    transcript
+        .lines(&Theme::dark(), 80, ' ')
+        .iter()
+        .flat_map(|l| l.spans.iter().map(|s| s.content.to_string()))
+        .collect()
+}
+
+fn final_event(session: &str, text: &str) -> crate::events::UiEvent {
+    crate::events::UiEvent::AssistantFinal {
+        session: session.into(),
+        text: text.into(),
+        model: None,
+    }
+}
+
+#[test]
+fn parked_session_events_land_in_their_slot_only() {
+    let (mut app, _ctl, _rx) = test_app();
+    app.transcript.push_user("live prompt".into(), false);
+    app.open_new_session("s-two".into(), true);
+    assert_eq!(app.session_id, "s-two");
+    assert_eq!(app.parked.len(), 1);
+    let live_before = transcript_text(&mut app.transcript);
+
+    app.apply_ui(final_event("dsh-test", "old session answer"));
+
+    assert!(
+        transcript_text(&mut app.parked[0].transcript).contains("old session answer"),
+        "event folded into the parked slot"
+    );
+    assert_eq!(
+        transcript_text(&mut app.transcript),
+        live_before,
+        "live transcript untouched by a parked session's event"
+    );
+}
+
+#[test]
+fn unknown_session_events_never_reach_any_transcript() {
+    let (mut app, _ctl, _rx) = test_app();
+    app.open_new_session("s-two".into(), true);
+    let live_before = transcript_text(&mut app.transcript);
+    let parked_before = transcript_text(&mut app.parked[0].transcript);
+
+    app.apply_ui(final_event("s-foreign", "foreign answer"));
+
+    assert_eq!(transcript_text(&mut app.transcript), live_before);
+    assert_eq!(transcript_text(&mut app.parked[0].transcript), parked_before);
+}
+
+#[test]
+fn parked_completion_edge_badges_the_tab_and_switching_clears_it() {
+    let (mut app, _ctl, _rx) = test_app();
+    app.open_new_session("s-two".into(), true);
+    // The parked session (tab 0) runs, then goes idle while out of view.
+    app.apply_ui(crate::events::UiEvent::SessionStatus {
+        session: "dsh-test".into(),
+        running: true,
+    });
+    app.apply_ui(crate::events::UiEvent::SessionStatus {
+        session: "dsh-test".into(),
+        running: false,
+    });
+
+    let tabs = app.session_tabs();
+    assert_eq!(tabs.len(), 2);
+    assert!(tabs[0].completed_unseen, "running → idle edge badges the tab");
+    assert!(!tabs[1].completed_unseen);
+
+    app.switch_to_session(0);
+
+    assert_eq!(app.session_id, "dsh-test");
+    assert!(
+        !app.session_tabs()[0].completed_unseen,
+        "viewing the tab clears the badge"
+    );
+}
+
+#[test]
+fn switch_round_trip_preserves_transcripts_and_queues() {
+    let (mut app, ctl, _rx) = test_app();
+    app.transcript.push_user("alpha".into(), false);
+    app.state = RunState::Running;
+    app.send_agent_text("queued alpha".into(), &ctl);
+    assert_eq!(app.queued, 1);
+
+    app.run_slash("new", "s-two", &ctl);
+    assert_eq!(app.session_id, "s-two");
+    assert_eq!(app.queued, 0, "the new tab has its own empty queue");
+    assert!(!transcript_text(&mut app.transcript).contains("alpha"));
+    app.transcript.push_user("beta".into(), false);
+
+    app.switch_to_session(0);
+    assert_eq!(app.session_id, "dsh-test");
+    let text = transcript_text(&mut app.transcript);
+    assert!(text.contains("alpha"), "first transcript survives:\n{text}");
+    assert!(!text.contains("beta"));
+    assert_eq!(app.queued, 1, "first session's queue survives");
+    assert_eq!(app.state, RunState::Running, "running bit round-trips");
+
+    app.switch_to_session(1);
+    assert_eq!(app.session_id, "s-two");
+    let text = transcript_text(&mut app.transcript);
+    assert!(text.contains("beta"), "second transcript survives:\n{text}");
+    assert!(!text.contains("alpha"));
+}
+
+#[test]
+fn session_bound_lands_on_the_tab_that_asked() {
+    let (mut app, ctl, _rx) = test_app();
+    app.demo = false;
+    app.run_slash("new", "", &ctl);
+    let placeholder = app.session_id.clone();
+    assert!(
+        placeholder.starts_with("dsh-") && placeholder != "dsh-test",
+        "ACP /new opens a placeholder tab: {placeholder}"
+    );
+    assert_eq!(app.parked[0].id, "dsh-test", "previous session parked");
+
+    // The user switches away before session/new resolves.
+    app.switch_to_session(0);
+    assert_eq!(app.session_id, "dsh-test");
+    app.handle(
+        AppEvent::Ctl(CtlEvent::SessionBound {
+            session_id: "acp-9".into(),
+            notice: None,
+        }),
+        &ctl,
+    );
+
+    assert_eq!(
+        app.session_id, "dsh-test",
+        "the bind must not hijack the viewed tab"
+    );
+    let slot = app
+        .parked
+        .iter()
+        .find(|slot| slot.id == "acp-9")
+        .expect("bind landed on the tab that asked");
+    assert!(slot.session_bound);
+}
+
+#[test]
+fn parked_session_idle_dispatches_its_own_queue() {
+    let (mut app, _demo_ctl, _rx) = test_app();
+    let (ctl, commands) = crate::controller::tests::test_controller();
+    app.run_slash("new", "s-two", &ctl);
+    while commands.try_recv().is_ok() {} // /new's FetchSkills
+    app.parked[0].prompt_queue.push_back(ClientQueuedPrompt {
+        id: 7,
+        blocks: vec![StagedBlock::Text("followup".into())],
+    });
+    app.apply_ui(crate::events::UiEvent::SessionStatus {
+        session: "dsh-test".into(),
+        running: true,
+    });
+
+    app.handle(
+        AppEvent::Ui(crate::events::UiEvent::SessionStatus {
+            session: "dsh-test".into(),
+            running: false,
+        }),
+        &ctl,
+    );
+
+    match commands.try_recv() {
+        Ok(Cmd::Prompt { session_id, text }) => {
+            assert_eq!(session_id, "dsh-test", "addressed by its own session id");
+            assert_eq!(text, "followup");
+        }
+        other => panic!("expected the parked queue head to dispatch, got {other:?}"),
+    }
+    assert!(app.parked[0].prompt_queue.is_empty());
+    assert!(app.parked[0].prompt_pending);
+    assert!(
+        transcript_text(&mut app.parked[0].transcript).contains("followup"),
+        "dispatched prompt echoes into its own transcript"
+    );
+}
+
+#[test]
+fn closing_tabs_keeps_the_rest_in_order() {
+    let (mut app, ctl, _rx) = test_app();
+    app.run_slash("new", "s-two", &ctl);
+    app.run_slash("new", "s-three", &ctl);
+    // Tabs: [dsh-test, s-two, s-three]; viewing s-three.
+    assert_eq!(app.session_tab_count(), 3);
+    assert_eq!(app.session_id, "s-three");
+
+    // Closing the viewed tab moves to the left neighbor (it was last).
+    app.close_session(2);
+    assert_eq!(app.session_id, "s-two");
+    let labels: Vec<String> = app.session_tabs().into_iter().map(|t| t.label).collect();
+    assert_eq!(labels, ["dsh-test", "s-two"]);
+
+    // Closing a parked tab left of the live one keeps the view put.
+    app.close_session(0);
+    assert_eq!(app.session_id, "s-two");
+    assert_eq!(app.session_tab_count(), 1);
+
+    // The last remaining session is never closed.
+    app.close_session(0);
+    assert_eq!(app.session_id, "s-two");
+    assert_eq!(app.session_tab_count(), 1);
+}
+
+#[test]
+fn tab_strip_renders_only_with_multiple_sessions() {
+    let (mut app, ctl, _rx) = test_app();
+    let single = crate::ui::dump_frame(&mut app, 100, 30);
+    assert!(
+        !single.lines().next().unwrap_or_default().contains('+'),
+        "one session renders no tab strip:\n{single}"
+    );
+
+    app.run_slash("new", "s-two", &ctl);
+    let frame = crate::ui::dump_frame(&mut app, 100, 30);
+    let row0 = frame.lines().next().unwrap_or_default();
+    assert!(row0.contains("dsh-test"), "parked tab label:\n{frame}");
+    assert!(row0.contains("s-two"), "live tab label:\n{frame}");
+    assert!(row0.contains('+'), "plus cell:\n{frame}");
+}
+
+#[test]
+fn prompt_waits_for_session_bind_and_sends_with_the_real_id() {
+    let (mut app, _demo_ctl, _rx) = test_app();
+    let (ctl, commands) = crate::controller::tests::test_controller();
+    app.demo = false;
+    app.run_slash("new", "", &ctl);
+    while commands.try_recv().is_ok() {} // /new's NewSession etc.
+    let placeholder = app.session_id.clone();
+    assert!(
+        placeholder.starts_with("dsh-"),
+        "ACP /new opens a placeholder tab: {placeholder}"
+    );
+    assert!(!app.session_bound);
+
+    // Submitted before session/new resolves: queued, nothing sent — acp.rs
+    // rejects ids it never bound, so a placeholder prompt must wait.
+    app.send_agent_text("hello".into(), &ctl);
+    assert_eq!(app.prompt_queue.len(), 1);
+    assert!(
+        commands.try_recv().is_err(),
+        "no prompt may leave with a placeholder id"
+    );
+
+    app.handle(
+        AppEvent::Ctl(CtlEvent::SessionBound {
+            session_id: "acp-real".into(),
+            notice: None,
+        }),
+        &ctl,
+    );
+
+    assert_eq!(app.session_id, "acp-real");
+    assert!(app.session_bound);
+    match commands.try_recv() {
+        Ok(Cmd::Prompt { session_id, text }) => {
+            assert_eq!(session_id, "acp-real", "dispatched with the bound id");
+            assert_eq!(text, "hello");
+        }
+        other => panic!("expected the bind to dispatch the queued prompt, got {other:?}"),
+    }
+    assert!(app.prompt_queue.is_empty());
+}

--- a/tests/unit/app__session_tabs_tests.rs
+++ b/tests/unit/app__session_tabs_tests.rs
@@ -276,3 +276,336 @@ fn prompt_waits_for_session_bind_and_sends_with_the_real_id() {
     }
     assert!(app.prompt_queue.is_empty());
 }
+
+fn ask_options() -> Vec<PermissionAskOption> {
+    vec![
+        PermissionAskOption {
+            option_id: "deny".into(),
+            kind: "reject_once".into(),
+            name: "Reject".into(),
+        },
+        PermissionAskOption {
+            option_id: "allow".into(),
+            kind: "allow_once".into(),
+            name: "Allow once".into(),
+        },
+    ]
+}
+
+#[test]
+fn permission_ask_follows_its_session_across_tab_switches() {
+    let (mut app, ctl, _rx) = test_app();
+    app.open_new_session("s-two".into(), true);
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    app.handle(
+        AppEvent::PermissionAsk {
+            session_id: "s-two".into(),
+            title: "bash".into(),
+            options: ask_options(),
+            reply: tx,
+        },
+        &ctl,
+    );
+    assert!(app.permission_ask.is_some(), "live ask shows on its own tab");
+
+    // Switching away must take the popup off screen with its session —
+    // never leave it floating over the newly viewed tab.
+    app.switch_to_session(0);
+    assert_eq!(app.session_id, "dsh-test");
+    assert!(
+        app.permission_ask.is_none(),
+        "no stray popup on the tab just viewed"
+    );
+    let parked = app
+        .parked
+        .iter()
+        .find(|slot| slot.id == "s-two")
+        .expect("s-two parked");
+    assert!(
+        parked.permission_ask.is_some(),
+        "the ask parks with its session"
+    );
+    assert!(app.session_tabs()[1].ask_pending, "its tab is badged");
+
+    // The parked ask cannot be answered from the wrong tab and survives
+    // untouched until its own tab is viewed again.
+    app.switch_to_session(1);
+    assert_eq!(app.session_id, "s-two");
+    let ask = app.permission_ask.as_ref().expect("ask resurfaces");
+    assert_eq!(ask.title, "bash");
+    assert_eq!(ask.sel, 1, "selection survived the round trip");
+    app.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE), &ctl);
+    assert_eq!(
+        rx.blocking_recv().expect("reply"),
+        PermissionAskReply::Selected("allow".into())
+    );
+    assert!(
+        !app.session_tabs().iter().any(|tab| tab.ask_pending),
+        "answering clears the badge"
+    );
+}
+
+#[test]
+fn ask_for_a_parked_session_waits_in_its_slot() {
+    let (mut app, ctl, _rx) = test_app();
+    app.open_new_session("s-two".into(), true); // live s-two, dsh-test parked
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    app.handle(
+        AppEvent::PermissionAsk {
+            session_id: "dsh-test".into(),
+            title: "write".into(),
+            options: ask_options(),
+            reply: tx,
+        },
+        &ctl,
+    );
+    assert!(
+        app.permission_ask.is_none(),
+        "a parked session's ask never pops over the live tab"
+    );
+    let slot = app
+        .parked
+        .iter()
+        .find(|slot| slot.id == "dsh-test")
+        .expect("dsh-test parked");
+    assert!(slot.permission_ask.is_some(), "ask parked with its owner");
+    let tabs = app.session_tabs();
+    assert!(
+        tabs[0].ask_pending && !tabs[1].ask_pending,
+        "only the owning tab is badged"
+    );
+
+    // Esc on the owning tab cancels — never silently while parked.
+    app.switch_to_session(0);
+    assert!(app.permission_ask.is_some(), "ask surfaced on its own tab");
+    app.handle_key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE), &ctl);
+    assert_eq!(
+        rx.blocking_recv().expect("reply"),
+        PermissionAskReply::Cancelled
+    );
+    assert!(!app.session_tabs()[0].ask_pending);
+}
+
+#[test]
+fn elicitation_form_round_trips_through_parking_unchanged() {
+    let (mut app, ctl, _rx) = test_app();
+    app.open_new_session("s-two".into(), true);
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    app.handle(
+        AppEvent::ElicitationAsk {
+            session_id: Some("s-two".into()),
+            form: crate::elicitation::ElicitationForm {
+                message: "The agent needs your input.".into(),
+                fields: Vec::new(),
+            },
+            reply: tx,
+        },
+        &ctl,
+    );
+    assert!(app.elicitation_ask.is_some(), "form opened on its tab");
+
+    app.switch_to_session(0);
+    assert!(app.elicitation_ask.is_none(), "form left the screen");
+    assert_eq!(app.session_tabs()[1].ask_pending, true);
+
+    app.switch_to_session(1);
+    let ask = app.elicitation_ask.as_ref().expect("form restored");
+    assert_eq!(ask.form.message, "The agent needs your input.");
+
+    // Session teardown (the slot is dropped) cancels the open ask.
+    drop(app);
+    assert_eq!(
+        rx.blocking_recv().expect("reply"),
+        crate::elicitation::ElicitationReply::Cancelled
+    );
+}
+
+#[test]
+fn unknown_session_ask_stays_answerable_on_the_live_view() {
+    let (mut app, ctl, _rx) = test_app();
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    app.handle(
+        AppEvent::PermissionAsk {
+            session_id: "s-foreign".into(),
+            title: "bash".into(),
+            options: ask_options(),
+            reply: tx,
+        },
+        &ctl,
+    );
+    assert!(
+        app.permission_ask.is_some(),
+        "an unattributable ask falls back to the live view instead of cancelling"
+    );
+    app.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE), &ctl);
+    assert_eq!(
+        rx.blocking_recv().expect("reply"),
+        PermissionAskReply::Selected("allow".into())
+    );
+}
+
+fn mouse(kind: MouseEventKind, x: u16, y: u16) -> MouseEvent {
+    MouseEvent {
+        kind,
+        column: x,
+        row: y,
+        modifiers: KeyModifiers::NONE,
+    }
+}
+
+fn push_plugin_view(app: &mut App, ctl: &Controller, id: &str, text: &str) {
+    app.handle(
+        AppEvent::Rpc {
+            method: crate::cordis::OVERLAY_UPDATE.into(),
+            params: serde_json::json!({
+                "protocol": 0,
+                "overlay": {
+                    "kind": "view",
+                    "id": id,
+                    "title": id,
+                    "nodes": [{ "id": "content", "kind": "markdown", "text": text }]
+                }
+            }),
+        },
+        ctl,
+    );
+}
+
+#[test]
+fn painter_popups_park_with_their_session_and_resurface() {
+    let (mut app, ctl, _rx) = test_app();
+    app.push_keys();
+    assert!(app.view_overlay.is_some(), "/keys opened");
+    // The /plugins tree parks the same way (tree selection included).
+    app.plugin_tree = Some(PluginTree {
+        title: "plugins".into(),
+        state: tui_tree_widget::TreeState::default(),
+    });
+
+    app.open_new_session("s-two".into(), true);
+    assert!(
+        app.view_overlay.is_none(),
+        "the popup left the screen with its tab"
+    );
+    assert!(app.plugin_tree.is_none(), "/plugins left the screen too");
+    assert!(
+        app.parked[0].view_overlay.is_some(),
+        "/keys parked with dsh-test"
+    );
+    assert!(app.parked[0].plugin_tree.is_some(), "/plugins parked too");
+
+    app.switch_to_session(0);
+    let view = app.view_overlay.as_ref().expect("/keys resurfaced");
+    assert_eq!(view.id, "builtin.keys");
+    assert!(!view.notify_plugin, "painter popup, not compositor-owned");
+    assert!(app.plugin_tree.is_some(), "/plugins tree resurfaced");
+
+    // Esc closes it on its own tab, painter-side (no plugin event).
+    app.handle_key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE), &ctl);
+    assert!(app.view_overlay.is_none());
+    app.switch_to_session(1);
+    app.switch_to_session(0);
+    assert!(
+        app.view_overlay.is_none(),
+        "closed popups stay closed across switches"
+    );
+}
+
+#[test]
+fn tab_click_cancels_a_plugin_view_with_its_esc_event() {
+    let (mut app, _demo_ctl, _rx) = test_app();
+    let (ctl, commands) = crate::controller::tests::test_controller();
+    app.open_new_session("s-two".into(), true); // live s-two, dsh-test parked
+    push_plugin_view(&mut app, &ctl, "plan-view", "step 1");
+    assert!(app.view_overlay.is_some(), "plugin view opened");
+    assert!(app.view_overlay.as_ref().unwrap().notify_plugin);
+
+    // Tab strip geometry, as recorded by the painter each frame.
+    app.tab_rects.push((ratatui::layout::Rect::new(0, 0, 10, 1), 0));
+    app.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 2, 0), &ctl);
+
+    assert_eq!(app.session_id, "dsh-test", "switched to the clicked tab");
+    assert!(
+        app.view_overlay.is_none(),
+        "the compositor overlay did not ride along"
+    );
+    match commands.try_recv() {
+        Ok(Cmd::PluginOverlayEvent { id, event, value }) => {
+            assert_eq!(id, "plan-view");
+            assert_eq!(event, "cancel");
+            assert!(value.is_none(), "view cancel carries no value");
+        }
+        other => panic!("expected the cancel event, got {other:?}"),
+    }
+}
+
+#[test]
+fn tab_click_cancels_a_plugin_select_carrying_the_selection_value() {
+    let (mut app, _demo_ctl, _rx) = test_app();
+    let (ctl, commands) = crate::controller::tests::test_controller();
+    app.open_new_session("s-two".into(), true);
+    app.handle(
+        AppEvent::Rpc {
+            method: crate::cordis::OVERLAY_UPDATE.into(),
+            params: serde_json::json!({
+                "protocol": 0,
+                "overlay": {
+                    "kind": "select",
+                    "id": "harness",
+                    "title": "Harness",
+                    "value": "b",
+                    "options": [
+                        { "value": "a", "label": "A" },
+                        { "value": "b", "label": "B" }
+                    ]
+                }
+            }),
+        },
+        &ctl,
+    );
+    assert!(app.select_overlay.is_some(), "select opened");
+
+    app.tab_rects.push((ratatui::layout::Rect::new(0, 0, 10, 1), 0));
+    app.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 2, 0), &ctl);
+
+    assert!(app.select_overlay.is_none(), "select dismissed on the switch");
+    match commands.try_recv() {
+        Ok(Cmd::PluginOverlayEvent { id, event, value }) => {
+            assert_eq!(id, "harness");
+            assert_eq!(event, "cancel");
+            assert_eq!(value, Some(serde_json::json!("b")));
+        }
+        other => panic!("expected the select cancel event, got {other:?}"),
+    }
+}
+
+#[test]
+fn plugin_null_ack_after_a_tab_switch_keeps_the_restored_painter_popup() {
+    let (mut app, _demo_ctl, _rx) = test_app();
+    let (ctl, _commands) = crate::controller::tests::test_controller();
+    app.push_keys(); // painter popup on dsh-test
+    app.open_new_session("s-two".into(), true); // parks it with dsh-test
+    push_plugin_view(&mut app, &ctl, "status", "idle");
+
+    // Click tab 0: the plugin view is cancelled and /keys resurfaces.
+    app.tab_rects.push((ratatui::layout::Rect::new(0, 0, 10, 1), 0));
+    app.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 2, 0), &ctl);
+    assert_eq!(app.session_id, "dsh-test");
+    assert!(
+        app.view_overlay.as_ref().is_some_and(|view| !view.notify_plugin),
+        "the painter popup was restored"
+    );
+
+    // The compositor's null ack lands afterwards and must not eat /keys.
+    app.handle(
+        AppEvent::Rpc {
+            method: crate::cordis::OVERLAY_UPDATE.into(),
+            params: serde_json::json!({ "protocol": 0, "overlay": null }),
+        },
+        &ctl,
+    );
+    assert!(
+        app.view_overlay.as_ref().is_some_and(|view| !view.notify_plugin),
+        "the null ack only closes compositor-owned overlays"
+    );
+}

--- a/tests/unit/events__tests.rs
+++ b/tests/unit/events__tests.rs
@@ -922,3 +922,151 @@ fn malformed_payloads_yield_empty_vec() {
     )
     .is_empty());
 }
+
+fn update_ev(session: &str, update: serde_json::Value) -> crate::bus::AppEvent {
+    crate::bus::AppEvent::Rpc {
+        method: "session/update".into(),
+        params: json!({ "sessionId": session, "update": update }),
+    }
+}
+
+fn text_chunk(session: &str, kind: &str, message: &str, text: &str) -> crate::bus::AppEvent {
+    update_ev(
+        session,
+        json!({
+            "sessionUpdate": kind,
+            "content": { "type": "text", "text": text },
+            "messageId": message,
+        }),
+    )
+}
+
+#[test]
+fn adjacent_text_chunks_for_one_message_merge() {
+    let mut events = vec![
+        text_chunk("s1", "agent_message_chunk", "1:1", "hello "),
+        text_chunk("s1", "agent_message_chunk", "1:1", "world"),
+        text_chunk("s1", "agent_thought_chunk", "1:1", "thinking "),
+        text_chunk("s1", "agent_thought_chunk", "1:1", "aloud"),
+    ];
+    coalesce_session_updates(&mut events);
+    assert_eq!(events.len(), 2);
+    let crate::bus::AppEvent::Rpc { params, .. } = &events[0] else {
+        panic!("rpc")
+    };
+    assert_eq!(params["update"]["content"]["text"], "hello world");
+    let crate::bus::AppEvent::Rpc { params, .. } = &events[1] else {
+        panic!("rpc")
+    };
+    assert_eq!(params["update"]["content"]["text"], "thinking aloud");
+}
+
+#[test]
+fn text_chunks_do_not_merge_across_messages_sessions_or_kinds() {
+    let mut events = vec![
+        text_chunk("s1", "agent_message_chunk", "1:1", "a"),
+        text_chunk("s1", "agent_message_chunk", "1:2", "b"),
+        text_chunk("s2", "agent_message_chunk", "1:2", "c"),
+        text_chunk("s2", "agent_thought_chunk", "1:2", "d"),
+    ];
+    coalesce_session_updates(&mut events);
+    assert_eq!(events.len(), 4);
+}
+
+#[test]
+fn the_final_chunks_meta_survives_a_merge() {
+    let mut events = vec![
+        text_chunk("s1", "agent_message_chunk", "1:1", "body"),
+        update_ev(
+            "s1",
+            json!({
+                "sessionUpdate": "agent_message_chunk",
+                "content": { "type": "text", "text": "" },
+                "messageId": "1:1",
+                "_meta": { "dsh": { "event": "assistant_message", "model": "deepseek-v4-flash" } },
+            }),
+        ),
+    ];
+    coalesce_session_updates(&mut events);
+    assert_eq!(events.len(), 1);
+    let crate::bus::AppEvent::Rpc { params, .. } = &events[0] else {
+        panic!("rpc")
+    };
+    assert_eq!(params["update"]["content"]["text"], "body");
+    assert_eq!(params["update"]["_meta"]["dsh"]["model"], "deepseek-v4-flash");
+}
+
+fn bare_tool_update(session: &str, call: &str, status: &str) -> crate::bus::AppEvent {
+    update_ev(
+        session,
+        json!({
+            "sessionUpdate": "tool_call_update",
+            "toolCallId": call,
+            "title": "bash ls",
+            "status": status,
+        }),
+    )
+}
+
+#[test]
+fn bare_tool_call_updates_keep_only_the_latest() {
+    let mut events = vec![
+        bare_tool_update("s1", "c1", "pending"),
+        bare_tool_update("s1", "c1", "pending"),
+        bare_tool_update("s1", "c1", "in_progress"),
+        bare_tool_update("s1", "c2", "pending"),
+    ];
+    coalesce_session_updates(&mut events);
+    assert_eq!(events.len(), 2);
+    let crate::bus::AppEvent::Rpc { params, .. } = &events[0] else {
+        panic!("rpc")
+    };
+    assert_eq!(params["update"]["status"], "in_progress");
+    let crate::bus::AppEvent::Rpc { params, .. } = &events[1] else {
+        panic!("rpc")
+    };
+    assert_eq!(params["update"]["toolCallId"], "c2");
+}
+
+#[test]
+fn rich_tool_call_updates_are_never_dropped() {
+    let mut events = vec![
+        bare_tool_update("s1", "c1", "pending"),
+        update_ev(
+            "s1",
+            json!({
+                "sessionUpdate": "tool_call_update",
+                "toolCallId": "c1",
+                "status": "completed",
+                "rawOutput": { "output": "ok", "isError": false },
+            }),
+        ),
+        update_ev(
+            "s1",
+            json!({
+                "sessionUpdate": "tool_call_update",
+                "toolCallId": "c1",
+                "_meta": { "terminal_output": { "terminal_id": "c1", "data": "chunk" } },
+            }),
+        ),
+    ];
+    coalesce_session_updates(&mut events);
+    assert_eq!(events.len(), 3);
+}
+
+#[test]
+fn non_update_events_pass_through_untouched() {
+    let mut events = vec![
+        text_chunk("s1", "agent_message_chunk", "1:1", "a"),
+        update_ev("s1", json!({ "sessionUpdate": "tool_call", "toolCallId": "c1" })),
+        text_chunk("s1", "agent_message_chunk", "1:1", "b"),
+        crate::bus::AppEvent::Ui(UiEvent::TurnEnd {
+            session: "s1".into(),
+            kind: "end_turn".into(),
+        }),
+        text_chunk("s1", "agent_message_chunk", "1:1", "c"),
+    ];
+    coalesce_session_updates(&mut events);
+    // The tool_call start and the TurnEnd break every run: nothing merges.
+    assert_eq!(events.len(), 5);
+}

--- a/tests/unit/ui__rpc_probe.rs
+++ b/tests/unit/ui__rpc_probe.rs
@@ -243,7 +243,13 @@ fn plan_review_elicitation_renders_markdown_and_scrolls() {
     let form = crate::elicitation::form_from_request(&request).expect("supported form");
     let (tx, mut rx) = tokio::sync::oneshot::channel();
     app.handle(
-        crate::bus::AppEvent::ElicitationAsk { form, reply: tx },
+        crate::bus::AppEvent::ElicitationAsk {
+            // The probe request is scoped to session s1, which this app
+            // does not know — the fallback surfaces it on the live view.
+            session_id: Some("s1".into()),
+            form,
+            reply: tx,
+        },
         &ctl,
     );
     assert!(app.elicitation_ask.is_some(), "elicitation opened");


### PR DESCRIPTION
## 摘要

多会话并行管理(issue #94)+ 弹窗/询问随 tab 归属,合入最新上游(session/resume)。

### feat(tui): multi-session parallel management with native session tabs (issue #94)

- 一条 ACP 连接并发驱动多个会话:出现第二个会话后顶部出现原生 tab 条(运行指示、`✓` 后台完成徽标),左键点击切换
- `/new`、`/resume` 改为 park 当前会话而不是丢弃:切回时 transcript、prompt 队列、modes、subagent 面板原样恢复;后台会话继续把 `session/update` 折入自己的 transcript(事件路由隔离,外来会话事件不再泄漏进当前视图)
- prompt/steer/interrupt/队列按 session id 寻址,不同会话的轮次真正并发
- 会话/load 回放大洪峰防御:相邻 `session/update` 合并(文本 delta 拼接、工具调用状态取最新),composer 在风暴排空期间保持响应
- `scripts/acp-multi-session.smoke.mjs` / `scripts/tui-multi-session.e2e.mjs` 冒烟脚本

### 弹窗与询问归属会话

- ACP ask(permission/elicitation)带 session id 路由:后台会话的询问停靠在其 tab(tab strip 显示 `?`),只有所属 tab 能回答/Esc;切换绝不取消或误答;两会话并发 ask 不再互相顶掉(原来被顶掉的 ask 会经 Drop 静默 Cancelled = 静默拒绝工具调用)
- painter 信息弹窗(`/help` `/keys` `/session` `/status` 回退)与 `/plugins` 树随会话停靠(滚动位置、树选中状态保留);插件 compositor overlay(单槽协议、无法停靠)在切换 tab 时按 Esc 语义发 cancel,插件槽位正确释放;插件的 null 回执不再误吞切换时恢复的 painter 弹窗
- 修复:`/resume`(ACP)不再被欢迎横幅盖住回放内容——横幅只会在首次发送 prompt 时清除,导致启动后直接 resume 看不到任何已加载消息

### 合入上游 main(至 v0.2.31)

- 上游 `session/resume` 支持(长会话免全量回放,`session/load` 回退保留),已适配多会话骨架(bind_session/awaiting_binds),642 + 集成测试全绿
