### PR TITLE
style(tui): render session tabs as Powerline arrows

### DIFF
--- a/scripts/tui-multi-session.e2e.mjs
+++ b/scripts/tui-multi-session.e2e.mjs
@@ -254,7 +254,7 @@ try {
   // 3. Open a second tab: the native tab strip appears on row 0.
   await type('/new')
   term.write('\r')
-  await waitFor(() => row0().includes('│'), 30000, 'tab strip with 2 tabs')
+  await waitFor(() => row0().includes('\ue0b0'), 30000, 'tab strip with 2 arrow tabs')
   check('tab strip renders with ≥2 sessions', true)
 
   // 4. Prompt session B (instant answer) while A is still streaming.
@@ -303,11 +303,11 @@ try {
   check('✓ badge cleared after viewing tab A', badgeCleared, badgeCleared ? '' : `row0: ${row0()}`)
 
   // 8. Click session B's tab: compute its column from row 0's layout — the
-  //    region between the first │ separator and the next one (or the end).
+  //    region between the first Powerline arrow and the next one.
   const strip = row0()
-  const sep1 = strip.indexOf('│')
-  const tabBStart = sep1 + 2 // 0-based index right after " │ "
-  let tabBEnd = strip.indexOf('│', tabBStart)
+  const sep1 = strip.indexOf('\ue0b0')
+  const tabBStart = sep1 + 1 // 0-based index right after tab A's arrow
+  let tabBEnd = strip.indexOf('\ue0b0', tabBStart)
   if (tabBEnd < 0) tabBEnd = strip.length
   const tabBCol = tabBStart + Math.max(1, Math.floor((tabBEnd - tabBStart) / 2)) + 1 // 1-based
   console.log(`tab B click target: col ${tabBCol} (strip: "${strip}")`)

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -13,7 +13,7 @@ use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 use crate::app::{App, RunState};
 use crate::logo;
 use crate::pet::{SPRITE_H, SPRITE_W, WHALE_XS};
-use crate::theme::{lerp, Theme};
+use crate::theme::{lerp, Mode, Theme};
 
 /// Columns the composer text keeps clear of the pet at its right edge
 /// (widest pet form is 8 cols, plus a one-column gap).
@@ -997,33 +997,43 @@ fn draw_right_slot(f: &mut Frame, app: &App, area: Rect) {
     f.render_widget(Paragraph::new(lines).block(block), area);
 }
 
-/// The session tab strip (issue #94) — native status chrome fed by
-/// per-session running facts, the same source as `state_line`. Per tab: a
-/// status indicator, a ✓ completion badge for a session that finished
-/// while parked, and a title/short-id label. A `?` indicator (warn color)
-/// marks a tab whose session has an unanswered ACP ask (permission or
-/// elicitation) — the agent is waiting on that tab. Tab rects are recorded
-/// for `App::tab_at` mouse hit-testing.
+/// The session tab strip (issue #94) — Powerline-shaped native status chrome
+/// fed by per-session running facts, the same source as `state_line`. Per tab:
+/// a status indicator, a ✓ completion badge for a session that finished while
+/// parked, and a title/short-id label. A `?` indicator (warn color) marks a tab
+/// whose session has an unanswered ACP ask (permission or elicitation) — the
+/// agent is waiting on that tab. Tab rects include their trailing arrow for
+/// `App::tab_at` mouse hit-testing.
 fn draw_session_tabs(f: &mut Frame, app: &mut App, area: Rect) {
+    const ARROW: &str = "\u{e0b0}";
+
     let theme = app.theme;
+    let canvas_bg = app.canvas_background_color();
+    let active_fg = match theme.mode {
+        Mode::Dark => theme.bg,
+        Mode::Light => theme.fg,
+    };
+    let background_for = |index: usize, current: bool| {
+        if current {
+            theme.brand
+        } else if index % 2 == 0 {
+            theme.panel
+        } else {
+            theme.bg
+        }
+    };
     let tabs = app.session_tabs();
     let spinner = app.spinner();
     let right = area.right() as usize;
     let mut spans: Vec<Span> = Vec::new();
     let mut x = area.x as usize;
     for (idx, tab) in tabs.iter().enumerate() {
-        if idx > 0 {
-            if x + 3 > right {
-                break;
-            }
-            spans.push(Span::styled(" │ ", Style::default().fg(theme.border)));
-            x += 3;
-        }
         let label = crate::transcript::clamp_str(&tab.label, 16);
+        let tab_bg = background_for(idx, tab.current);
         let (indicator, indicator_style) = if tab.ask_pending {
             // A session-bound ask outranks every other badge: the agent is
             // blocked until this tab answers.
-            ("?".to_string(), Style::default().fg(theme.warn))
+            ("?".to_string(), Style::default().fg(theme.warn).bg(tab_bg))
         } else if tab.running {
             (
                 if tab.current {
@@ -1031,31 +1041,57 @@ fn draw_session_tabs(f: &mut Frame, app: &mut App, area: Rect) {
                 } else {
                     "●".to_string()
                 },
-                Style::default().fg(theme.brand),
+                Style::default()
+                    .fg(if tab.current { active_fg } else { theme.brand })
+                    .bg(tab_bg),
             )
         } else if tab.completed_unseen {
-            ("✓".to_string(), Style::default().fg(theme.warn_soft()))
+            (
+                "✓".to_string(),
+                Style::default().fg(theme.warn_soft()).bg(tab_bg),
+            )
         } else {
-            ("·".to_string(), Style::default().fg(theme.caption))
+            (
+                "·".to_string(),
+                Style::default()
+                    .fg(if tab.current {
+                        active_fg
+                    } else {
+                        theme.caption
+                    })
+                    .bg(tab_bg),
+            )
         };
         let label_style = if tab.current {
-            Style::default().fg(theme.fg).add_modifier(Modifier::BOLD)
+            Style::default()
+                .fg(active_fg)
+                .bg(tab_bg)
+                .add_modifier(Modifier::BOLD)
         } else {
-            Style::default().fg(theme.fg_tertiary)
+            Style::default().fg(theme.fg_secondary).bg(tab_bg)
         };
-        let width = indicator.width() + label.width() + 3;
+        let arrow_width = ARROW.width();
+        let width = indicator.width() + label.width() + 3 + arrow_width;
         if x + width > right {
             break;
         }
-        app.tab_rects.push((
-            Rect::new(x as u16, area.y, width as u16, 1),
-            idx,
-        ));
-        spans.push(Span::styled(
-            format!(" {indicator} ",),
-            indicator_style,
-        ));
+        app.tab_rects
+            .push((Rect::new(x as u16, area.y, width as u16, 1), idx));
+        spans.push(Span::styled(format!(" {indicator} ",), indicator_style));
         spans.push(Span::styled(format!("{label} "), label_style));
+        let next_fits = tabs.get(idx + 1).is_some_and(|next| {
+            let next_label = crate::transcript::clamp_str(&next.label, 16);
+            // Every native status marker (including the Braille spinner) is
+            // one terminal cell wide.
+            let next_width = next_label.width() + 4;
+            x + width + next_width <= right
+        });
+        let next_bg = tabs
+            .get(idx + 1)
+            .filter(|_| next_fits)
+            .map(|next| background_for(idx + 1, next.current))
+            .unwrap_or(canvas_bg);
+        spans.push(Span::styled(ARROW, Style::default().fg(tab_bg).bg(next_bg)));
         x += width;
     }
     f.render_widget(Paragraph::new(Line::from(spans)), area);

--- a/tests/unit/app__session_tabs_tests.rs
+++ b/tests/unit/app__session_tabs_tests.rs
@@ -231,7 +231,86 @@ fn tab_strip_renders_only_with_multiple_sessions() {
     let row0 = frame.lines().next().unwrap_or_default();
     assert!(row0.contains("dsh-test"), "parked tab label:\n{frame}");
     assert!(row0.contains("s-two"), "live tab label:\n{frame}");
-    assert!(row0.contains('│'), "tab separator:\n{frame}");
+    assert!(
+        row0.contains("dsh-test \u{e0b0}") && row0.contains("s-two \u{e0b0}"),
+        "each tab ends in a Powerline arrow:\n{frame}"
+    );
+    assert!(!row0.contains('│'), "plain dividers are replaced:\n{frame}");
+
+    let first_arrow_byte = row0.find('\u{e0b0}').expect("first arrow");
+    let first_arrow_col =
+        unicode_width::UnicodeWidthStr::width(&row0[..first_arrow_byte]) as u16;
+    assert_eq!(
+        app.tab_rects[0].0.right(),
+        first_arrow_col + 1,
+        "the visible arrow belongs to the tab's mouse target"
+    );
+}
+
+#[test]
+fn powerline_tabs_use_a_brand_active_segment_and_seamless_arrows() {
+    use ratatui::backend::TestBackend;
+    use ratatui::Terminal;
+
+    let (mut app, ctl, _rx) = test_app();
+    app.run_slash("new", "s-two", &ctl);
+    let backend = TestBackend::new(100, 30);
+    let mut terminal = Terminal::new(backend).expect("test terminal");
+    terminal
+        .draw(|f| crate::ui::draw(f, &mut app))
+        .expect("draw frame");
+
+    let theme = app.theme;
+    let parked = app.tab_rects[0].0;
+    let active = app.tab_rects[1].0;
+    let buf = terminal.backend().buffer();
+
+    assert_eq!(buf[(parked.x, parked.y)].bg, theme.panel);
+    assert_eq!(buf[(active.x, active.y)].bg, theme.brand);
+
+    let into_active = &buf[(parked.right() - 1, parked.y)];
+    assert_eq!(into_active.symbol(), "\u{e0b0}");
+    assert_eq!(into_active.fg, theme.panel, "arrow keeps the left fill");
+    assert_eq!(into_active.bg, theme.brand, "arrow meets the active fill");
+
+    let into_canvas = &buf[(active.right() - 1, active.y)];
+    assert_eq!(into_canvas.symbol(), "\u{e0b0}");
+    assert_eq!(into_canvas.fg, theme.brand);
+    assert_eq!(into_canvas.bg, theme.bg);
+}
+
+#[test]
+fn adjacent_inactive_powerline_tabs_alternate_neutral_fills() {
+    use ratatui::backend::TestBackend;
+    use ratatui::Terminal;
+
+    let (mut app, ctl, _rx) = test_app();
+    app.run_slash("new", "s-two", &ctl);
+    app.run_slash("new", "s-three", &ctl);
+    let backend = TestBackend::new(100, 30);
+    let mut terminal = Terminal::new(backend).expect("test terminal");
+    terminal
+        .draw(|f| crate::ui::draw(f, &mut app))
+        .expect("draw frame");
+
+    let theme = app.theme;
+    let first = app.tab_rects[0].0;
+    let second = app.tab_rects[1].0;
+    let active = app.tab_rects[2].0;
+    let buf = terminal.backend().buffer();
+
+    assert_eq!(buf[(first.x, first.y)].bg, theme.panel);
+    assert_eq!(buf[(second.x, second.y)].bg, theme.bg);
+    assert_eq!(buf[(active.x, active.y)].bg, theme.brand);
+
+    let separator = &buf[(first.right() - 1, first.y)];
+    assert_eq!(separator.symbol(), "\u{e0b0}");
+    assert_eq!(separator.fg, theme.panel);
+    assert_eq!(separator.bg, theme.bg);
+    assert_ne!(
+        separator.fg, separator.bg,
+        "adjacent inactive tabs must keep a visible arrow edge"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- replace plain session-tab dividers with seamless Powerline arrows
- use the brand fill for the active tab and alternating neutral fills for inactive tabs
- include each trailing arrow in its tab mouse target and update the opt-in multi-session E2E locator

## Test plan

- `cargo test --locked session_tabs`
- `cargo check --locked --tests`

The opt-in `tui-multi-session.e2e.mjs` was not run because it consumes model tokens.