### PR TITLE
fix(tui): /close, tab-bound state, multi-session routing and hardening (issue #94)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,8 +33,29 @@ All notable changes to this project are documented here. The project follows
   strip no longer needs the mouse. Both routes (click and key) share one
   path that dismisses transient interactions and releases compositor
   overlays with their cancel events before parking the session.
+  `alt+]` / `ctrl+pagedown` and `alt+[` / `ctrl+pageup` cycle through
+  tabs, and overflowing tab bars show an overflow counter (`+N`).
 
 ### Fixed
+
+- Background session subagents now receive their transcript updates and
+  streamed deltas cleanly, rather than having non-root session facts dropped
+  at the UI event router while parked.
+
+- Permission and elicitation asks from subagents are routed to their owning
+  session tab (badging the tab when parked) instead of defaulting to the
+  live tab and cancelling any foreground ask already on screen.
+
+- Closing a session (`/close`) now purges any auth-stalled prompts parked
+  for that session, and prompt settlement always reports session idle state
+  so a stall on one session never freezes queue dispatch on others.
+
+- Local shell commands (`!cmd`) started on an unbound tab update their
+  pending tracker when `SessionBound` arrives, ensuring command completion
+  never hangs indefinitely.
+
+- `list_sessions` now pre-sorts files by modified time before loading and
+  parsing JSONL logs, bounding decompression work to the top 50 sessions.
 
 - `/plan` (and host skill config actions that map onto ACP
   `session/set_config_option`) now addresses the **viewed** session: the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,14 @@ All notable changes to this project are documented here. The project follows
 
 ### Fixed
 
+- The session tab strip now scrolls instead of cutting off: clicking the
+  leftmost or rightmost visible tab switches to it **and** nudges the
+  strip by one, so the adjacent tab appears — repeated edge clicks walk
+  the mouse through every session tab in either direction. The window
+  always keeps the live tab on screen: opening or switching to a session
+  outside the window re-anchors the strip with it at the right edge, and
+  once the tabs all fit again the strip snaps back to the head.
+
 - The mouse wheel now scrolls an open picker dialog (the `/resume` session
   list, `/model`, `/mode`, …) instead of falling through to the chat
   behind it: one notch moves the selection exactly like one ↑/↓ press,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,69 @@ All notable changes to this project are documented here. The project follows
 
 ## [Unreleased]
 
+### Added
+
+- `/close` closes the current session tab (issue #94): everything bound to
+  the tab — transcript, composer draft, staged images, prompt queue, ACP
+  asks, subagents — is discarded, and the ACP controller forgets the
+  session's turn state so no queued follow-up is sent into the void.
+  Local only: ACP has no session/close, so the server-side session
+  survives and a running turn keeps settling (its result drops at the
+  router); the session can be re-entered later with `/resume`. The last
+  remaining tab cannot close. Closing a tab that is still awaiting its
+  `session/new`·`resume` bind keeps the FIFO slot but marks it dead, so
+  the late bind is forgotten instead of rebinding whatever tab is on
+  screen.
+
+- Everything the frame paints between the session tab strip and the
+  composer stats dock is now bound to the viewed tab, not shared: the
+  composer draft and its staged `[image n]` chips (plus the `@file`
+  browser and the pinned/expanded composer height) park with their
+  session like the queue already did, chat scroll position, the `/model`
+  pick, the welcome banner, and the running-state meta row (elapsed
+  timer + state note) survive a tab switch exactly as left, and a `!`
+  shell command started on one session lands its result in that session's
+  transcript even if the user switched tabs while it ran.
+
+- `alt+1` … `alt+9` jump straight to a session tab (issue #94) — the tab
+  strip no longer needs the mouse. Both routes (click and key) share one
+  path that dismisses transient interactions and releases compositor
+  overlays with their cancel events before parking the session.
+
 ### Fixed
+
+- `/plan` (and host skill config actions that map onto ACP
+  `session/set_config_option`) now addresses the **viewed** session: the
+  command carries the session id, so toggling plan mode on an older tab
+  no longer silently flips the most recently bound session's plan.
+
+- Failures are now routed to the session they concern instead of always
+  printing on the viewed tab: prompt/steer/config rejections and errors
+  arrive as session-scoped events and land in the owning tab's own
+  transcript (including parked tabs), while a parked session's
+  `Send Now` settlement (`SteerSettled`) requeues into that session's
+  FIFO even if the user switched away meanwhile.
+
+- Auth stalls no longer misroute retries or lose payloads: a prompt that
+  hits an auth error is parked **with its owning session** (a queue, so
+  concurrent stalls on several sessions cannot overwrite each other), its
+  tab settles like a finished turn, and the next successful sign-in (or
+  any succeeding prompt) retries every stalled prompt into its own
+  session — never into the fallback session. A stalled prompt whose tab
+  was closed meanwhile is dropped instead of leaking into another
+  conversation.
+
+- Failed or auth-stalled `session/new`·`resume` requests no longer poison
+  the bind FIFO: they emit a bind-failure event that drops the awaiting
+  entry and tells its tab (which stays open), so the next successful bind
+  lands on the tab that actually asked — including the startup race where
+  the client's own `/new` overtakes the unrequested startup bind (the
+  startup session now finds its original parked tab instead of hijacking
+  the viewed one).
+
+- An unbound tab's queued prompts are never burned: queue dispatch is
+  gated on the session bind, so a rejection error cannot cascade-pop the
+  whole FIFO through repeated unknown-session errors.
 
 - `/resume` over ACP (`session/load`) no longer leaves the welcome banner
   covering the replayed transcript: the banner was only dismissed by the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,22 @@ All notable changes to this project are documented here. The project follows
 
 ### Fixed
 
+- The mouse wheel now scrolls an open picker dialog (the `/resume` session
+  list, `/model`, `/mode`, …) instead of falling through to the chat
+  behind it: one notch moves the selection exactly like one ↑/↓ press,
+  clamping at the list ends. Permission asks floating above a picker take
+  the wheel first, matching their keyboard priority.
+
+- Picker dialogs own a stable viewport window now: ↑/↓ and the wheel
+  sweep the highlight through the visible rows, and the window only
+  scrolls once the selection leaves it — previously the window was
+  re-pinned to the selection every frame, so keys after a wheel-scroll
+  slid the whole list instead of moving the highlight, and the highlight
+  stuck to a window edge instead of tracking the wheel. The scrollbar
+  thumb also tracks the real scroll offset (rescaled onto the track), so
+  it reaches the bottom at the deepest scroll instead of stalling a
+  third of the way down.
+
 - Background session subagents now receive their transcript updates and
   streamed deltas cleanly, rather than having non-root session facts dropped
   at the UI event router while parked.

--- a/src/acp.rs
+++ b/src/acp.rs
@@ -219,17 +219,26 @@ fn emit_auth(bus: &Sender<AppEvent>, snap: AuthSnapshot) {
     let _ = bus.send(AppEvent::Ctl(CtlEvent::Auth(snap)));
 }
 
-/// Parked composer payload retried after a later `authenticate` succeeds.
+/// The composer payload of one prompt stalled on auth.
 #[derive(Clone)]
-enum ParkedPrompt {
+enum ParkedPromptKind {
     Text(String),
     Images(Vec<crate::bus::PromptBlock>),
+}
+
+/// One stalled prompt with the session that owned it (`None` = it was
+/// submitted before the first session existed and adopts the current
+/// fallback on retry). A stall can hit several sessions' in-flight prompts
+/// at once, so parked is a queue — never an overwriting slot (issue #94).
+struct ParkedPrompt {
+    session: Option<String>,
+    kind: ParkedPromptKind,
 }
 
 struct PromptFinish {
     session_id: String,
     result: Result<agent_client_protocol::schema::v1::PromptResponse, AcpError>,
-    parked_on_auth: ParkedPrompt,
+    payload: ParkedPromptKind,
 }
 
 /// Per-session turn state on one shared ACP connection. The server allows one
@@ -319,7 +328,7 @@ fn spawn_session_prompt(
     bus: Sender<AppEvent>,
     sid: SessionId,
     content: Vec<ContentBlock>,
-    parked_on_auth: ParkedPrompt,
+    payload: ParkedPromptKind,
     done: tokio::sync::mpsc::UnboundedSender<PromptFinish>,
 ) -> tokio::task::JoinHandle<()> {
     tokio::spawn(async move {
@@ -341,7 +350,7 @@ fn spawn_session_prompt(
         let _ = done.send(PromptFinish {
             session_id: sid.to_string(),
             result,
-            parked_on_auth,
+            payload,
         });
     })
 }
@@ -371,7 +380,7 @@ fn begin_prompt(
     cx: &ConnectionTo<Agent>,
     bus: &Sender<AppEvent>,
     session_id: &Option<SessionId>,
-    parked: &mut Option<ParkedPrompt>,
+    parked: &mut VecDeque<ParkedPrompt>,
     methods: &[AuthMethodInfo],
     selected: Option<&AuthMethodInfo>,
     surface: &Arc<Mutex<Surface>>,
@@ -381,7 +390,10 @@ fn begin_prompt(
     match cmd {
         Cmd::Prompt { text, .. } => {
             let Some(sid) = session_id.clone() else {
-                *parked = Some(ParkedPrompt::Text(text));
+                parked.push_back(ParkedPrompt {
+                    session: None,
+                    kind: ParkedPromptKind::Text(text),
+                });
                 emit_needs_auth_open(
                     bus,
                     methods.to_vec(),
@@ -395,13 +407,16 @@ fn begin_prompt(
                 bus.clone(),
                 sid,
                 vec![text.clone().into()],
-                ParkedPrompt::Text(text),
+                ParkedPromptKind::Text(text),
                 done.clone(),
             ))
         }
         Cmd::Steer { text, .. } => {
             let Some(sid) = session_id.clone() else {
-                *parked = Some(ParkedPrompt::Text(text));
+                parked.push_back(ParkedPrompt {
+                    session: None,
+                    kind: ParkedPromptKind::Text(text),
+                });
                 emit_needs_auth_open(
                     bus,
                     methods.to_vec(),
@@ -415,13 +430,16 @@ fn begin_prompt(
                 bus.clone(),
                 sid,
                 vec![text.clone().into()],
-                ParkedPrompt::Text(text),
+                ParkedPromptKind::Text(text),
                 done.clone(),
             ))
         }
         Cmd::PromptImages { blocks, .. } => {
             let Some(sid) = session_id.clone() else {
-                *parked = Some(ParkedPrompt::Images(blocks));
+                parked.push_back(ParkedPrompt {
+                    session: None,
+                    kind: ParkedPromptKind::Images(blocks),
+                });
                 emit_needs_auth_open(
                     bus,
                     methods.to_vec(),
@@ -430,7 +448,7 @@ fn begin_prompt(
                 );
                 return None;
             };
-            let parked_on_auth = ParkedPrompt::Images(blocks.clone());
+            let payload = ParkedPromptKind::Images(blocks.clone());
             let prompt_image = surface
                 .lock()
                 .unwrap_or_else(|e| e.into_inner())
@@ -441,7 +459,7 @@ fn begin_prompt(
                     bus.clone(),
                     sid,
                     content,
-                    parked_on_auth,
+                    payload,
                     done.clone(),
                 )),
                 Ok(_) => {
@@ -456,7 +474,10 @@ fn begin_prompt(
         }
         Cmd::SteerImages { blocks, .. } => {
             let Some(sid) = session_id.clone() else {
-                *parked = Some(ParkedPrompt::Images(blocks));
+                parked.push_back(ParkedPrompt {
+                    session: None,
+                    kind: ParkedPromptKind::Images(blocks),
+                });
                 emit_needs_auth_open(
                     bus,
                     methods.to_vec(),
@@ -465,7 +486,7 @@ fn begin_prompt(
                 );
                 return None;
             };
-            let parked_on_auth = ParkedPrompt::Images(blocks.clone());
+            let payload = ParkedPromptKind::Images(blocks.clone());
             let prompt_image = surface
                 .lock()
                 .unwrap_or_else(|e| e.into_inner())
@@ -476,7 +497,7 @@ fn begin_prompt(
                     bus.clone(),
                     sid,
                     content,
-                    parked_on_auth,
+                    payload,
                     done.clone(),
                 )),
                 Ok(_) => {
@@ -500,14 +521,17 @@ fn drain_ready_sessions(
     sessions: &mut HashMap<String, SessionHandle>,
     cx: &ConnectionTo<Agent>,
     bus: &Sender<AppEvent>,
-    parked: &mut Option<ParkedPrompt>,
+    parked: &mut VecDeque<ParkedPrompt>,
     methods: &[AuthMethodInfo],
     selected: Option<&AuthMethodInfo>,
     surface: &Arc<Mutex<Surface>>,
     workspace: &str,
     done: &tokio::sync::mpsc::UnboundedSender<PromptFinish>,
 ) {
-    if parked.is_some() {
+    // While any prompt is stalled on auth, new prompts are not started:
+    // they would only fail the same way (and the stall release drains
+    // everything in order).
+    if !parked.is_empty() {
         return;
     }
     let keys: Vec<String> = sessions.keys().cloned().collect();
@@ -533,15 +557,60 @@ fn drain_ready_sessions(
             workspace,
             done,
         );
-        if parked.is_some() {
+        // If the begin parked a prompt (only possible without a session,
+        // which drain never passes) stop starting more.
+        if !parked.is_empty() {
             return;
         }
     }
 }
 
+/// Send stalled prompts back to the sessions that owned them — an
+/// `authenticate` just succeeded, or another prompt succeeded, either of
+/// which proves the stall is over. Entries whose session was closed while
+/// stalled (`/close` → ForgetSession) are dropped: nobody views them, and
+/// retrying into the fallback session would leak the message into a
+/// conversation it never belonged to. Pre-session entries (no owner yet)
+/// adopt the current fallback session; with no session at all they stay
+/// parked for the next release. Returns how many prompts were requeued.
+fn requeue_parked_prompts(
+    sessions: &mut HashMap<String, SessionHandle>,
+    current: &Option<SessionId>,
+    parked: &mut VecDeque<ParkedPrompt>,
+) -> usize {
+    let mut retried = 0;
+    let mut still_parked: VecDeque<ParkedPrompt> = VecDeque::new();
+    while let Some(p) = parked.pop_front() {
+        let target = match p.session {
+            Some(sid) if sessions.contains_key(&sid) => Some(sid),
+            Some(_) => None, // closed while stalled — drop
+            None => current.as_ref().map(|c| c.to_string()),
+        };
+        match (target, p.kind) {
+            (Some(sid), kind) => {
+                let cmd = match kind {
+                    ParkedPromptKind::Text(text) => Cmd::Prompt {
+                        session_id: sid.clone(),
+                        text,
+                    },
+                    ParkedPromptKind::Images(blocks) => Cmd::PromptImages {
+                        session_id: sid.clone(),
+                        blocks,
+                    },
+                };
+                sessions.entry(sid).or_default().queue.push_front(cmd);
+                retried += 1;
+            }
+            (None, kind) => still_parked.push_back(ParkedPrompt { session: None, kind }),
+        }
+    }
+    *parked = still_parked;
+    retried
+}
+
 fn apply_prompt_finish(
     finish: PromptFinish,
-    parked: &mut Option<ParkedPrompt>,
+    parked: &mut VecDeque<ParkedPrompt>,
     bus: &Sender<AppEvent>,
     methods: &[AuthMethodInfo],
     selected: Option<&AuthMethodInfo>,
@@ -572,10 +641,23 @@ fn apply_prompt_finish(
                 session: finish.session_id,
                 kind: finish_kind.into(),
             }));
-            *parked = None;
+            // A success proves the stall is over — the release happens in
+            // the caller (it owns the session map); nothing parks here.
         }
         Err(err) if is_auth_required_error(&err) => {
-            *parked = Some(finish.parked_on_auth);
+            // Park the payload with its owning session so the retry (after
+            // `authenticate`) lands on the right tab. The turn itself is
+            // over for the UI: settle the session's transcript and badge
+            // like any other turn end — but never start a new prompt while
+            // the stall stands.
+            parked.push_back(ParkedPrompt {
+                session: Some(finish.session_id.clone()),
+                kind: finish.payload,
+            });
+            let _ = bus.send(AppEvent::Ui(crate::events::UiEvent::TurnEnd {
+                session: finish.session_id,
+                kind: "interrupted".into(),
+            }));
             emit_needs_auth_open(
                 bus,
                 methods.to_vec(),
@@ -585,10 +667,13 @@ fn apply_prompt_finish(
         }
         Err(err) => {
             let _ = bus.send(AppEvent::Ui(crate::events::UiEvent::TurnEnd {
-                session: finish.session_id,
+                session: finish.session_id.clone(),
                 kind: "error".into(),
             }));
-            let _ = bus.send(AppEvent::Ctl(CtlEvent::Error(format!("prompt: {err}"))));
+            let _ = bus.send(AppEvent::Ctl(CtlEvent::SessionError {
+                session_id: finish.session_id,
+                message: format!("prompt: {err}"),
+            }));
         }
     }
 }
@@ -609,13 +694,13 @@ fn emit_open_auth_if_needed(bus: &Sender<AppEvent>, status: AuthStatus) {
     }
 }
 
-fn parked_prompt(cmd: &Cmd) -> Option<ParkedPrompt> {
+fn parked_prompt(cmd: &Cmd) -> Option<ParkedPromptKind> {
     match cmd {
         Cmd::Prompt { text, .. } | Cmd::Steer { text, .. } => {
-            Some(ParkedPrompt::Text(text.clone()))
+            Some(ParkedPromptKind::Text(text.clone()))
         }
         Cmd::PromptImages { blocks, .. } | Cmd::SteerImages { blocks, .. } => {
-            Some(ParkedPrompt::Images(blocks.clone()))
+            Some(ParkedPromptKind::Images(blocks.clone()))
         }
         _ => None,
     }
@@ -1639,7 +1724,7 @@ where
                     }
                 }
                 let _ = bus.send(AppEvent::Ctl(CtlEvent::Ready { server: agent_name }));
-                let mut parked: Option<ParkedPrompt> = None;
+                let mut parked: VecDeque<ParkedPrompt> = VecDeque::new();
 
                 let (fwd_tx, mut fwd_rx) = tokio::sync::mpsc::unbounded_channel::<Cmd>();
                 std::thread::Builder::new()
@@ -1661,42 +1746,49 @@ where
                     tokio::select! {
                         cmd = fwd_rx.recv() => {
                             let Some(mut cmd) = cmd else { break };
-                            if current.is_none()
-                                && parked.is_none()
-                                && parked_prompt(&cmd).is_some()
-                            {
-                                if session_auth_pending {
-                                    parked = parked_prompt(&cmd);
-                                    continue;
-                                }
-                                match create_prompt_session(
-                                    &cx,
-                                    &cwd,
-                                    &surface,
-                                    &bus,
-                                    &methods,
-                                    selected.as_ref(),
-                                ).await {
-                                    Ok(Some(sid)) => {
-                                        retarget_session(&mut cmd, &sid);
-                                        bind_session(
-                                            &mut sessions,
-                                            &mut current,
-                                            &mut pending,
-                                            sid,
-                                        );
-                                        session_auth_pending = false;
-                                    }
-                                    Ok(None) => {
-                                        session_auth_pending = true;
-                                        parked = parked_prompt(&cmd);
+                            if current.is_none() && parked.is_empty() {
+                                if let Some(kind) = parked_prompt(&cmd) {
+                                    if session_auth_pending {
+                                        parked.push_back(ParkedPrompt {
+                                            session: None,
+                                            kind,
+                                        });
                                         continue;
                                     }
-                                    Err(err) => {
-                                        let _ = bus.send(AppEvent::Ctl(CtlEvent::Error(format!(
-                                            "session/new: {err}"
-                                        ))));
-                                        continue;
+                                    match create_prompt_session(
+                                        &cx,
+                                        &cwd,
+                                        &surface,
+                                        &bus,
+                                        &methods,
+                                        selected.as_ref(),
+                                    )
+                                    .await
+                                    {
+                                        Ok(Some(sid)) => {
+                                            retarget_session(&mut cmd, &sid);
+                                            bind_session(
+                                                &mut sessions,
+                                                &mut current,
+                                                &mut pending,
+                                                sid,
+                                            );
+                                            session_auth_pending = false;
+                                        }
+                                        Ok(None) => {
+                                            session_auth_pending = true;
+                                            parked.push_back(ParkedPrompt {
+                                                session: None,
+                                                kind,
+                                            });
+                                            continue;
+                                        }
+                                        Err(err) => {
+                                            let _ = bus.send(AppEvent::Ctl(CtlEvent::Error(
+                                                format!("session/new: {err}"),
+                                            )));
+                                            continue;
+                                        }
                                     }
                                 }
                             }
@@ -1709,7 +1801,7 @@ where
                             match resolve_cmd_session(&sessions, &current, &cmd_session, "prompt") {
                                 Ok(Some(sid)) => {
                                     let handle = sessions.entry(sid.to_string()).or_default();
-                                    if handle.inflight.is_some() || parked.is_some() {
+                                    if handle.inflight.is_some() || !parked.is_empty() {
                                         handle.queue.push_back(next);
                                     } else {
                                         handle.inflight = begin_prompt(
@@ -1728,7 +1820,10 @@ where
                                 }
                                 Ok(None) => pending.push_back(next),
                                 Err(err) => {
-                                    let _ = bus.send(AppEvent::Ctl(CtlEvent::Error(err)));
+                                    let _ = bus.send(AppEvent::Ctl(CtlEvent::SessionError {
+                                    session_id: cmd_session.clone(),
+                                    message: err,
+                                }));
                                 }
                             }
                         }
@@ -1746,7 +1841,7 @@ where
                                             message_id,
                                             steer_done_tx.clone(),
                                         );
-                                    } else if parked.is_some() {
+                                    } else if !parked.is_empty() {
                                         let _ = bus.send(AppEvent::Ctl(CtlEvent::SteerSettled {
                                             message_id,
                                             deferred: true,
@@ -1782,7 +1877,10 @@ where
                                     }));
                                 }
                                 Err(err) => {
-                                    let _ = bus.send(AppEvent::Ctl(CtlEvent::Error(err)));
+                                    let _ = bus.send(AppEvent::Ctl(CtlEvent::SessionError {
+                                    session_id: cmd_session.clone(),
+                                    message: err,
+                                }));
                                 }
                             }
                         }
@@ -1794,7 +1892,7 @@ where
                             match resolve_cmd_session(&sessions, &current, &cmd_session, "prompt_images") {
                                 Ok(Some(sid)) => {
                                     let handle = sessions.entry(sid.to_string()).or_default();
-                                    if handle.inflight.is_some() || parked.is_some() {
+                                    if handle.inflight.is_some() || !parked.is_empty() {
                                         handle.queue.push_back(next);
                                     } else {
                                         handle.inflight = begin_prompt(
@@ -1813,7 +1911,10 @@ where
                                 }
                                 Ok(None) => pending.push_back(next),
                                 Err(err) => {
-                                    let _ = bus.send(AppEvent::Ctl(CtlEvent::Error(err)));
+                                    let _ = bus.send(AppEvent::Ctl(CtlEvent::SessionError {
+                                    session_id: cmd_session.clone(),
+                                    message: err,
+                                }));
                                 }
                             }
                         }
@@ -1842,10 +1943,13 @@ where
                                                 )));
                                             }
                                             Err(err) => {
-                                                let _ = bus.send(AppEvent::Ctl(CtlEvent::Error(err)));
+                                                let _ = bus.send(AppEvent::Ctl(CtlEvent::SessionError {
+                                                session_id: cmd_session.clone(),
+                                                message: err,
+                                            }));
                                             }
                                         }
-                                    } else if parked.is_some() {
+                                    } else if !parked.is_empty() {
                                         let _ = bus.send(AppEvent::Ctl(CtlEvent::SteerSettled {
                                             message_id,
                                             deferred: true,
@@ -1881,7 +1985,10 @@ where
                                     }));
                                 }
                                 Err(err) => {
-                                    let _ = bus.send(AppEvent::Ctl(CtlEvent::Error(err)));
+                                    let _ = bus.send(AppEvent::Ctl(CtlEvent::SessionError {
+                                        session_id: cmd_session.clone(),
+                                        message: err,
+                                    }));
                                 }
                             }
                         }
@@ -1902,7 +2009,10 @@ where
                                 }
                                 Ok(None) => {}
                                 Err(err) => {
-                                    let _ = bus.send(AppEvent::Ctl(CtlEvent::Error(err)));
+                                    let _ = bus.send(AppEvent::Ctl(CtlEvent::SessionError {
+                                    session_id: cmd_session.clone(),
+                                    message: err,
+                                }));
                                 }
                             }
                         }
@@ -1911,7 +2021,10 @@ where
                                 Ok(Some(sid)) => sid,
                                 Ok(None) => continue,
                                 Err(err) => {
-                                    let _ = bus.send(AppEvent::Ctl(CtlEvent::Error(err)));
+                                    let _ = bus.send(AppEvent::Ctl(CtlEvent::SessionError {
+                                    session_id: cmd_session.clone(),
+                                    message: err,
+                                }));
                                     continue;
                                 }
                             };
@@ -2189,7 +2302,10 @@ where
                                 Ok(Some(sid)) => sid,
                                 Ok(None) => continue,
                                 Err(err) => {
-                                    let _ = bus.send(AppEvent::Ctl(CtlEvent::Error(err)));
+                                    let _ = bus.send(AppEvent::Ctl(CtlEvent::SessionError {
+                                    session_id: cmd_session.clone(),
+                                    message: err,
+                                }));
                                     continue;
                                 }
                             };
@@ -2231,7 +2347,10 @@ where
                                 Ok(Some(sid)) => sid,
                                 Ok(None) => continue,
                                 Err(err) => {
-                                    let _ = bus.send(AppEvent::Ctl(CtlEvent::Error(err)));
+                                    let _ = bus.send(AppEvent::Ctl(CtlEvent::SessionError {
+                                    session_id: cmd_session.clone(),
+                                    message: err,
+                                }));
                                     continue;
                                 }
                             };
@@ -2279,11 +2398,25 @@ where
                             }
                         }
                         Cmd::SetConfigOption {
-                            config_id, value, ..
+                            session_id: cmd_session,
+                            config_id,
+                            value,
                         } => {
-                            // Carries no session id; address the fallback session.
-                            let Some(sid) = current.clone() else {
-                                continue;
+                            let sid = match resolve_cmd_session(
+                                &sessions,
+                                &current,
+                                &cmd_session,
+                                "config_option",
+                            ) {
+                                Ok(Some(sid)) => sid,
+                                Ok(None) => continue,
+                                Err(err) => {
+                                    let _ = bus.send(AppEvent::Ctl(CtlEvent::SessionError {
+                                        session_id: cmd_session.clone(),
+                                        message: err,
+                                    }));
+                                    continue;
+                                }
                             };
                             match cx
                                 .send_request(SetSessionConfigOptionRequest::new(
@@ -2313,9 +2446,10 @@ where
                                     );
                                 }
                                 Err(err) => {
-                                    let _ = bus.send(AppEvent::Ctl(CtlEvent::TuiOpFailed(
-                                        format!("config option switch failed: {err}"),
-                                    )));
+                                    let _ = bus.send(AppEvent::Ctl(CtlEvent::SessionError {
+                                        session_id: sid.to_string(),
+                                        message: format!("config option switch failed: {err}"),
+                                    }));
                                 }
                             }
                         }
@@ -2407,40 +2541,22 @@ where
                                         &bus,
                                         configured_snapshot(methods.clone(), Some(&method)),
                                     );
-                                            match parked.take() {
-                                        None => {
-                                            let _ = bus.send(AppEvent::Ctl(CtlEvent::TuiOpDone(
-                                                "signed in".into(),
-                                            )));
-                                        }
-                                        Some(prompt) => {
-                                            let Some(sid) = current.clone() else {
-                                                parked = Some(prompt);
-                                                let _ = bus.send(AppEvent::Ctl(CtlEvent::TuiOpDone(
-                                                    "signed in — resend from the composer".into(),
-                                                )));
-                                                continue;
-                                            };
-                                            let retry = match prompt {
-                                                ParkedPrompt::Text(text) => Cmd::Prompt {
-                                                    session_id: sid.to_string(),
-                                                    text,
-                                                },
-                                                ParkedPrompt::Images(blocks) => Cmd::PromptImages {
-                                                    session_id: sid.to_string(),
-                                                    blocks,
-                                                },
-                                            };
-                                            sessions
-                                                .entry(sid.to_string())
-                                                .or_default()
-                                                .queue
-                                                .push_front(retry);
-                                            let _ = bus.send(AppEvent::Ctl(CtlEvent::TuiOpDone(
-                                                "signed in — retried the parked prompt".into(),
-                                            )));
-                                        }
-                                    }
+                                    // Release every stalled prompt into its
+                                    // own session's queue (entries whose
+                                    // session was closed meanwhile are
+                                    // dropped by the helper).
+                                    let retried = requeue_parked_prompts(
+                                        &mut sessions,
+                                        &current,
+                                        &mut parked,
+                                    );
+                                    let _ = bus.send(AppEvent::Ctl(CtlEvent::TuiOpDone(if retried
+                                        > 0
+                                    {
+                                        format!("signed in — retried {retried} parked prompt{s}", s = if retried == 1 { "" } else { "s" })
+                                    } else {
+                                        "signed in".into()
+                                    })));
                                 }
                                 Err(err) if is_auth_required_error(&err) => {
                                     emit_auth(
@@ -2484,6 +2600,12 @@ where
                                     );
                                 }
                                 Err(err) if is_auth_required_error(&err) => {
+                                    // The bind request is dead for now: pop
+                                    // its awaiting entry so a later bind can
+                                    // never land on it. The tab stays open
+                                    // (BindFailed notice) — /new again after
+                                    // signing in.
+                                    let _ = bus.send(AppEvent::Ctl(CtlEvent::BindFailed));
                                     emit_needs_auth_open(
                                         &bus,
                                         methods.clone(),
@@ -2491,10 +2613,11 @@ where
                                         Some(acp_error_message(&err)),
                                     );
                                 }
-                                Err(err) => {
-                                    let _ = bus.send(AppEvent::Ctl(CtlEvent::Error(format!(
-                                        "session/new: {err}"
-                                    ))));
+                                Err(_) => {
+                                    // The request the UI is awaiting died;
+                                    // the tab that asked stays open but the
+                                    // bind is never coming.
+                                    let _ = bus.send(AppEvent::Ctl(CtlEvent::BindFailed));
                                 }
                             }
                         }
@@ -2614,6 +2737,10 @@ where
                                     apply_setup(&setup, Some(&session), &surface, &bus);
                                 }
                                 Err(err) if is_auth_required_error(&err) => {
+                                    // Same dead-request rule as /new: the
+                                    // awaiting entry pops now; retry /resume
+                                    // after signing in.
+                                    let _ = bus.send(AppEvent::Ctl(CtlEvent::BindFailed));
                                     emit_needs_auth_open(
                                         &bus,
                                         methods.clone(),
@@ -2621,10 +2748,10 @@ where
                                         Some(acp_error_message(&err)),
                                     );
                                 }
-                                Err(err) => {
-                                    let _ = bus.send(AppEvent::Ctl(CtlEvent::Error(format!(
-                                        "session/resume: {err}"
-                                    ))));
+                                Err(_) => {
+                                    // session/resume failed outright: the
+                                    // awaiting tab's bind is never coming.
+                                    let _ = bus.send(AppEvent::Ctl(CtlEvent::BindFailed));
                                 }
                             }
                         }
@@ -2685,6 +2812,28 @@ where
                             )
                             .await;
                         }
+                        Cmd::ForgetSession { session_id } => {
+                            // `/close`: this client stopped viewing the
+                            // session. Drop its turn state and queued
+                            // prompts so nothing more is sent agent-side;
+                            // an in-flight prompt (if any) keeps running
+                            // and its finish is dropped by the prompt_done
+                            // guard. ACP has no session/close — the
+                            // server-side session survives and can be
+                            // re-entered later via session/resume.
+                            if sessions.remove(&session_id).is_some()
+                                && current
+                                    .as_ref()
+                                    .is_some_and(|c| c.to_string() == session_id)
+                            {
+                                // Repoint the id-less fallback at any
+                                // remaining session.
+                                current = sessions
+                                    .keys()
+                                    .next()
+                                    .map(|id| SessionId::new(id.clone()));
+                            }
+                        }
                         Cmd::Shutdown => break,
                     }
                             drain_ready_sessions(
@@ -2722,11 +2871,16 @@ where
                         finish = prompt_done_rx.recv() => {
                             let Some(done) = finish else { continue };
                             let key = done.session_id.clone();
-                            let mut aborted = false;
-                            if let Some(handle) = sessions.get_mut(&key) {
-                                handle.inflight = None;
-                                aborted = std::mem::take(&mut handle.turn_aborted);
-                            }
+                            // A session closed with `/close` (ForgetSession)
+                            // while its prompt was in flight: the turn ends
+                            // here — its UI events would be foreign on every
+                            // tab, and an auth error must not park a retry
+                            // for a session nobody views. Drop the finish.
+                            let Some(handle) = sessions.get_mut(&key) else {
+                                continue;
+                            };
+                            handle.inflight = None;
+                            let aborted = std::mem::take(&mut handle.turn_aborted);
                             if aborted {
                                 let _ = bus.send(AppEvent::Ui(
                                     crate::events::UiEvent::TurnEnd {
@@ -2738,6 +2892,7 @@ where
                                     session_id: key.clone(),
                                 }));
                             } else {
+                                let ok = matches!(done.result, Ok(_));
                                 apply_prompt_finish(
                                     done,
                                     &mut parked,
@@ -2745,8 +2900,18 @@ where
                                     &methods,
                                     selected.as_ref(),
                                 );
+                                if ok && !parked.is_empty() {
+                                    // A success proves the auth stall is
+                                    // over: requeue every stalled prompt
+                                    // into its owning session.
+                                    requeue_parked_prompts(
+                                        &mut sessions,
+                                        &current,
+                                        &mut parked,
+                                    );
+                                }
                             }
-                            if parked.is_none() {
+                            if parked.is_empty() {
                                 let queued = sessions
                                     .get(&key)
                                     .is_some_and(|handle| !handle.queue.is_empty());

--- a/src/acp.rs
+++ b/src/acp.rs
@@ -75,7 +75,12 @@ struct Surface {
 }
 
 impl Surface {
-    fn apply_config_options(&mut self, options: &Value, bus: &Sender<AppEvent>) {
+    fn apply_config_options(
+        &mut self,
+        options: &Value,
+        bus: &Sender<AppEvent>,
+        session_id: Option<&str>,
+    ) {
         let (models, presets, composition_id) = catalog_from_config_options(options);
         self.models = models.clone();
         self.presets = presets.clone();
@@ -110,6 +115,7 @@ impl Surface {
                             .collect();
                     if !self.modes.is_empty() {
                         let _ = bus.send(AppEvent::Ctl(CtlEvent::SessionModes {
+                            session_id: session_id.map(str::to_string),
                             modes: self.modes.clone(),
                             current: mode
                                 .get("currentValue")
@@ -124,7 +130,12 @@ impl Surface {
         let _ = bus.send(AppEvent::Ctl(CtlEvent::Catalog { models, presets }));
     }
 
-    fn apply_session_modes(&mut self, modes: &Value, bus: &Sender<AppEvent>) {
+    fn apply_session_modes(
+        &mut self,
+        modes: &Value,
+        bus: &Sender<AppEvent>,
+        session_id: Option<&str>,
+    ) {
         let (list, current) = session_modes_from_value(modes);
         if list.is_empty() && current.is_none() {
             return;
@@ -133,6 +144,7 @@ impl Surface {
             self.modes = list.clone();
         }
         let _ = bus.send(AppEvent::Ctl(CtlEvent::SessionModes {
+            session_id: session_id.map(str::to_string),
             modes: list,
             current,
         }));
@@ -748,24 +760,24 @@ fn apply_setup(
 ) {
     if let Ok(mut surface) = surface.lock() {
         surface.modes.clear();
+        let session = value
+            .get("sessionId")
+            .or_else(|| value.get("session_id"))
+            .and_then(Value::as_str)
+            .or(session_hint);
         if let Some(options) = value
             .get("configOptions")
             .or_else(|| value.get("config_options"))
         {
-            surface.apply_config_options(options, bus);
-            if let Some(session) = value
-                .get("sessionId")
-                .or_else(|| value.get("session_id"))
-                .and_then(Value::as_str)
-                .or(session_hint)
-            {
-                for event in config_option_events(session.to_string(), options) {
+            surface.apply_config_options(options, bus, session);
+            if let Some(s) = session {
+                for event in config_option_events(s.to_string(), options) {
                     let _ = bus.send(AppEvent::Ui(event));
                 }
             }
         }
         if let Some(modes) = value.get("modes") {
-            surface.apply_session_modes(modes, bus);
+            surface.apply_session_modes(modes, bus, session);
         }
     }
 }
@@ -797,7 +809,7 @@ fn apply_config_response(
         .or_else(|| value.get("config_options"))?
         .clone();
     if let Ok(mut surface) = surface.lock() {
-        surface.apply_config_options(&options, bus);
+        surface.apply_config_options(&options, bus, Some(&session.0));
     }
     for event in config_option_events(session.to_string(), &options) {
         let _ = bus.send(AppEvent::Ui(event));
@@ -1214,8 +1226,9 @@ where
                             .get("configOptions")
                             .or_else(|| update.get("config_options"))
                         {
+                            let session = params.get("sessionId").and_then(Value::as_str);
                             if let Ok(mut surface) = surface_n.lock() {
-                                surface.apply_config_options(options, &bus_n);
+                                surface.apply_config_options(options, &bus_n, session);
                             }
                         }
                         if let Some(commands) = update
@@ -2086,6 +2099,7 @@ where
                             }));
                             if !surface.modes.is_empty() {
                                 let _ = bus.send(AppEvent::Ctl(CtlEvent::SessionModes {
+                                    session_id: None,
                                     modes: surface.modes.clone(),
                                     current: None,
                                 }));
@@ -2370,17 +2384,24 @@ where
                                 .await
                             {
                                 Ok(response) => {
-                                    if let Ok(value) = serde_json::to_value(&response) {
+                                     if let Ok(value) = serde_json::to_value(&response) {
                                         if let Some(options) = value
                                             .get("configOptions")
                                             .or_else(|| value.get("config_options"))
                                         {
                                             if let Ok(mut surface) = surface.lock() {
-                                                surface.apply_config_options(options, &bus);
+                                                surface.apply_config_options(
+                                                    options,
+                                                    &bus,
+                                                    Some(&sid.0),
+                                                );
                                             }
                                         }
                                     }
-                                    let _ = bus.send(AppEvent::Ctl(CtlEvent::PresetSet { preset }));
+                                    let _ = bus.send(AppEvent::Ctl(CtlEvent::PresetSet {
+                                        session_id: sid.to_string(),
+                                        preset,
+                                    }));
                                 }
                                 Err(err) if is_auth_required_error(&err) => {
                                     emit_needs_auth_open(
@@ -2821,6 +2842,7 @@ where
                             // guard. ACP has no session/close — the
                             // server-side session survives and can be
                             // re-entered later via session/resume.
+                            parked.retain(|p| p.session.as_deref() != Some(&session_id));
                             if sessions.remove(&session_id).is_some()
                                 && current
                                     .as_ref()
@@ -2911,31 +2933,30 @@ where
                                     );
                                 }
                             }
-                            if parked.is_empty() {
-                                let queued = sessions
+                            let queued = parked.is_empty()
+                                && sessions
                                     .get(&key)
                                     .is_some_and(|handle| !handle.queue.is_empty());
-                                if queued {
-                                    drain_ready_sessions(
-                                        &mut sessions,
-                                        &cx,
-                                        &bus,
-                                        &mut parked,
-                                        &methods,
-                                        selected.as_ref(),
-                                        &surface,
-                                        &cfg.workspace,
-                                        &prompt_done_tx,
-                                    );
-                                } else {
-                                    let _ = bus.send(AppEvent::Rpc {
-                                        method: "session.status".into(),
-                                        params: json!({
-                                            "sessionId": key,
-                                            "status": "idle"
-                                        }),
-                                    });
-                                }
+                            if queued {
+                                drain_ready_sessions(
+                                    &mut sessions,
+                                    &cx,
+                                    &bus,
+                                    &mut parked,
+                                    &methods,
+                                    selected.as_ref(),
+                                    &surface,
+                                    &cfg.workspace,
+                                    &prompt_done_tx,
+                                );
+                            } else {
+                                let _ = bus.send(AppEvent::Rpc {
+                                    method: "session.status".into(),
+                                    params: json!({
+                                        "sessionId": key,
+                                        "status": "idle"
+                                    }),
+                                });
                             }
                         }
                     }

--- a/src/app.rs
+++ b/src/app.rs
@@ -1815,6 +1815,7 @@ impl App {
         self.picker = None;
         self.queue_selection = None;
         self.queue_edit = None;
+        self.vim.reset_pending();
         self.needs_redraw = true;
     }
 
@@ -1993,7 +1994,6 @@ impl App {
                 if slot.running {
                     slot.completed_unseen = true;
                 }
-                slot.running = false;
                 slot.prompt_pending = false;
             }
             _ => {}
@@ -2030,6 +2030,10 @@ impl App {
             }
         }
         slot.prompt_pending = true;
+        slot.running = true;
+        slot.run_started = Some(Instant::now());
+        slot.state_note = self.locale.tr("sending queued followup", "正在发送排队消息").into();
+        slot.scroll_up = 0;
         match prompt.blocks.as_slice() {
             [StagedBlock::Text(text)] => ctl.send(Cmd::Prompt {
                 session_id: session.to_string(),
@@ -3334,29 +3338,45 @@ impl App {
                             }
                         }
                     }
-                    CtlEvent::SessionModes { modes, current } => {
+                    CtlEvent::SessionModes {
+                        session_id,
+                        modes,
+                        current,
+                    } => {
+                        let is_live = match &session_id {
+                            Some(sid) => sid == &self.session_id,
+                            None => true,
+                        };
                         if !modes.is_empty() {
                             self.permission_choices = modes.clone();
                         }
-                        if let Some(id) = current {
-                            self.modes.permission = Some(id);
-                        }
-                        let reported = self.modes.permission.clone();
-                        let current_id = self.current_permission().to_string();
-                        let choices = self.permission_choices.clone();
-                        if let Some(picker) = &mut self.picker {
-                            if matches!(picker.kind, PickerKind::Permission) && !choices.is_empty()
-                            {
-                                picker.items = permission_picker_items(
-                                    &choices,
-                                    reported.as_deref(),
-                                    &current_id,
-                                );
-                                picker.sel = picker
-                                    .items
-                                    .iter()
-                                    .position(|i| i.id == current_id)
-                                    .unwrap_or(0);
+                        if is_live {
+                            if let Some(id) = &current {
+                                self.modes.permission = Some(id.clone());
+                            }
+                            let reported = self.modes.permission.clone();
+                            let current_id = self.current_permission().to_string();
+                            let choices = self.permission_choices.clone();
+                            if let Some(picker) = &mut self.picker {
+                                if matches!(picker.kind, PickerKind::Permission) && !choices.is_empty()
+                                {
+                                    picker.items = permission_picker_items(
+                                        &choices,
+                                        reported.as_deref(),
+                                        &current_id,
+                                    );
+                                    picker.sel = picker
+                                        .items
+                                        .iter()
+                                        .position(|i| i.id == current_id)
+                                        .unwrap_or(0);
+                                }
+                            }
+                        } else if let Some(sid) = session_id.as_deref() {
+                            if let Some(slot) = self.parked.iter_mut().find(|s| s.id == sid) {
+                                if let Some(id) = current {
+                                    slot.modes.permission = Some(id);
+                                }
                             }
                         }
                     }
@@ -3366,16 +3386,33 @@ impl App {
                         }
                         self.open_effort_picker(efforts, default);
                     }
-                    CtlEvent::PresetSet { preset } => {
+                    CtlEvent::PresetSet {
+                        session_id,
+                        preset,
+                    } => {
+                        let is_live = session_id.is_empty() || session_id == self.session_id;
                         let label = self.agent_label(&preset);
-                        self.modes.agent_preset = Some(preset.clone());
-                        self.transcript.push_notice(
-                            NoticeLevel::Info,
-                            format!(
-                                "⚙ agent → {} · composes on this session's first prompt",
-                                label
-                            ),
-                        );
+                        if is_live {
+                            self.modes.agent_preset = Some(preset.clone());
+                            self.transcript.push_notice(
+                                NoticeLevel::Info,
+                                format!(
+                                    "⚙ agent → {} · composes on this session's first prompt",
+                                    label
+                                ),
+                            );
+                        } else if let Some(slot) =
+                            self.parked.iter_mut().find(|s| s.id == session_id)
+                        {
+                            slot.modes.agent_preset = Some(preset.clone());
+                            slot.transcript.push_notice(
+                                NoticeLevel::Info,
+                                format!(
+                                    "⚙ agent → {} · composes on this session's first prompt",
+                                    label
+                                ),
+                            );
+                        }
                     }
                     CtlEvent::TuiOpDone(desc) => {
                         self.transcript.push_notice(NoticeLevel::Info, desc);
@@ -3439,6 +3476,7 @@ impl App {
                             match owner {
                                 Some(pidx) => {
                                     let slot = &mut self.parked[pidx];
+                                    let old_id = slot.id.clone();
                                     slot.id = session_id.clone();
                                     slot.transcript.set_root_session(session_id.clone());
                                     slot.session_bound = true;
@@ -3446,24 +3484,44 @@ impl App {
                                         slot.transcript
                                             .push_notice(NoticeLevel::Info, notice);
                                     }
+                                    for (_, sid, _) in &mut self.shell_pending {
+                                        if sid == &old_id {
+                                            *sid = session_id.clone();
+                                        }
+                                    }
                                     just_bound = Some(slot.id.clone());
                                 }
                                 None => {
-                                    // Every parked tab is bound (reconnect
-                                    // after a long outage): adopt the fresh
-                                    // session on the viewed tab, the
-                                    // pre-multi-session semantic.
-                                    if self.session_id != session_id {
-                                        self.reset_subagent_views();
+                                    if !self.session_bound
+                                        && !self.awaiting_binds.iter().any(|e| e.id == self.session_id)
+                                    {
+                                        if self.session_id != session_id {
+                                            self.reset_subagent_views();
+                                        }
+                                        let old_id = self.session_id.clone();
+                                        self.session_id = session_id.clone();
+                                        self.transcript.set_root_session(session_id.clone());
+                                        self.session_bound = true;
+                                        if let Some(notice) = notice {
+                                            self.transcript
+                                                .push_notice(NoticeLevel::Info, notice);
+                                        }
+                                        for (_, sid, _) in &mut self.shell_pending {
+                                            if sid == &old_id {
+                                                *sid = session_id.clone();
+                                            }
+                                        }
+                                        just_bound = Some(self.session_id.clone());
+                                    } else {
+                                        // The viewed tab is bound or awaiting its own bind:
+                                        // park this startup session as a fresh slot.
+                                        let mut slot = SessionSlot::fresh(session_id.clone(), true);
+                                        if let Some(notice) = notice {
+                                            slot.transcript.push_notice(NoticeLevel::Info, notice);
+                                        }
+                                        just_bound = Some(session_id.clone());
+                                        self.parked.push(slot);
                                     }
-                                    self.session_id = session_id.clone();
-                                    self.transcript.set_root_session(session_id);
-                                    self.session_bound = true;
-                                    if let Some(notice) = notice {
-                                        self.transcript
-                                            .push_notice(NoticeLevel::Info, notice);
-                                    }
-                                    just_bound = Some(self.session_id.clone());
                                 }
                             }
                         } else if let Some(awaiting) = self.awaiting_binds.pop_front() {
@@ -3484,21 +3542,33 @@ impl App {
                                     "session {session_id} bound after its tab was closed"
                                 ));
                             } else if self.session_id == awaiting.id {
+                                let old_id = self.session_id.clone();
                                 self.session_id = session_id.clone();
                                 self.transcript.set_root_session(session_id.clone());
                                 self.session_bound = true;
                                 if let Some(notice) = notice {
                                     self.transcript.push_notice(NoticeLevel::Info, notice);
                                 }
+                                for (_, sid, _) in &mut self.shell_pending {
+                                    if sid == &old_id || sid == &awaiting.id {
+                                        *sid = session_id.clone();
+                                    }
+                                }
                                 just_bound = Some(self.session_id.clone());
                             } else if let Some(slot) =
                                 self.parked.iter_mut().find(|slot| slot.id == awaiting.id)
                             {
+                                let old_id = slot.id.clone();
                                 slot.id = session_id.clone();
                                 slot.transcript.set_root_session(session_id.clone());
                                 slot.session_bound = true;
                                 if let Some(notice) = notice {
                                     slot.transcript.push_notice(NoticeLevel::Info, notice);
+                                }
+                                for (_, sid, _) in &mut self.shell_pending {
+                                    if sid == &old_id || sid == &awaiting.id {
+                                        *sid = session_id.clone();
+                                    }
                                 }
                                 just_bound = Some(slot.id.clone());
                             } else {
@@ -3521,11 +3591,17 @@ impl App {
                             if self.session_id != session_id {
                                 self.reset_subagent_views();
                             }
+                            let old_id = self.session_id.clone();
                             self.session_id = session_id.clone();
-                            self.transcript.set_root_session(session_id);
+                            self.transcript.set_root_session(session_id.clone());
                             self.session_bound = true;
                             if let Some(notice) = notice {
                                 self.transcript.push_notice(NoticeLevel::Info, notice);
+                            }
+                            for (_, sid, _) in &mut self.shell_pending {
+                                if sid == &old_id {
+                                    *sid = session_id.clone();
+                                }
                             }
                             just_bound = Some(self.session_id.clone());
                         }
@@ -3706,10 +3782,17 @@ impl App {
                     self.needs_redraw = true;
                     return;
                 }
-                if let Some(slot) = self.parked.iter_mut().find(|slot| slot.id == session) {
-                    Self::apply_to_slot(slot, ui);
-                    self.needs_redraw = true;
-                    return;
+                for slot in &mut self.parked {
+                    if slot.id == session {
+                        Self::apply_to_slot(slot, ui);
+                        self.needs_redraw = true;
+                        return;
+                    }
+                    if let Some(view) = slot.subagents.iter_mut().find(|view| view.id == session) {
+                        view.transcript.apply(ui);
+                        self.needs_redraw = true;
+                        return;
+                    }
                 }
                 // A session this client never opened (or already closed):
                 // drop the event. Foreign-session facts must never fall
@@ -5104,6 +5187,24 @@ impl App {
                     self.switch_view_to_tab(tab, ctl);
                 }
             }
+            Action::NextSessionTab => {
+                let count = self.session_tab_count();
+                if count > 1 {
+                    let next = (self.current + 1) % count;
+                    self.switch_view_to_tab(next, ctl);
+                }
+            }
+            Action::PrevSessionTab => {
+                let count = self.session_tab_count();
+                if count > 1 {
+                    let prev = if self.current == 0 {
+                        count - 1
+                    } else {
+                        self.current - 1
+                    };
+                    self.switch_view_to_tab(prev, ctl);
+                }
+            }
             Action::HistoryPrev => self.history_prev(),
             Action::HistoryNext => self.history_next(),
             Action::ScrollHalfUp => self.scroll_by(10),
@@ -5307,9 +5408,15 @@ impl App {
             options,
             reply: Some(reply),
         };
-        if session_id == self.session_id {
+        let belongs_to_live = session_id == self.session_id
+            || self.subagents.iter().any(|v| v.id == session_id);
+        if belongs_to_live {
             self.permission_ask = Some(overlay);
-        } else if let Some(slot) = self.parked.iter_mut().find(|slot| slot.id == session_id) {
+        } else if let Some(slot) = self
+            .parked
+            .iter_mut()
+            .find(|slot| slot.id == session_id || slot.subagents.iter().any(|v| v.id == session_id))
+        {
             // A parked session asked while out of view: keep the ask on its
             // tab — it must not float over the tab on screen.
             slot.permission_ask = Some(overlay);
@@ -5336,14 +5443,16 @@ impl App {
         };
         let for_live = match session_id {
             None => true,
-            Some(sid) => sid == self.session_id,
+            Some(sid) => sid == self.session_id || self.subagents.iter().any(|v| v.id == sid),
         };
         if for_live {
             self.elicitation_ask = Some(overlay);
         } else if let Some(slot) = self
             .parked
             .iter_mut()
-            .find(|slot| Some(slot.id.as_str()) == session_id)
+            .find(|slot| {
+                session_id.is_some_and(|sid| slot.id == sid || slot.subagents.iter().any(|v| v.id == sid))
+            })
         {
             slot.elicitation_ask = Some(overlay);
         } else {
@@ -7918,12 +8027,15 @@ impl App {
 mod persistent_shell_tests;
 
 pub fn timestamp() -> String {
+    use std::sync::atomic::{AtomicU64, Ordering};
     use std::time::{SystemTime, UNIX_EPOCH};
-    let secs = SystemTime::now()
+    static COUNTER: AtomicU64 = AtomicU64::new(1);
+    let micros = SystemTime::now()
         .duration_since(UNIX_EPOCH)
-        .map(|d| d.as_secs())
+        .map(|d| d.as_micros())
         .unwrap_or(0);
-    format!("{secs:x}")
+    let seq = COUNTER.fetch_add(1, Ordering::Relaxed);
+    format!("{micros:x}-{seq:x}")
 }
 
 /// Model ids from the host catalog snapshot: either inline JSON in

--- a/src/app.rs
+++ b/src/app.rs
@@ -1265,6 +1265,13 @@ pub struct App {
     awaiting_binds: VecDeque<AwaitingBind>,
     /// Tab strip hit-test rects, recorded by `ui::draw_session_tabs`.
     pub(crate) tab_rects: Vec<(ratatui::layout::Rect, usize)>,
+    /// First tab index rendered in the session tab strip (the strip's
+    /// scroll window). Mouse clicks on the window's edge tabs nudge it by
+    /// one so the neighboring tab appears — a mouse can walk through every
+    /// session tab without ever hitting a dead end. The draw pass keeps the
+    /// window sane (never past the tail, head-anchored when there is no
+    /// overflow, live tab always in view).
+    pub(crate) tab_strip_offset: usize,
     pub cfg: RuntimeConfig,
     /// Model explicitly picked this session (`/model`); wins over
     /// `transcript.last_model` in the chip until a turn realizes it.
@@ -1660,6 +1667,7 @@ impl App {
             current: 0,
             awaiting_binds: VecDeque::new(),
             tab_rects: Vec::new(),
+            tab_strip_offset: 0,
             cfg,
             selected_model: None,
             demo,
@@ -1928,6 +1936,13 @@ impl App {
     /// Number of session tabs (parked + live).
     pub fn session_tab_count(&self) -> usize {
         self.parked.len() + 1
+    }
+
+    /// Tab index of the live session — the position where `session_tabs`
+    /// splices it into the parked list. The painter uses it to keep the
+    /// strip's scroll window anchored on the tab being viewed.
+    pub(crate) fn live_tab_index(&self) -> usize {
+        self.current
     }
 
     /// Hit-test a screen cell against the tab rects recorded by the painter.
@@ -3983,6 +3998,30 @@ impl App {
                 // Session tab strip (issue #94): left-click a tab switches.
                 if let Some(tab) = self.tab_at(mouse.column, mouse.row) {
                     self.switch_view_to_tab(tab, ctl);
+                    // Clicking the strip's outermost visible tab also
+                    // nudges the strip so its neighbor appears — repeated
+                    // edge clicks walk the mouse through every session
+                    // tab, left or right. `switch_view_to_tab` already
+                    // released overlays etc.; only the strip moves here.
+                    let first = self
+                        .tab_rects
+                        .iter()
+                        .map(|(_, idx)| *idx)
+                        .min()
+                        .unwrap_or(tab);
+                    let last = self
+                        .tab_rects
+                        .iter()
+                        .map(|(_, idx)| *idx)
+                        .max()
+                        .unwrap_or(tab);
+                    if tab == first && tab > 0 {
+                        self.tab_strip_offset = self.tab_strip_offset.saturating_sub(1);
+                        self.needs_redraw = true;
+                    } else if tab == last && tab + 1 < self.session_tab_count() {
+                        self.tab_strip_offset = self.tab_strip_offset.saturating_add(1);
+                        self.needs_redraw = true;
+                    }
                     return;
                 }
                 if let Some(action) = self

--- a/src/app.rs
+++ b/src/app.rs
@@ -160,6 +160,11 @@ pub const SLASH_COMMANDS: &[SlashCommand] = &[
         desc: "resume a durable session from this workspace",
     },
     SlashCommand {
+        name: "close",
+        usage: "/close",
+        desc: "close the current session tab (last tab cannot close)",
+    },
+    SlashCommand {
         name: "clear",
         usage: "/clear",
         desc: "clear the scrollback",
@@ -739,10 +744,40 @@ pub struct SubagentView {
 /// One non-live session's full state while another tab is viewed (issue
 /// #94). The App's own fields always describe the viewed session; a tab
 /// switch moves them into a slot and loads the target slot in their place.
+///
+/// Everything the frame paints between the session tab strip and the
+/// composer stats dock is session state: the transcript and its scroll
+/// position, the composer draft + staged images + `@file` browser, the
+/// queue shelf, subagents, ACP asks, painter popups — a tab switch must
+/// never show another session's chrome on this session's tab.
 pub struct SessionSlot {
     pub id: String,
     pub title: Option<String>,
     pub transcript: Transcript,
+    /// Composer draft (text, cursor, per-tab recall history) rides with
+    /// its session like the queue does — the composer area is bound to
+    /// the viewed tab.
+    pub input: ComposerEditor,
+    /// Images staged in the draft as `[image n]` chips (draft-bound).
+    pub pending_images: crate::attachments::Staged,
+    /// Composer well pinned to the amplified height (issue #92).
+    pub input_expanded: bool,
+    /// Open `@file` browser + its Esc-dismissed `@` token tag. Both are
+    /// draft-bound: the menu filters the draft's token, so it follows the
+    /// draft to its tab.
+    pub file_menu: Option<crate::file_ref::FileMenu>,
+    pub file_menu_dismissed: Option<String>,
+    /// Chat scroll offset in lines above the bottom (0 = follow).
+    pub scroll_up: usize,
+    /// Model explicitly picked on this session (`/model`); wins over
+    /// `transcript.last_model` in the chip until a turn realizes it.
+    pub selected_model: Option<String>,
+    /// Welcome banner: shown until this session sends its first prompt.
+    pub show_banner: bool,
+    /// Meta-row chrome while the session runs: state note text and the
+    /// elapsed-timer anchor.
+    pub state_note: String,
+    pub run_started: Option<Instant>,
     /// Authoritative per-session running bit (folded from `SessionStatus`
     /// and turn lifecycle events).
     pub running: bool,
@@ -784,6 +819,18 @@ impl SessionSlot {
             transcript: Transcript::new(id.clone()),
             id,
             title: None,
+            input: ComposerEditor::new(),
+            pending_images: crate::attachments::Staged::default(),
+            input_expanded: false,
+            file_menu: None,
+            file_menu_dismissed: None,
+            scroll_up: 0,
+            selected_model: None,
+            // A fresh tab has not prompted yet — the welcome banner paints
+            // until its first send (resume paths force it off).
+            show_banner: true,
+            state_note: String::new(),
+            run_started: None,
             running: false,
             completed_unseen: false,
             prompt_queue: VecDeque::new(),
@@ -802,6 +849,13 @@ impl SessionSlot {
             plugin_tree: None,
         }
     }
+}
+
+/// One FIFO entry for a tab awaiting its `SessionBound` (see the App
+/// field `awaiting_binds`).
+struct AwaitingBind {
+    id: String,
+    open: bool,
 }
 
 /// One row of the session tab strip (native chrome, `ui::draw_session_tabs`).
@@ -1195,10 +1249,14 @@ pub struct App {
     parked: Vec<SessionSlot>,
     /// Tab index of the live session (`0..=parked.len()`).
     current: usize,
-    /// Ids of tabs awaiting their `SessionBound`, FIFO: `/new` placeholders
-    /// and `session/load` targets. The bind lands on the tab that asked,
-    /// even if the user switched away while it resolved.
-    awaiting_binds: VecDeque<String>,
+    /// One FIFO entry for a tab awaiting its `SessionBound`: `/new`
+    /// placeholders and `session/load` targets. The bind lands on the tab
+    /// that asked, even if the user switched away while it resolved.
+    /// Closing the tab before the bind resolves keeps the entry (its FIFO
+    /// position still owns the in-flight request) but marks it dead — the
+    /// bind is discarded when it arrives instead of rebinding some other
+    /// tab.
+    awaiting_binds: VecDeque<AwaitingBind>,
     /// Tab strip hit-test rects, recorded by `ui::draw_session_tabs`.
     pub(crate) tab_rects: Vec<(ratatui::layout::Rect, usize)>,
     pub cfg: RuntimeConfig,
@@ -1211,6 +1269,13 @@ pub struct App {
     /// A real `session/new`, `session/resume`, or `session/load` supplied this id.
     /// Cached session options stay hidden until this becomes true.
     pub session_bound: bool,
+    /// The unrequested startup/reconnect bind has been seen. Before it,
+    /// any `SessionBound` is the acp-side `session/new` this client did not
+    /// ask for — so when one arrives while tabs are awaiting their own
+    /// binds it must land on the parked tab that is not awaiting anything,
+    /// not on the FIFO head (issue #94 startup race). Seeded bound
+    /// sessions (demo, tests) have no pending unrequested bind.
+    startup_bound: bool,
     /// ACP initialize / authenticate status (live ACP only).
     pub auth: crate::acp_auth::AuthSnapshot,
     /// Leave the TUI and run this agent login, then `authenticate`.
@@ -1232,7 +1297,7 @@ pub struct App {
     /// ACP request task yet. Runtime startup alone does not make a turn busy.
     prompt_pending: bool,
     shell_seq: u64,
-    shell_pending: Vec<(u64, usize)>, // (id, cell idx)
+    shell_pending: Vec<(u64, String, usize)>, // (id, session id, cell idx)
     shell_worker: Option<ShellWorker>,
     bus_tx: Sender<AppEvent>,
     pub server_info: Option<String>,
@@ -1594,6 +1659,9 @@ impl App {
             demo,
             attached,
             session_bound: demo,
+            // Seeded-bound sessions (demo, tests, local resume) have no
+            // unrequested bind coming; a live ACP start does.
+            startup_bound: demo,
             auth: crate::acp_auth::AuthSnapshot::none(),
             pending_terminal_auth: None,
             quit: false,
@@ -1645,6 +1713,17 @@ impl App {
             id: std::mem::take(&mut self.session_id),
             title: self.session_title.take(),
             transcript: std::mem::replace(&mut self.transcript, Transcript::new(String::new())),
+            // Composer + chat chrome bound to the tab (see `put_live_slot`).
+            input: std::mem::take(&mut self.input),
+            pending_images: std::mem::take(&mut self.pending_images),
+            input_expanded: std::mem::take(&mut self.input_expanded),
+            file_menu: self.file_menu.take(),
+            file_menu_dismissed: self.file_menu_dismissed.take(),
+            scroll_up: std::mem::take(&mut self.scroll_up),
+            selected_model: std::mem::take(&mut self.selected_model),
+            show_banner: std::mem::take(&mut self.show_banner),
+            state_note: std::mem::take(&mut self.state_note),
+            run_started: self.run_started.take(),
             running: self.state != RunState::Idle || self.prompt_pending,
             completed_unseen: false,
             prompt_queue: std::mem::take(&mut self.prompt_queue),
@@ -1670,7 +1749,8 @@ impl App {
 
     /// Load a slot's state into the App fields — the inverse of
     /// [`Self::take_live_slot`]. RunState is recomputed from the slot's
-    /// authoritative `running` bit; the elapsed timer restarts.
+    /// authoritative `running` bit; an in-flight turn keeps its elapsed
+    /// timer and state note.
     fn put_live_slot(&mut self, slot: SessionSlot) {
         self.session_id = slot.id;
         self.session_title = slot.title;
@@ -1694,19 +1774,39 @@ impl App {
         // Painter popups and the /plugins tree resurface the same way.
         self.view_overlay = slot.view_overlay;
         self.plugin_tree = slot.plugin_tree;
-        self.state = if slot.running || slot.prompt_pending {
+        // Composer + chat chrome bound to the tab: draft, staged images,
+        // @file browser, scroll, banner, model pick, running note.
+        self.input = slot.input;
+        self.pending_images = slot.pending_images;
+        self.input_expanded = slot.input_expanded;
+        self.file_menu = slot.file_menu;
+        self.file_menu_dismissed = slot.file_menu_dismissed;
+        self.scroll_up = slot.scroll_up;
+        self.selected_model = slot.selected_model;
+        self.show_banner = slot.show_banner;
+        let running = slot.running || slot.prompt_pending;
+        self.state = if running {
             RunState::Running
         } else {
             RunState::Idle
         };
-        self.run_started = None;
-        self.state_note.clear();
+        // Restore the meta-row chrome as left: an in-flight turn keeps its
+        // elapsed timer and note; a session that settled while parked
+        // shows the idle meta row.
+        self.run_started = if running { slot.run_started } else { None };
+        self.state_note = if running {
+            slot.state_note
+        } else {
+            String::new()
+        };
     }
 
-    /// Per-view caches that must not leak across a tab switch.
+    /// Per-view caches that must not leak across a tab switch. Draft,
+    /// staged images, scroll and model pick come back from the slot via
+    /// [`Self::put_live_slot`]; everything here is transient interaction
+    /// state that must never resurface on the incoming tab.
     fn after_switch(&mut self) {
         self.chat_view = ChatView::default();
-        self.scroll_up = 0;
         self.sel = None;
         self.selecting = false;
         self.last_click = None;
@@ -1715,8 +1815,6 @@ impl App {
         self.picker = None;
         self.queue_selection = None;
         self.queue_edit = None;
-        // The incoming transcript's own model is the truth for the chip.
-        self.selected_model = None;
         self.needs_redraw = true;
     }
 
@@ -1740,6 +1838,24 @@ impl App {
         self.current = tab;
         self.put_live_slot(target);
         self.after_switch();
+    }
+
+    /// Leave the viewed session for another tab — mouse click and keyboard
+    /// (alt+1…9) take the same path: transient interactions are dismissed
+    /// and compositor-owned overlays are released with their cancel events
+    /// (the plugin owns a single-overlay slot; Esc would send the same).
+    /// Painter popups and ACP asks park with their session instead and
+    /// resurface on return.
+    pub fn switch_view_to_tab(&mut self, tab: usize, ctl: &Controller) {
+        self.sel = None;
+        self.selecting = false;
+        self.last_click = None;
+        self.input_sel = None;
+        self.input_selecting = false;
+        if tab != self.current {
+            self.cancel_plugin_overlays(ctl);
+        }
+        self.switch_to_session(tab);
     }
 
     /// Park the live session and open a fresh tab for `id` at the end.
@@ -1867,7 +1983,12 @@ impl App {
                     slot.prompt_pending = false;
                 }
             }
-            E::TurnStart { .. } => slot.running = true,
+            E::TurnStart { .. } => {
+                // A new turn on this session starts a fresh subagent batch
+                // (mirror of the live path in `apply_ui`).
+                slot.next_subagent_starts_batch = true;
+                slot.running = true;
+            }
             E::TurnEnd { .. } => {
                 if slot.running {
                     slot.completed_unseen = true;
@@ -1919,6 +2040,51 @@ impl App {
                 blocks: prompt_blocks_from_staged(prompt.blocks),
             }),
         }
+    }
+
+    /// Settle one Send Now (steer) outcome. The steer's session may have
+    /// been parked or even closed while the agent decided, so the pending
+    /// entry is looked up on the viewed tab first and then in every parked
+    /// slot (`next_prompt_id` is a single counter, so ids are unique app-
+    /// wide). A deferred steer is requeued into its own session's FIFO and
+    /// its echo bubble hidden there.
+    fn settle_steer(&mut self, message_id: u64, deferred: bool) {
+        if let Some(pending) = self.pending_steer_cells.remove(&message_id) {
+            if deferred {
+                self.transcript.hide_cells(&pending.cells);
+                let queued = ClientQueuedPrompt {
+                    id: message_id,
+                    blocks: pending.blocks,
+                };
+                if pending.requeue_front {
+                    self.prompt_queue.push_front(queued);
+                } else {
+                    self.prompt_queue.push_back(queued);
+                }
+                self.queued = self.prompt_queue.len();
+                self.show_tip("agent deferred Send Now — queued after the active turn");
+            }
+            return;
+        }
+        // The owning tab is not the one in view — settle inside its slot.
+        for slot in &mut self.parked {
+            if let Some(pending) = slot.pending_steer_cells.remove(&message_id) {
+                if deferred {
+                    slot.transcript.hide_cells(&pending.cells);
+                    let queued = ClientQueuedPrompt {
+                        id: message_id,
+                        blocks: pending.blocks,
+                    };
+                    if pending.requeue_front {
+                        slot.prompt_queue.push_front(queued);
+                    } else {
+                        slot.prompt_queue.push_back(queued);
+                    }
+                }
+                return;
+            }
+        }
+        // The session was closed before the settle: nothing to do.
     }
 
     /// Re-detect the workspace git branch for the composer cap label. One
@@ -2944,6 +3110,9 @@ impl App {
                 // kept in proto's tail buffer for diagnostics; stay quiet here
             }
             AppEvent::RuntimeExited(code) => {
+                // A next prompt restarts the runtime; its fresh startup
+                // bind is again an unrequested one (see `startup_bound`).
+                self.startup_bound = false;
                 self.prompt_pending = false;
                 self.queued = 0;
                 self.prompt_queue.clear();
@@ -2998,31 +3167,73 @@ impl App {
                         message_id,
                         deferred,
                     } => {
-                        if let Some(pending) = self.pending_steer_cells.remove(&message_id) {
-                            if deferred {
-                                self.transcript.hide_cells(&pending.cells);
-                                let queued = ClientQueuedPrompt {
-                                    id: message_id,
-                                    blocks: pending.blocks,
-                                };
-                                if pending.requeue_front {
-                                    self.prompt_queue.push_front(queued);
-                                } else {
-                                    self.prompt_queue.push_back(queued);
-                                }
-                                self.queued = self.prompt_queue.len();
-                                self.show_tip(
-                                    "agent deferred Send Now — queued after the active turn",
-                                );
-                            }
-                        }
+                        self.settle_steer(message_id, deferred);
                     }
                     CtlEvent::Error(err) => {
+                        // Connection-level failure (no session context): the
+                        // notice belongs to the viewed tab. Session-scoped
+                        // failures arrive as `SessionError` instead.
                         self.prompt_pending = false;
                         self.state = RunState::Idle;
                         self.run_started = None;
                         self.transcript.push_notice(NoticeLevel::Error, err);
                         self.dispatch_next_queued(ctl);
+                    }
+                    CtlEvent::SessionError {
+                        session_id,
+                        message,
+                    } => {
+                        // A failure for one specific session (prompt,
+                        // steer, config select, …): the notice lands in that
+                        // session's own transcript — a parked tab must not
+                        // spill errors onto the viewed one. The session's
+                        // delivery state settles (its prompt, if any, is not
+                        // coming back) but its queue is left alone: an
+                        // unbound/forgotten tab must not burn queued
+                        // prompts through repeated rejections.
+                        if session_id == self.session_id {
+                            self.prompt_pending = false;
+                            self.state = RunState::Idle;
+                            self.run_started = None;
+                            self.transcript
+                                .push_notice(NoticeLevel::Error, message);
+                        } else if let Some(slot) = self
+                            .parked
+                            .iter_mut()
+                            .find(|slot| slot.id == session_id)
+                        {
+                            slot.prompt_pending = false;
+                            slot.running = false;
+                            slot.transcript
+                                .push_notice(NoticeLevel::Error, message);
+                        }
+                    }
+                    CtlEvent::BindFailed => {
+                        // session/new·resume failed outright. acp completes
+                        // bind requests in order, so the FIFO head owns the
+                        // failure: drop its entry so a later bind cannot
+                        // land on the dead request, and tell the tab that
+                        // asked (it stays open and unbound — /close or
+                        // retry /new·resume).
+                        if let Some(awaiting) = self.awaiting_binds.pop_front() {
+                            if awaiting.open {
+                                let msg: String = self.locale.tr(
+                                    "session bind failed — this tab stays open; /close it or retry /new",
+                                    "会话绑定失败 —— 本标签页保持打开;/close 关闭或重试 /new",
+                                ).into();
+                                if self.session_id == awaiting.id {
+                                    self.transcript.push_notice(NoticeLevel::Warn, msg);
+                                } else if let Some(slot) = self
+                                    .parked
+                                    .iter_mut()
+                                    .find(|slot| slot.id == awaiting.id)
+                                {
+                                    slot.transcript.push_notice(NoticeLevel::Warn, msg);
+                                }
+                            }
+                        }
+                        self.show_tip("session bind failed");
+                        self.needs_redraw = true;
                     }
                     CtlEvent::CancelRequested => {
                         self.state_note = "cancelling".into();
@@ -3211,13 +3422,68 @@ impl App {
                         // below (prompts submitted while the tab was unbound
                         // are held in its queue — acp.rs rejects unbound ids).
                         let mut just_bound: Option<String> = None;
-                        if let Some(awaiting) = self.awaiting_binds.pop_front() {
+                        if !self.startup_bound && !self.awaiting_binds.is_empty() {
+                            // The unrequested startup/reconnect session/new
+                            // resolved while the user's own /new·resume is
+                            // still in flight — acp completes the startup
+                            // bind before any UI request, so this bind owns
+                            // no awaiting entry. Its tab is the parked
+                            // session that is unbound and not itself
+                            // awaiting anything; never steal the FIFO head
+                            // from the request that really owns it.
+                            self.startup_bound = true;
+                            let owner = self.parked.iter().position(|slot| {
+                                !slot.session_bound
+                                    && !self.awaiting_binds.iter().any(|e| e.id == slot.id)
+                            });
+                            match owner {
+                                Some(pidx) => {
+                                    let slot = &mut self.parked[pidx];
+                                    slot.id = session_id.clone();
+                                    slot.transcript.set_root_session(session_id.clone());
+                                    slot.session_bound = true;
+                                    if let Some(notice) = notice {
+                                        slot.transcript
+                                            .push_notice(NoticeLevel::Info, notice);
+                                    }
+                                    just_bound = Some(slot.id.clone());
+                                }
+                                None => {
+                                    // Every parked tab is bound (reconnect
+                                    // after a long outage): adopt the fresh
+                                    // session on the viewed tab, the
+                                    // pre-multi-session semantic.
+                                    if self.session_id != session_id {
+                                        self.reset_subagent_views();
+                                    }
+                                    self.session_id = session_id.clone();
+                                    self.transcript.set_root_session(session_id);
+                                    self.session_bound = true;
+                                    if let Some(notice) = notice {
+                                        self.transcript
+                                            .push_notice(NoticeLevel::Info, notice);
+                                    }
+                                    just_bound = Some(self.session_id.clone());
+                                }
+                            }
+                        } else if let Some(awaiting) = self.awaiting_binds.pop_front() {
                             // The tab that asked for session/new (placeholder
                             // id) or session/resume·load (target id) owns
                             // this bind — the user may have switched away
                             // while it resolved, so rebind by the awaiting
                             // id, not by which tab happens to be live.
-                            if self.session_id == awaiting {
+                            if !awaiting.open {
+                                // The requesting tab was closed (/close)
+                                // before the bind resolved. acp already
+                                // registered the new session server-side, so
+                                // forget it and never hijack the viewed tab.
+                                ctl.send(Cmd::ForgetSession {
+                                    session_id: session_id.clone(),
+                                });
+                                self.show_tip(format!(
+                                    "session {session_id} bound after its tab was closed"
+                                ));
+                            } else if self.session_id == awaiting.id {
                                 self.session_id = session_id.clone();
                                 self.transcript.set_root_session(session_id.clone());
                                 self.session_bound = true;
@@ -3226,7 +3492,7 @@ impl App {
                                 }
                                 just_bound = Some(self.session_id.clone());
                             } else if let Some(slot) =
-                                self.parked.iter_mut().find(|slot| slot.id == awaiting)
+                                self.parked.iter_mut().find(|slot| slot.id == awaiting.id)
                             {
                                 slot.id = session_id.clone();
                                 slot.transcript.set_root_session(session_id.clone());
@@ -3251,6 +3517,7 @@ impl App {
                             just_bound = Some(slot.id.clone());
                         } else {
                             // Startup / reconnect: rebind the viewed session.
+                            self.startup_bound = true;
                             if self.session_id != session_id {
                                 self.reset_subagent_views();
                             }
@@ -3292,9 +3559,22 @@ impl App {
                 self.open_elicitation_ask(session_id.as_deref(), form, reply);
             }
             AppEvent::ShellDone { id, code, output } => {
-                if let Some(pos) = self.shell_pending.iter().position(|(sid, _)| *sid == id) {
-                    let (_, cell) = self.shell_pending.remove(pos);
-                    self.transcript.finish_shell(cell, code, output);
+                if let Some(pos) = self
+                    .shell_pending
+                    .iter()
+                    .position(|(sid, _, _)| *sid == id)
+                {
+                    let (_, session, cell) = self.shell_pending.remove(pos);
+                    // The shell is workspace-wide but its cell lives in the
+                    // transcript of the session that ran it — the user may
+                    // have switched tabs while the command ran.
+                    if session == self.session_id {
+                        self.transcript.finish_shell(cell, code, output);
+                    } else if let Some(slot) =
+                        self.parked.iter_mut().find(|slot| slot.id == session)
+                    {
+                        slot.transcript.finish_shell(cell, code, output);
+                    }
                     self.needs_redraw = true;
                 }
                 // `!git checkout …` in the session shell moves the branch —
@@ -3321,14 +3601,23 @@ impl App {
                 // A parked session's subagent tree: register the child in
                 // its slot and fold the event into the slot's transcripts.
                 for slot in &mut self.parked {
-                    if slot.id == *parent {
+                    if slot.id == *parent || slot.subagents.iter().any(|v| v.id == *parent) {
+                        // A fresh turn starts a new batch, exactly like the
+                        // live path below — background sessions must keep
+                        // their current/history grouping current.
+                        if slot.next_subagent_starts_batch {
+                            slot.current_subagents.clear();
+                            slot.next_subagent_starts_batch = false;
+                        }
+                        slot.current_subagents.insert(child.clone());
                         upsert_subagent_view(&mut slot.subagents, parent, child);
-                        slot.transcript.apply(ui);
-                        self.needs_redraw = true;
-                        return;
-                    }
-                    if let Some(view) = slot.subagents.iter_mut().find(|view| view.id == *parent) {
-                        view.transcript.apply(ui);
+                        if slot.id == *parent {
+                            slot.transcript.apply(ui);
+                        } else if let Some(view) =
+                            slot.subagents.iter_mut().find(|view| view.id == *parent)
+                        {
+                            view.transcript.apply(ui);
+                        }
                         self.needs_redraw = true;
                         return;
                     }
@@ -3366,6 +3655,13 @@ impl App {
                             slot.subagents.iter_mut().find(|view| view.id == parent)
                         {
                             pview.transcript.apply(ui);
+                        }
+                        // Issue #80 parity: a parked session's rail also
+                        // auto-closes once every subagent task has ended.
+                        if slot.agent_selection.is_some()
+                            && !slot.subagents.iter().any(|view| view.running || view.failed)
+                        {
+                            slot.agent_selection = None;
                         }
                         self.needs_redraw = true;
                         return;
@@ -3585,22 +3881,7 @@ impl App {
                 self.needs_redraw = true;
                 // Session tab strip (issue #94): left-click a tab switches.
                 if let Some(tab) = self.tab_at(mouse.column, mouse.row) {
-                    self.sel = None;
-                    self.selecting = false;
-                    self.last_click = None;
-                    self.input_sel = None;
-                    self.input_selecting = false;
-                    if tab != self.current {
-                        // Compositor-owned modals (plugin view/select/
-                        // slider, e.g. live /status) cannot ride along to
-                        // another tab: leaving cancels them exactly like
-                        // Esc so the plugin releases its single-overlay
-                        // slot. Painter popups (/help, /keys, /session,
-                        // painter /status) park with the session inside
-                        // `switch_to_session`.
-                        self.cancel_plugin_overlays(ctl);
-                    }
-                    self.switch_to_session(tab);
+                    self.switch_view_to_tab(tab, ctl);
                     return;
                 }
                 if let Some(action) = self
@@ -4816,6 +5097,13 @@ impl App {
             Action::ModelPicker => self.open_model_picker(ctl),
             Action::CycleAgent => self.cycle_agent(ctl),
             Action::CyclePermission => self.cycle_permission(ctl),
+            Action::SessionTab(n) => {
+                // alt+1…9: jump to session tab N (no-op beyond the strip).
+                let tab = n.saturating_sub(1) as usize;
+                if tab <= self.parked.len() {
+                    self.switch_view_to_tab(tab, ctl);
+                }
+            }
             Action::HistoryPrev => self.history_prev(),
             Action::HistoryNext => self.history_next(),
             Action::ScrollHalfUp => self.scroll_by(10),
@@ -5617,9 +5905,92 @@ impl App {
             // real id lands on this tab via `awaiting_binds` at SessionBound.
             let placeholder = format!("dsh-{}", timestamp());
             self.open_new_session(placeholder.clone(), false);
-            self.awaiting_binds.push_back(placeholder);
+            self.awaiting_binds.push_back(AwaitingBind {
+                id: placeholder,
+                open: true,
+            });
             ctl.send(Cmd::NewSession);
             self.show_tip("session/new …");
+        }
+    }
+
+    /// The `/close` flow (issue #94): stop viewing the current session tab
+    /// and drop everything bound to it (transcript, composer draft, queue,
+    /// asks, subagents). Local only — ACP has no session/close, so the
+    /// server-side session keeps existing; acp.rs forgets its turn state
+    /// and queued prompts so nothing more is sent into the void, and the
+    /// session's later updates drop at the router. An in-flight turn keeps
+    /// running and is dropped when it settles. Never closes the last tab.
+    fn close_session_flow(&mut self, ctl: &Controller) {
+        let total = self.session_tab_count();
+        if total < 2 {
+            self.show_tip(self.locale.tr(
+                "cannot close the last session — /new opens another first",
+                "不能关闭最后一个会话 —— 先用 /new 开一个新的",
+            ));
+            return;
+        }
+        let doomed = self.session_id.clone();
+        let running = self.state != RunState::Idle || self.prompt_pending;
+        // Compositor-owned overlays (plugin view/select/slider) must be
+        // released with a cancel event before the tab dies — the same path
+        // a tab click takes. Painter popups, asks and the composer draft
+        // die with the slot (ask overlays auto-cancel through Drop).
+        self.cancel_plugin_overlays(ctl);
+        let doomed_slot = self.take_live_slot();
+        let discarded = doomed_slot.prompt_queue.len();
+        let had_draft = !doomed_slot.input.is_empty()
+            || !doomed_slot.pending_images.is_empty();
+        let had_ask =
+            doomed_slot.permission_ask.is_some() || doomed_slot.elicitation_ask.is_some();
+        drop(doomed_slot);
+
+        // The bind this tab may still be awaiting keeps its FIFO position
+        // (the in-flight session/new·resume owns it) but is now dead: when
+        // it resolves the session is forgotten, never bound onto a
+        // neighboring tab.
+        if let Some(entry) = self.awaiting_binds.iter_mut().find(|entry| entry.id == doomed) {
+            entry.open = false;
+        }
+        // Forget the session on the ACP side too: drop its turn state and
+        // queued prompts (no-op for an unbound placeholder id).
+        ctl.send(Cmd::ForgetSession {
+            session_id: doomed.clone(),
+        });
+
+        // View a neighbor first, keeping the closed tab's conceptual slot:
+        // the right neighbor when one exists, else the tab on the left.
+        let right = self.current + 1 < total;
+        let pidx = if right { self.current } else { self.current - 1 };
+        let mut target = self.parked.remove(pidx);
+        target.completed_unseen = false;
+        self.current = if right {
+            self.current
+        } else {
+            self.current.saturating_sub(1)
+        };
+        self.put_live_slot(target);
+        self.after_switch();
+        self.needs_redraw = true;
+
+        let label = short_id(&doomed);
+        let mut bits: Vec<String> = Vec::new();
+        if running {
+            bits.push("its running turn keeps settling".into());
+        }
+        if discarded > 0 {
+            bits.push(format!("{discarded} queued dropped"));
+        }
+        if had_draft {
+            bits.push("draft dropped".into());
+        }
+        if had_ask {
+            bits.push("pending ask cancelled".into());
+        }
+        if bits.is_empty() {
+            self.show_tip(format!("closed {label}"));
+        } else {
+            self.show_tip(format!("closed {label} · {}", bits.join(", ")));
         }
     }
 
@@ -5658,7 +6029,9 @@ impl App {
         // any path that (re)loads real history must dismiss it — the local
         // `resume_session` does the same. Without this, a /resume before the
         // first prompt left the banner covering the whole replayed chat.
-        self.show_banner = false;
+        // Dismissed *after* the branch: a fresh tab starts with the banner
+        // (composer chrome is tab-bound), and the same-session branch resets
+        // its own fields.
         if self.session_id == id {
             // Resuming the viewed session: reset its UI and re-stream.
             self.reset_session_ui();
@@ -5674,8 +6047,12 @@ impl App {
             // transcript; the legacy `session/load` fallback streams it via
             // session/update tagged with this id.
             self.open_new_session(id.to_string(), false);
-            self.awaiting_binds.push_back(id.to_string());
+            self.awaiting_binds.push_back(AwaitingBind {
+                id: id.to_string(),
+                open: true,
+            });
         }
+        self.show_banner = false;
         ctl.send(Cmd::ResumeSession {
             session_id: id.to_string(),
         });
@@ -6316,6 +6693,7 @@ impl App {
                 }
             }
             "new" => self.new_session_flow(arg, ctl),
+            "close" => self.close_session_flow(ctl),
             "session" => self.push_session_info(),
             "status" => self.push_status_info(),
             "auth" => self.start_auth(arg, ctl),
@@ -6380,6 +6758,7 @@ impl App {
                     };
                     if let Some(value) = value {
                         ctl.send(Cmd::SetConfigOption {
+                            session_id: self.session_id.clone(),
                             config_id: action.config_id,
                             value,
                         });
@@ -7010,6 +7389,13 @@ impl App {
             self.show_tip("queue paused · finish or close the queue editor");
             return;
         }
+        if !self.session_bound {
+            // The tab still awaits (or lost) its session bind: an unbound
+            // id would be rejected by acp, and every rejection error would
+            // re-enter this function and burn the whole queue. The prompt
+            // stays queued for the SessionBound handler (issue #94).
+            return;
+        }
         let Some(prompt) = self.prompt_queue.pop_front() else {
             return;
         };
@@ -7506,7 +7892,9 @@ impl App {
         self.shell_seq += 1;
         let id = self.shell_seq;
         let cell = self.transcript.push_shell(cmd.clone());
-        self.shell_pending.push((id, cell));
+        // Tag the pending cell with its session: the worker is shared and
+        // the user may switch tabs before the command settles.
+        self.shell_pending.push((id, self.session_id.clone(), cell));
         let request = ShellRequest { id, command: cmd };
         let worker = self.shell_worker.get_or_insert_with(|| {
             ShellWorker::spawn(self.cfg.workspace.clone(), self.bus_tx.clone())

--- a/src/app.rs
+++ b/src/app.rs
@@ -700,6 +700,12 @@ pub struct Picker {
     pub title: String,
     pub sel: usize,
     pub items: Vec<PickerItem>,
+    /// First row of the popup's viewport. Unlike `sel` (which keys and the
+    /// wheel move freely), the window only scrolls when the selection
+    /// leaves it — the draw pass adjusts this by the minimum needed, so a
+    /// static window lets ↑/↓ and wheel sweep the highlight row by row
+    /// instead of re-pinning the window edge under it every frame.
+    pub offset: usize,
 }
 
 /// The `/plugins` static inventory as a two-level tree (provider → plugin),
@@ -2277,6 +2283,7 @@ impl App {
             .position(|item| item.id == self.active_palette_id)
             .unwrap_or(0);
         self.picker = Some(Picker {
+            offset: 0,
             kind: PickerKind::Theme,
             title: self
                 .locale
@@ -2307,6 +2314,7 @@ impl App {
             .position(|plugin| plugin.status == "active")
             .unwrap_or(0);
         self.picker = Some(Picker {
+            offset: 0,
             kind: PickerKind::UiPlugin,
             title: self
                 .locale
@@ -2366,6 +2374,7 @@ impl App {
             })
             .collect();
         self.picker = Some(Picker {
+            offset: 0,
             kind: PickerKind::CordisPlugin,
             title: self
                 .locale
@@ -2381,6 +2390,7 @@ impl App {
 
     fn open_cordis_approval_picker(&mut self, request_id: String) {
         self.picker = Some(Picker {
+            offset: 0,
             kind: PickerKind::CordisApproval,
             title: self
                 .locale
@@ -3941,10 +3951,14 @@ impl App {
             MouseEventKind::ScrollUp => {
                 if self.elicitation_ask.is_some() {
                     self.elicitation_scroll_by(-3);
+                } else if self.permission_ask.is_some() {
+                    self.permission_ask_scroll_by(-1);
                 } else if let Some(tree) = &mut self.plugin_tree {
                     tree.state.scroll_up(3);
                 } else if self.view_overlay.is_some() {
                     self.view_scroll_by(-3);
+                } else if self.picker.is_some() {
+                    self.picker_scroll_by(-1);
                 } else {
                     self.mouse_scroll(3, mouse.column, mouse.row);
                 }
@@ -3952,10 +3966,14 @@ impl App {
             MouseEventKind::ScrollDown => {
                 if self.elicitation_ask.is_some() {
                     self.elicitation_scroll_by(3);
+                } else if self.permission_ask.is_some() {
+                    self.permission_ask_scroll_by(1);
                 } else if let Some(tree) = &mut self.plugin_tree {
                     tree.state.scroll_down(3);
                 } else if self.view_overlay.is_some() {
                     self.view_scroll_by(3);
+                } else if self.picker.is_some() {
+                    self.picker_scroll_by(1);
                 } else {
                     self.mouse_scroll(-3, mouse.column, mouse.row);
                 }
@@ -4266,6 +4284,44 @@ impl App {
             }
             self.needs_redraw = true;
         }
+    }
+
+    /// Wheel-scroll the open picker — the `/resume` session list, `/model`,
+    /// `/mode`, … One notch moves the selection exactly like one ↑/↓ press
+    /// (the highlight sweeps through a static window; the window itself only
+    /// scrolls once the selection leaves it — see `draw_model_picker`).
+    /// Steps clamp at both ends; only the arrows wrap, so an overscrolled
+    /// notch never teleports the highlight to the list tail.
+    fn picker_scroll_by(&mut self, delta: i64) {
+        let Some(picker) = &mut self.picker else { return };
+        let last = picker.items.len().saturating_sub(1);
+        if delta < 0 {
+            picker.sel = picker
+                .sel
+                .saturating_sub(delta.unsigned_abs() as usize)
+                .min(last);
+        } else {
+            picker.sel = picker.sel.saturating_add(delta as usize).min(last);
+        }
+        self.needs_redraw = true;
+    }
+
+    /// Wheel over an ACP permission ask (which floats above host pickers)
+    /// moves its highlight, mirroring the ↑/↓ keys and the modal priority
+    /// of `handle_key` — an ask on top of the `/resume` picker must not
+    /// scroll the picker underneath it.
+    fn permission_ask_scroll_by(&mut self, delta: i64) {
+        let Some(ask) = &mut self.permission_ask else { return };
+        let last = ask.options.len().saturating_sub(1);
+        if delta < 0 {
+            ask.sel = ask
+                .sel
+                .saturating_sub(delta.unsigned_abs() as usize)
+                .min(last);
+        } else {
+            ask.sel = ask.sel.saturating_add(delta as usize).min(last);
+        }
+        self.needs_redraw = true;
     }
 
     /// Toggle a tool between its collapsed viewport and full expansion.
@@ -5733,6 +5789,7 @@ impl App {
             return;
         }
         self.picker = Some(Picker {
+            offset: 0,
             kind: PickerKind::AgentHistory,
             title: "Agent history".into(),
             sel: 0,
@@ -5771,6 +5828,7 @@ impl App {
             .position(|i| i.id == self.cfg.model)
             .unwrap_or(0);
         self.picker = Some(Picker {
+            offset: 0,
             kind: PickerKind::Model,
             title: self
                 .locale
@@ -5813,6 +5871,7 @@ impl App {
                 .collect();
         }
         self.picker = Some(Picker {
+            offset: 0,
             kind: PickerKind::Effort,
             title: self
                 .locale
@@ -5861,6 +5920,7 @@ impl App {
             .collect();
         self.resume_candidates = sessions;
         self.picker = Some(Picker {
+            offset: 0,
             kind: PickerKind::Session,
             title: self
                 .locale
@@ -6224,6 +6284,7 @@ impl App {
             .collect();
         self.resume_via_acp = true;
         self.picker = Some(Picker {
+            offset: 0,
             kind: PickerKind::Session,
             title: self
                 .locale
@@ -6291,6 +6352,7 @@ impl App {
         let current = self.current_mode();
         let sel = items.iter().position(|i| i.id == current).unwrap_or(0);
         self.picker = Some(Picker {
+            offset: 0,
             kind: PickerKind::Mode,
             title: self
                 .locale
@@ -6500,6 +6562,7 @@ impl App {
         };
         let sel = items.iter().position(|i| i.id == current).unwrap_or(0);
         self.picker = Some(Picker {
+            offset: 0,
             kind: PickerKind::Permission,
             title: self
                 .locale
@@ -6942,6 +7005,7 @@ impl App {
             .and_then(|id| items.iter().position(|item| item.id == *id))
             .unwrap_or(0);
         self.picker = Some(Picker {
+            offset: 0,
             kind: PickerKind::Auth,
             title: self
                 .locale

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -118,6 +118,14 @@ pub enum CtlEvent {
         efforts: Vec<String>,
         default: Option<String>,
     },
+    /// A command failed for one specific session (prompt, steer, config
+    /// select, …). The UI routes the notice into that session's own
+    /// transcript — parked sessions no longer spill their errors onto the
+    /// viewed tab.
+    SessionError {
+        session_id: String,
+        message: String,
+    },
     /// A client-side control call succeeded.
     TuiOpDone(String),
     /// A client-side control call failed (or is unsupported on this transport).
@@ -137,6 +145,12 @@ pub enum CtlEvent {
         session_id: String,
         notice: Option<String>,
     },
+    /// A `session/new` or `session/resume` request failed outright (not an
+    /// auth stall — auth keeps the request parked). acp completes bind
+    /// requests in order, so the awaiting-bind FIFO head owns the failure;
+    /// the UI drops that entry instead of letting a later bind land on a
+    /// dead request (issue #94 bind poisoning).
+    BindFailed,
     /// `session/list` rows (`prefix` is the `/resume` argument, if any).
     SessionList {
         sessions: Vec<SessionListItem>,
@@ -393,6 +407,7 @@ pub enum Cmd {
     /// Agent-advertised command action (`_meta.commandAction`) mapped onto
     /// standard ACP `session/set_config_option`.
     SetConfigOption {
+        session_id: String,
         config_id: String,
         value: String,
     },
@@ -410,6 +425,13 @@ pub enum Cmd {
     },
     /// Live ACP `/resume` pick → `session/resume`, with legacy `session/load` fallback.
     ResumeSession {
+        session_id: String,
+    },
+    /// `/close`: this client stops viewing a session. ACP has no
+    /// session/close, so the server-side session survives; the controller
+    /// drops the session's turn state and queued prompts so nothing more is
+    /// sent into the void, and its later events settle at the router.
+    ForgetSession {
         session_id: String,
     },
     Shutdown,

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -108,11 +108,15 @@ pub enum CtlEvent {
     CordisPlugins { plugins: Vec<CordisPluginItem> },
     /// ACP session modes (permission / `session/set_mode`).
     SessionModes {
+        session_id: Option<String>,
         modes: Vec<CatalogPreset>,
         current: Option<String>,
     },
     /// The agent accepted a composition switch (`session/set_config_option`).
-    PresetSet { preset: String },
+    PresetSet {
+        session_id: String,
+        preset: String,
+    },
     /// Selectable reasoning efforts for the current model.
     Efforts {
         efforts: Vec<String>,

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -596,6 +596,10 @@ fn controller_loop(
                         .into(),
                 )));
             }
+            Cmd::ForgetSession { .. } => {
+                // Sessions only exist on the ACP transport; the legacy/demo
+                // controller owns nothing to forget.
+            }
             Cmd::QueueSnapshot { .. } | Cmd::AgentsSnapshot { .. } => {
                 // The legacy/demo controller has no local Cordis compositor.
             }

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -559,7 +559,10 @@ fn controller_loop(
                 });
                 match result {
                     Some(Ok(_)) => {
-                        let _ = bus.send(AppEvent::Ctl(CtlEvent::PresetSet { preset }));
+                        let _ = bus.send(AppEvent::Ctl(CtlEvent::PresetSet {
+                            session_id,
+                            preset,
+                        }));
                     }
                     Some(Err(err)) => {
                         // The host locks the preset once the session's agent

--- a/src/events.rs
+++ b/src/events.rs
@@ -1041,6 +1041,11 @@ fn merge_update(prev: &mut Value, new: &Value) -> MergeOutcome {
     if !same_str(prev_update, new_update, "sessionUpdate") {
         return MergeOutcome::Keep;
     }
+    let prev_subagent = prev_update.pointer("/_meta/dsh/subagent/childSessionId");
+    let new_subagent = new_update.pointer("/_meta/dsh/subagent/childSessionId");
+    if prev_subagent != new_subagent {
+        return MergeOutcome::Keep;
+    }
     let kind = new_update
         .get("sessionUpdate")
         .and_then(Value::as_str)

--- a/src/input/keymap.rs
+++ b/src/input/keymap.rs
@@ -71,6 +71,10 @@ pub enum Action {
     CutSelection,
     /// Jump to session tab `n` (alt+1 … alt+9; 1-based, issue #94).
     SessionTab(u8),
+    /// Cycle to next session tab (alt+] / ctrl+pagedown).
+    NextSessionTab,
+    /// Cycle to previous session tab (alt+[ / ctrl+pageup).
+    PrevSessionTab,
 }
 
 /// The composer facts the mapping depends on (dual-use keys: `home`/`^u`
@@ -156,6 +160,8 @@ pub fn classify(key: &KeyEvent, ctx: KeyCtx) -> Option<Action> {
         KeyCode::Char('f') if alt => WordRight,
 
         // --- scrolling ----------------------------------------------------
+        KeyCode::PageUp if ctrl => PrevSessionTab,
+        KeyCode::PageDown if ctrl => NextSessionTab,
         KeyCode::PageUp => PageUp,
         KeyCode::PageDown => PageDown,
 
@@ -195,6 +201,8 @@ pub fn classify(key: &KeyEvent, ctx: KeyCtx) -> Option<Action> {
         // alt+1…alt+9 jump straight to a session tab (browser-style). Plain
         // digits keep typing; the chord stays readable on legacy terminals.
         KeyCode::Char(ch @ '1'..='9') if alt => SessionTab(ch as u8 - b'0'),
+        KeyCode::Char(']') if alt => NextSessionTab,
+        KeyCode::Char('[') if alt => PrevSessionTab,
 
         // --- deletion ------------------------------------------------------
         // ⌘⌫ kills to line start; ⌥⌫ (macOS) / ctrl+⌫ (linux/windows)
@@ -590,6 +598,32 @@ pub const KEY_ROWS: &[KeyRow] = &[
         desc_en: "page down",
         desc_zh: "下一页",
         probes: &[p(KeyCode::PageDown, NONE, false)],
+    },
+    KeyRow {
+        action: NextSessionTab,
+        group: KeyGroup::Navigate,
+        chords_mac: &["⌥]", "^⇟"],
+        chords_other: &["alt+]", "ctrl+pagedown"],
+        ctx: CtxNote::Always,
+        desc_en: "next session tab",
+        desc_zh: "下一个会话标签",
+        probes: &[
+            p(KeyCode::Char(']'), ALT, false),
+            p(KeyCode::PageDown, CTRL, false),
+        ],
+    },
+    KeyRow {
+        action: PrevSessionTab,
+        group: KeyGroup::Navigate,
+        chords_mac: &["⌥[", "^⇞"],
+        chords_other: &["alt+[", "ctrl+pageup"],
+        ctx: CtxNote::Always,
+        desc_en: "previous session tab",
+        desc_zh: "上一个会话标签",
+        probes: &[
+            p(KeyCode::Char('['), ALT, false),
+            p(KeyCode::PageUp, CTRL, false),
+        ],
     },
     // --- composer textarea -------------------------------------------------
     KeyRow {

--- a/src/input/keymap.rs
+++ b/src/input/keymap.rs
@@ -69,6 +69,8 @@ pub enum Action {
     CopySelection,
     /// Cut the keyboard selection (clipboard + yank + delete).
     CutSelection,
+    /// Jump to session tab `n` (alt+1 … alt+9; 1-based, issue #94).
+    SessionTab(u8),
 }
 
 /// The composer facts the mapping depends on (dual-use keys: `home`/`^u`
@@ -189,6 +191,11 @@ pub fn classify(key: &KeyEvent, ctx: KeyCtx) -> Option<Action> {
         KeyCode::Left => CursorLeft,
         KeyCode::Right => CursorRight,
 
+        // --- session tabs (issue #94) -------------------------------------
+        // alt+1…alt+9 jump straight to a session tab (browser-style). Plain
+        // digits keep typing; the chord stays readable on legacy terminals.
+        KeyCode::Char(ch @ '1'..='9') if alt => SessionTab(ch as u8 - b'0'),
+
         // --- deletion ------------------------------------------------------
         // ⌘⌫ kills to line start; ⌥⌫ (macOS) / ctrl+⌫ (linux/windows)
         // delete a word; ^w works everywhere. Deleting over an inline
@@ -257,6 +264,7 @@ pub enum KeyGroup {
     /// selection, yank) — one dedicated section in `/keys`.
     Composer,
     App,
+    Session,
     Mouse,
 }
 
@@ -271,6 +279,8 @@ impl KeyGroup {
             (KeyGroup::Composer, true) => "输入框 · textarea",
             (KeyGroup::App, false) => "app shortcuts",
             (KeyGroup::App, true) => "应用快捷键",
+            (KeyGroup::Session, false) => "session tabs",
+            (KeyGroup::Session, true) => "会话标签页",
             (KeyGroup::Mouse, false) => "mouse",
             (KeyGroup::Mouse, true) => "鼠标",
         }
@@ -333,6 +343,96 @@ const fn p(code: KeyCode, m: KeyModifiers, empty: bool) -> (KeyCode, KeyModifier
 }
 
 pub const KEY_ROWS: &[KeyRow] = &[
+    KeyRow {
+        action: SessionTab(1),
+        group: KeyGroup::Session,
+        chords_mac: &["⌥1"],
+        chords_other: &["alt+1"],
+        ctx: CtxNote::Always,
+        desc_en: "session tab 1",
+        desc_zh: "会话标签 1",
+        probes: &[p(KeyCode::Char('1'), ALT, false)],
+    },
+    KeyRow {
+        action: SessionTab(2),
+        group: KeyGroup::Session,
+        chords_mac: &["⌥2"],
+        chords_other: &["alt+2"],
+        ctx: CtxNote::Always,
+        desc_en: "session tab 2",
+        desc_zh: "会话标签 2",
+        probes: &[p(KeyCode::Char('2'), ALT, false)],
+    },
+    KeyRow {
+        action: SessionTab(3),
+        group: KeyGroup::Session,
+        chords_mac: &["⌥3"],
+        chords_other: &["alt+3"],
+        ctx: CtxNote::Always,
+        desc_en: "session tab 3",
+        desc_zh: "会话标签 3",
+        probes: &[p(KeyCode::Char('3'), ALT, false)],
+    },
+    KeyRow {
+        action: SessionTab(4),
+        group: KeyGroup::Session,
+        chords_mac: &["⌥4"],
+        chords_other: &["alt+4"],
+        ctx: CtxNote::Always,
+        desc_en: "session tab 4",
+        desc_zh: "会话标签 4",
+        probes: &[p(KeyCode::Char('4'), ALT, false)],
+    },
+    KeyRow {
+        action: SessionTab(5),
+        group: KeyGroup::Session,
+        chords_mac: &["⌥5"],
+        chords_other: &["alt+5"],
+        ctx: CtxNote::Always,
+        desc_en: "session tab 5",
+        desc_zh: "会话标签 5",
+        probes: &[p(KeyCode::Char('5'), ALT, false)],
+    },
+    KeyRow {
+        action: SessionTab(6),
+        group: KeyGroup::Session,
+        chords_mac: &["⌥6"],
+        chords_other: &["alt+6"],
+        ctx: CtxNote::Always,
+        desc_en: "session tab 6",
+        desc_zh: "会话标签 6",
+        probes: &[p(KeyCode::Char('6'), ALT, false)],
+    },
+    KeyRow {
+        action: SessionTab(7),
+        group: KeyGroup::Session,
+        chords_mac: &["⌥7"],
+        chords_other: &["alt+7"],
+        ctx: CtxNote::Always,
+        desc_en: "session tab 7",
+        desc_zh: "会话标签 7",
+        probes: &[p(KeyCode::Char('7'), ALT, false)],
+    },
+    KeyRow {
+        action: SessionTab(8),
+        group: KeyGroup::Session,
+        chords_mac: &["⌥8"],
+        chords_other: &["alt+8"],
+        ctx: CtxNote::Always,
+        desc_en: "session tab 8",
+        desc_zh: "会话标签 8",
+        probes: &[p(KeyCode::Char('8'), ALT, false)],
+    },
+    KeyRow {
+        action: SessionTab(9),
+        group: KeyGroup::Session,
+        chords_mac: &["⌥9"],
+        chords_other: &["alt+9"],
+        ctx: CtxNote::Always,
+        desc_en: "session tab 9",
+        desc_zh: "会话标签 9",
+        probes: &[p(KeyCode::Char('9'), ALT, false)],
+    },
     // --- send · interrupt -------------------------------------------------
     KeyRow {
         action: Enter,
@@ -894,6 +994,11 @@ pub const KEY_ROWS: &[KeyRow] = &[
 ];
 
 pub const MOUSE_ROWS: &[MouseRow] = &[
+    MouseRow {
+        chords: &["click tab"],
+        desc_en: "switch session tab (strip shows 2+ sessions) · /new · /resume · /close",
+        desc_zh: "点击标签页切换会话（≥2 个会话时显示）· /new · /resume · /close",
+    },
     MouseRow {
         chords: &["click"],
         desc_en: "expand/collapse a tool · wheel scrolls",

--- a/src/input/vim.rs
+++ b/src/input/vim.rs
@@ -51,6 +51,11 @@ impl VimState {
         self.mode != VimMode::Off
     }
 
+    /// Clear any half-entered two-key chords (`dd`, `gg`) on mode/tab switches.
+    pub fn reset_pending(&mut self) {
+        self.pending = None;
+    }
+
     /// Handle one key while vim is active. Returns `true` when the key was
     /// consumed (must not reach the app keymap).
     pub fn handle_key(&mut self, key: &KeyEvent, editor: &mut ComposerEditor) -> bool {

--- a/src/sessions.rs
+++ b/src/sessions.rs
@@ -74,7 +74,7 @@ fn session_file(dir: &Path) -> Option<PathBuf> {
 /// foreign files are skipped, never an error.
 pub fn list_sessions(cfg_root: &str, workspace: &str, skip_id: &str) -> Vec<SessionSummary> {
     let slug = workspace_slug(workspace);
-    let mut out: Vec<SessionSummary> = Vec::new();
+    let mut candidate_files: Vec<(PathBuf, SystemTime)> = Vec::new();
     for root in session_roots(cfg_root) {
         // <root>/<slug>/<id>/session.jsonl[.zstd]
         let mut dirs: Vec<PathBuf> = Vec::new();
@@ -86,20 +86,33 @@ pub fn list_sessions(cfg_root: &str, workspace: &str, skip_id: &str) -> Vec<Sess
             dirs.extend(entries.flatten().map(|e| e.path()));
         }
         for dir in dirs {
-            let Some(file) = session_file(&dir) else {
-                continue;
-            };
-            let Some(summary) = summarize(&file) else {
-                continue;
-            };
-            if summary.id == skip_id || out.iter().any(|s| s.id == summary.id) {
+            if dir.file_name().and_then(|n| n.to_str()) == Some(skip_id) {
                 continue;
             }
-            out.push(summary);
+            if let Some(file) = session_file(&dir) {
+                let mtime = std::fs::metadata(&file)
+                    .and_then(|m| m.modified())
+                    .unwrap_or(SystemTime::UNIX_EPOCH);
+                candidate_files.push((file, mtime));
+            }
         }
     }
-    out.sort_by_key(|s| std::cmp::Reverse(s.modified));
-    out.truncate(50);
+    candidate_files.sort_by(|(f1, m1), (f2, m2)| m2.cmp(m1).then_with(|| f1.cmp(f2)));
+    candidate_files.dedup_by(|(f1, _), (f2, _)| f1 == f2);
+
+    let mut out: Vec<SessionSummary> = Vec::new();
+    for (file, _) in candidate_files {
+        let Some(summary) = summarize(&file) else {
+            continue;
+        };
+        if summary.id == skip_id || out.iter().any(|s| s.id == summary.id) {
+            continue;
+        }
+        out.push(summary);
+        if out.len() >= 50 {
+            break;
+        }
+    }
     out
 }
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1011,9 +1011,15 @@ fn draw_session_tabs(f: &mut Frame, app: &mut App, area: Rect) {
     let right = area.right() as usize;
     let mut spans: Vec<Span> = Vec::new();
     let mut x = area.x as usize;
+    let total = tabs.len();
     for (idx, tab) in tabs.iter().enumerate() {
         if idx > 0 {
             if x + 3 > right {
+                let remaining = total - idx;
+                let note = format!(" +{remaining}");
+                if x + note.len() <= right {
+                    spans.push(Span::styled(note, Style::default().fg(theme.caption)));
+                }
                 break;
             }
             spans.push(Span::styled(" │ ", Style::default().fg(theme.border)));
@@ -1045,6 +1051,11 @@ fn draw_session_tabs(f: &mut Frame, app: &mut App, area: Rect) {
         };
         let width = indicator.width() + label.width() + 3;
         if x + width > right {
+            let remaining = total - idx;
+            let note = format!(" +{remaining}");
+            if x + note.len() <= right {
+                spans.push(Span::styled(note, Style::default().fg(theme.caption)));
+            }
             break;
         }
         app.tab_rects.push((

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1004,6 +1004,13 @@ fn draw_right_slot(f: &mut Frame, app: &App, area: Rect) {
 /// whose session has an unanswered ACP ask (permission or elicitation) — the
 /// agent is waiting on that tab. Tab rects include their trailing arrow for
 /// `App::tab_at` mouse hit-testing.
+///
+/// The strip scrolls: only the tabs in its window (`App::tab_strip_offset`)
+/// are drawn. Clicking the window's edge tab in `App::handle_mouse` nudges
+/// the window by one so the neighbor appears, which lets a mouse walk
+/// through every tab; the window is re-anchored here whenever the live tab
+/// leaves it (keyboard jumps, tab closes) and snaps to the head when the
+/// suffix fits on one row.
 fn draw_session_tabs(f: &mut Frame, app: &mut App, area: Rect) {
     const ARROW: &str = "\u{e0b0}";
 
@@ -1025,10 +1032,60 @@ fn draw_session_tabs(f: &mut Frame, app: &mut App, area: Rect) {
     let tabs = app.session_tabs();
     let spinner = app.spinner();
     let right = area.right() as usize;
+    let total = tabs.len();
+    if total == 0 || area.width < 4 {
+        return;
+    }
+    // Per-tab display width: `" {indicator} {label} "` plus the trailing
+    // arrow. Every indicator — Braille spinner included — is one cell, so
+    // the widths only depend on the clamped label.
+    let widths: Vec<usize> = tabs
+        .iter()
+        .map(|tab| crate::transcript::clamp_str(&tab.label, 16).width() + 5)
+        .collect();
+    let avail = right.saturating_sub(area.x as usize);
+
+    // The strip's scroll window. The draw pass owns its normalization so a
+    // stale offset (labels grew, tabs closed) can never draw garbage.
+    let mut start = app.tab_strip_offset.min(total.saturating_sub(1));
+    if widths.iter().sum::<usize>() <= avail {
+        // The whole strip fits on one row: there is nothing to scroll, so
+        // a stale offset (tabs closed since the last walk) snaps to 0.
+        // Note this only fires when *everything* fits — once a walk has
+        // started, a window whose suffix fits but whose head does not
+        // stays where the mouse put it, or the walk could never reveal the
+        // final tab.
+        start = 0;
+    }
+    // Greedy end of the window from `start` — mirrors the render loop's
+    // `x + width > right` cut exactly.
+    let window_end = |start: usize| -> usize {
+        let mut x = area.x as usize;
+        let mut end = start;
+        while end < total && x + widths[end] <= right {
+            x += widths[end];
+            end += 1;
+        }
+        end
+    };
+    let live = app.live_tab_index().min(total - 1);
+    if live < start || live >= window_end(start) {
+        // The live tab left the window (keyboard jump, /close): re-anchor
+        // with the live tab at the right edge and as many predecessors as
+        // fit, so the tab being viewed is always on screen.
+        let mut anchor = live;
+        let mut width = widths[live];
+        while anchor > 0 && width + widths[anchor - 1] <= avail {
+            anchor -= 1;
+            width += widths[anchor];
+        }
+        start = anchor;
+    }
+    app.tab_strip_offset = start;
+
     let mut spans: Vec<Span> = Vec::new();
     let mut x = area.x as usize;
-    let total = tabs.len();
-    for (idx, tab) in tabs.iter().enumerate() {
+    for (idx, tab) in tabs.iter().enumerate().skip(start) {
         let label = crate::transcript::clamp_str(&tab.label, 16);
         let tab_bg = background_for(idx, tab.current);
         let (indicator, indicator_style) = if tab.ask_pending {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -3141,8 +3141,6 @@ fn draw_model_picker(f: &mut Frame, app: &mut App, screen: Rect) {
         .border_style(Style::default().fg(theme.brand))
         .title(Span::styled(title, Style::default().fg(theme.caption)))
         .style(Style::default().bg(theme.panel));
-    // TableState follows the selection into view (the viewport stays pinned
-    // to the ends), matching the old ListView behavior.
     let table = Table::new(
         rows,
         [
@@ -3160,12 +3158,50 @@ fn draw_model_picker(f: &mut Frame, app: &mut App, screen: Rect) {
             .bg(theme.chip_bg)
             .add_modifier(Modifier::BOLD),
     );
-    let mut table_state =
-        TableState::new().with_selected(Some(sel.min(items.len().saturating_sub(1))));
+    // The picker owns its viewport window (`offset`, persisted across
+    // frames): keys and the wheel only move the selection, and this draw
+    // pass scrolls the window by the minimum needed to keep the selection
+    // visible. A selection that stays inside the window therefore leaves
+    // the window alone — ↑/↓ and the wheel sweep the highlight through a
+    // static list, and only scroll the content once the highlight reaches
+    // an edge. Rebuilding the window from the selection every frame (the
+    // ratatui auto-reveal default) would instead re-pin the highlight to
+    // the window edge and slide the whole list on every key press.
+    let viewport_rows = h.saturating_sub(2) as usize;
+    let last = items.len().saturating_sub(1);
+    let sel = sel.min(last);
+    let mut offset = picker.offset;
+    if items.len() > viewport_rows {
+        if sel < offset {
+            // Selection crossed the top edge: pin it to the first row.
+            offset = sel;
+        } else if sel >= offset + viewport_rows {
+            // Selection crossed the bottom edge: pin it to the last row.
+            offset = sel + 1 - viewport_rows;
+        }
+    } else {
+        offset = 0;
+    }
+    let mut table_state = TableState::new()
+        .with_selected(Some(sel))
+        .with_offset(offset);
     f.render_stateful_widget(table, area, &mut table_state);
     if overflow {
         let inner = area.inner(Margin::new(1, 1));
-        let mut sb_state = ScrollbarState::new(item_count).position(table_state.offset());
+        // ratatui's scrollbar treats `content_length - 1` as the bottom of
+        // the track, while the window offset tops out at
+        // `items - visible rows`. Rescale so the thumb really reaches the
+        // bottom at the deepest scroll instead of stalling a third of the
+        // way down the track.
+        let max_offset = items.len().saturating_sub(viewport_rows);
+        let position = if max_offset == 0 {
+            0
+        } else {
+            offset.saturating_mul(items.len().saturating_sub(1)) / max_offset
+        };
+        let mut sb_state = ScrollbarState::new(item_count)
+            .position(position)
+            .viewport_content_length(viewport_rows);
         f.render_stateful_widget(
             Scrollbar::new(ScrollbarOrientation::VerticalRight)
                 .begin_symbol(None)
@@ -3175,14 +3211,17 @@ fn draw_model_picker(f: &mut Frame, app: &mut App, screen: Rect) {
             &mut sb_state,
         );
     }
-    // The viewport is the source of truth for what is visible; selection
-    // moves (mouse later, programmatic now) land back in the picker.
+    // The draw pass is the source of truth for the window: the selection
+    // it actually rendered (clamped to the rows) and the offset ratatui
+    // kept (unchanged when our pre-clamping already satisfied the window
+    // invariants) land back in the picker.
     if let Some(picker) = &mut app.picker {
         if let Some(selected) = table_state.selected() {
             picker.sel = selected;
         }
+        picker.offset = table_state.offset();
         // Page keys jump a screenful: the rows the popup actually shows.
-        app.picker_page_rows = h.saturating_sub(2) as usize;
+        app.picker_page_rows = viewport_rows;
     }
 }
 

--- a/tests/unit/acp__tests.rs
+++ b/tests/unit/acp__tests.rs
@@ -12,10 +12,15 @@ fn session_setup_keeps_current_mode_when_the_mode_catalog_is_empty() {
             "availableModes": []
         }),
         &bus,
+        None,
     );
 
     match events.try_recv() {
-        Ok(AppEvent::Ctl(CtlEvent::SessionModes { modes, current })) => {
+        Ok(AppEvent::Ctl(CtlEvent::SessionModes {
+            modes,
+            current,
+            ..
+        })) => {
             assert!(modes.is_empty());
             assert_eq!(current.as_deref(), Some("danger-full-access"));
         }

--- a/tests/unit/acp__tests.rs
+++ b/tests/unit/acp__tests.rs
@@ -149,10 +149,10 @@ fn prompt_response_usage_reaches_the_ui() {
     let finish = PromptFinish {
         session_id: "s".into(),
         result: Ok(response),
-        parked_on_auth: ParkedPrompt::Text("hello".into()),
+        payload: ParkedPromptKind::Text("hello".into()),
     };
     let (tx, rx) = std::sync::mpsc::channel();
-    let mut parked = Some(ParkedPrompt::Text("hello".into()));
+    let mut parked = VecDeque::new();
 
     apply_prompt_finish(finish, &mut parked, &tx, &[], None);
 
@@ -183,10 +183,10 @@ fn prompt_error_ends_the_ui_turn_before_reporting_the_error() {
     let finish = PromptFinish {
         session_id: "s".into(),
         result: Err(AcpError::new(-32603, "boom")),
-        parked_on_auth: ParkedPrompt::Text("hello".into()),
+        payload: ParkedPromptKind::Text("hello".into()),
     };
     let (tx, rx) = std::sync::mpsc::channel();
-    let mut parked = None;
+    let mut parked = VecDeque::new();
 
     apply_prompt_finish(finish, &mut parked, &tx, &[], None);
 
@@ -197,7 +197,8 @@ fn prompt_error_ends_the_ui_turn_before_reporting_the_error() {
     ));
     assert!(matches!(
         rx.try_recv(),
-        Ok(AppEvent::Ctl(CtlEvent::Error(_)))
+        Ok(AppEvent::Ctl(CtlEvent::SessionError { session_id, .. }))
+            if session_id == "s"
     ));
 }
 
@@ -1118,6 +1119,7 @@ async fn set_config_option_response_updates_client_state_without_a_notification(
     }
     cmd_tx
         .send(Cmd::SetConfigOption {
+            session_id: String::new(), // legacy: address the fallback session
             config_id: "collaboration_mode".into(),
             value: "plan".into(),
         })
@@ -3086,15 +3088,20 @@ async fn prompt_for_an_unbound_session_is_rejected_not_rerouted() {
     let mut rejection = None;
     while Instant::now() < deadline && rejection.is_none() {
         match bus_rx.recv_timeout(Duration::from_millis(20)) {
-            Ok(AppEvent::Ctl(CtlEvent::Error(err))) if err.contains("unknown session") => {
-                rejection = Some(err);
+            Ok(AppEvent::Ctl(CtlEvent::SessionError { session_id, message }))
+                if message.contains("unknown session") =>
+            {
+                rejection = Some((session_id, message));
             }
             Ok(_) => {}
             Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {}
             Err(err) => panic!("{err}"),
         }
     }
-    assert_eq!(rejection.as_deref(), Some("prompt: unknown session ghost"));
+    assert_eq!(
+        rejection,
+        Some(("ghost".to_string(), "prompt: unknown session ghost".to_string()))
+    );
     assert!(
         tokio::time::timeout(Duration::from_millis(200), prompt_rx.recv())
             .await

--- a/tests/unit/app__mode_tests.rs
+++ b/tests/unit/app__mode_tests.rs
@@ -3502,7 +3502,7 @@ fn advertised_plan_command_toggles_off_when_plan_is_active() {
 
     assert!(matches!(
         commands.recv_timeout(std::time::Duration::from_secs(1)),
-        Ok(Cmd::SetConfigOption { config_id, value })
+        Ok(Cmd::SetConfigOption { config_id, value, .. })
             if config_id == "collaboration_mode" && value == "default"
     ));
 }

--- a/tests/unit/app__mode_tests.rs
+++ b/tests/unit/app__mode_tests.rs
@@ -1159,6 +1159,7 @@ fn preset_ack_folds_the_chip_and_new_session_waits_for_the_host_mode() {
     let (mut app, ctl, _rx) = test_app();
     app.handle(
         AppEvent::Ctl(CtlEvent::PresetSet {
+            session_id: String::new(),
             preset: "cordis".into(),
         }),
         &ctl,

--- a/tests/unit/app__resume_tests.rs
+++ b/tests/unit/app__resume_tests.rs
@@ -237,6 +237,7 @@ fn picker_page_keys_jump_a_screenful_and_home_end_pin_the_ends() {
     let root = tmp_root("page");
     let (mut app, ctl) = test_app_with_root(root.to_str().unwrap(), "/w");
     app.picker = Some(Picker {
+        offset: 0,
         kind: PickerKind::Session,
         title: " resume session · 40 sessions · enter select · esc close ".into(),
         sel: 0,
@@ -279,6 +280,62 @@ fn picker_page_keys_jump_a_screenful_and_home_end_pin_the_ends() {
 }
 
 #[test]
+fn resume_picker_wheel_walks_the_selection_and_clamps_at_the_ends() {
+    let root = tmp_root("wheel");
+    let (mut app, ctl) = test_app_with_root(root.to_str().unwrap(), "/w");
+    app.picker = Some(Picker {
+        offset: 0,
+        kind: PickerKind::Session,
+        title: " resume session · 8 sessions · enter select · esc close ".into(),
+        sel: 0,
+        items: (0..8)
+            .map(|i| PickerItem {
+                id: format!("s{i:02}"),
+                label: format!("session {i:02}"),
+                meta: String::new(),
+                provider: None,
+            })
+            .collect(),
+    });
+    let wheel = |app: &mut App, kind: MouseEventKind| {
+        app.handle_mouse(
+            MouseEvent {
+                kind,
+                column: 40,
+                row: 10,
+                modifiers: KeyModifiers::NONE,
+            },
+            &ctl,
+        );
+    };
+
+    wheel(&mut app, MouseEventKind::ScrollDown);
+    assert_eq!(app.picker.as_ref().unwrap().sel, 1, "one notch = one row");
+    wheel(&mut app, MouseEventKind::ScrollDown);
+    assert_eq!(app.picker.as_ref().unwrap().sel, 2, "wheel down again");
+    wheel(&mut app, MouseEventKind::ScrollDown);
+    wheel(&mut app, MouseEventKind::ScrollDown);
+    wheel(&mut app, MouseEventKind::ScrollDown);
+    wheel(&mut app, MouseEventKind::ScrollDown);
+    wheel(&mut app, MouseEventKind::ScrollDown);
+    assert_eq!(
+        app.picker.as_ref().unwrap().sel,
+        7,
+        "clamps at the last row (8 items)"
+    );
+    wheel(&mut app, MouseEventKind::ScrollUp);
+    assert_eq!(app.picker.as_ref().unwrap().sel, 6, "wheel up walks back");
+    app.picker.as_mut().unwrap().sel = 0;
+    wheel(&mut app, MouseEventKind::ScrollUp);
+    assert_eq!(
+        app.picker.as_ref().unwrap().sel,
+        0,
+        "overscroll clamps at the first row — no wrap"
+    );
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+#[test]
 fn acp_resume_dismisses_the_welcome_banner_before_the_replay_streams() {
     let root = tmp_root("banner");
     let (mut app, ctl) = test_app_with_root(root.to_str().unwrap(), "/w");
@@ -296,5 +353,171 @@ fn acp_resume_dismisses_the_welcome_banner_before_the_replay_streams() {
         "ACP resume hides the banner so the loaded transcript paints"
     );
     assert_eq!(app.session_id, "acp-old", "switched to the loaded session");
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+#[test]
+fn picker_wheel_and_keys_share_a_stable_window() {
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseEvent, MouseEventKind};
+    let root = tmp_root("window");
+    let (mut app, ctl) = test_app_with_root(root.to_str().unwrap(), "/w");
+    app.picker = Some(Picker {
+        kind: PickerKind::Session,
+        title: " resume session · 40 sessions · enter select · esc close ".into(),
+        sel: 0,
+        offset: 0,
+         items: (0..40)
+            .map(|i| PickerItem {
+                id: format!("sess-{i:02}"),
+                label: format!("session {i:02}"),
+                meta: format!("meta {i:02}"),
+                provider: None,
+            })
+            .collect(),
+    });
+    // 24-row terminal: 20 visible rows (the draw records the viewport).
+    let draw = |app: &mut App| {
+        crate::ui::dump_frame(app, 100, 24);
+    };
+    let wheel = |app: &mut App, kind: MouseEventKind| {
+        app.handle_mouse(
+            MouseEvent { kind, column: 60, row: 12, modifiers: KeyModifiers::NONE },
+            &ctl,
+        );
+    };
+    let key = |app: &mut App, code: KeyCode| {
+        app.handle_key(KeyEvent::new(code, KeyModifiers::NONE), &ctl);
+    };
+    let sel = |app: &App| app.picker.as_ref().unwrap().sel;
+    let offset = |app: &App| app.picker.as_ref().unwrap().offset;
+
+    draw(&mut app);
+    assert_eq!(offset(&app), 0, "fresh picker starts at the head");
+
+    // The wheel sweeps the highlight through a static window row by row.
+    for _ in 0..19 {
+        wheel(&mut app, MouseEventKind::ScrollDown);
+    }
+    draw(&mut app);
+    assert_eq!(sel(&app), 19, "wheel walks one row per notch");
+    assert_eq!(offset(&app), 0, "window static while the highlight is inside it");
+
+    // Crossing the bottom edge scrolls the window by the deficit only.
+    wheel(&mut app, MouseEventKind::ScrollDown);
+    draw(&mut app);
+    assert_eq!(sel(&app), 20, "first row past the window edge");
+    assert_eq!(offset(&app), 1, "window scrolls exactly one row");
+    assert_eq!(app.picker_page_rows, 20, "page size unchanged");
+
+    // Keys after wheel moves keep the window: ↑ walks the highlight up
+    // inside the static window instead of re-pinning it to the edge and
+    // sliding the whole list (the old jump).
+    key(&mut app, KeyCode::Up);
+    draw(&mut app);
+    assert_eq!(sel(&app), 19, "↑ moves the selection");
+    assert_eq!(offset(&app), 1, "window does not move while 19 stays visible");
+
+    // Same at the tail: End parks the window at the bottom; ↑ walks the
+    // highlight through it without scrolling the content.
+    key(&mut app, KeyCode::End);
+    draw(&mut app);
+    assert_eq!(sel(&app), 39, "end pins the tail");
+    assert_eq!(offset(&app), 20, "window parked at the deepest scroll");
+    // 19 ↑ presses with a draw after each: the highlight walks from the
+    // tail to the window's first row (20) while the window never moves —
+    // the old code slid the whole window down on every single press.
+    for _ in 0..19 {
+        key(&mut app, KeyCode::Up);
+        draw(&mut app);
+    }
+    assert_eq!(sel(&app), 20, "walked up to the window's first row");
+    assert_eq!(offset(&app), 20, "window parked the whole walk");
+
+    // The next press leaves the window through the top: the window pins
+    // the selection to its new first row.
+    key(&mut app, KeyCode::Up);
+    draw(&mut app);
+    assert_eq!(sel(&app), 19, "left the window through the top");
+    assert_eq!(offset(&app), 19, "window pinned the selection to the first row");
+
+    key(&mut app, KeyCode::Home);
+    draw(&mut app);
+    assert_eq!(sel(&app), 0, "home pins the head");
+    assert_eq!(offset(&app), 0, "window back at the top");
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+#[test]
+fn picker_scrollbar_thumb_reaches_both_ends_of_the_track() {
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+    let root = tmp_root("thumb");
+    let (mut app, ctl) = test_app_with_root(root.to_str().unwrap(), "/w");
+    app.picker = Some(Picker {
+        kind: PickerKind::Session,
+        title: " resume session · 40 sessions · enter select · esc close ".into(),
+        sel: 0,
+        offset: 0,
+         items: (0..40)
+            .map(|i| PickerItem {
+                id: format!("sess-{i:02}"),
+                label: format!("session {i:02}"),
+                meta: format!("meta {i:02}"),
+                provider: None,
+            })
+            .collect(),
+    });
+    // Row 0 carries the popup title; body rows 1..20 are the table rows
+    // with the scrollbar in the column left of the right border. The
+    // composer text overlapping the popup's lower rows ends in other
+    // glyphs, so read the exact scrollbar cell by column.
+    let thumb_rows = |app: &mut App| -> Vec<u16> {
+        let frame = crate::ui::dump_frame(app, 100, 24);
+        let lines: Vec<&str> = frame.lines().collect();
+        let border = lines[0]
+            .chars()
+            .position(|c| c == '╮')
+            .expect("popup right border");
+        let mut rows = Vec::new();
+        for (i, line) in lines.iter().enumerate().skip(1).take(20) {
+            if line.chars().nth(border - 1) == Some('█') {
+                rows.push(i as u16);
+            }
+        }
+        rows
+    };
+
+    let at_top = thumb_rows(&mut app);
+    assert!(!at_top.is_empty(), "thumb rendered at the head");
+    assert_eq!(*at_top.first().unwrap(), 1, "thumb starts on the first body row");
+    assert!(
+        !at_top.contains(&20),
+        "thumb does not touch the track bottom at the head: {at_top:?}"
+    );
+
+    // End: the thumb must travel all the way to the bottom of the track —
+    // the old code scaled it against the full item count and left it a
+    // third of the way down at the deepest scroll.
+    app.handle_key(KeyEvent::new(KeyCode::End, KeyModifiers::NONE), &ctl);
+    let at_bottom = thumb_rows(&mut app);
+    assert!(!at_bottom.is_empty(), "thumb rendered at the tail");
+    assert!(
+        at_bottom.contains(&20),
+        "thumb reaches the last body row at the deepest scroll: {at_bottom:?}"
+    );
+    assert!(
+        !at_bottom.contains(&1),
+        "thumb left the track top at the deepest scroll: {at_bottom:?}"
+    );
+
+    // Mid-list the thumb sits between the two ends, not pinned to the top:
+    // offset 11 of 20 rescales to the middle of the 39-step track.
+    let p = app.picker.as_mut().unwrap();
+    p.sel = 30;
+    p.offset = 0;
+    let mid = thumb_rows(&mut app);
+    assert!(
+        !mid.contains(&1) && !mid.contains(&20),
+        "thumb mid-track: {mid:?}"
+    );
     let _ = std::fs::remove_dir_all(&root);
 }

--- a/tests/unit/app__session_tabs_tests.rs
+++ b/tests/unit/app__session_tabs_tests.rs
@@ -1221,13 +1221,153 @@ fn next_and_prev_session_tab_cycles_tabs() {
 
 #[test]
 fn tab_strip_renders_overflow_indicator_when_narrow() {
-    let (mut app, _ctl, _rx) = test_app();
+    let (mut app, ctl, _rx) = test_app();
     app.open_new_session("s-two".into(), true);
     app.open_new_session("s-three".into(), true);
     app.open_new_session("s-four".into(), true);
 
-    // On width 30, not all tabs fit; +N indicator should render
+    // On width 30, not all tabs fit. The live session is the newest one
+    // (s-four), so the window parks at the tail without an indicator —
+    // everything from the window to the end fits.
+    let frame = crate::ui::dump_frame(&mut app, 30, 15);
+    let row0 = frame.lines().next().unwrap_or_default();
+    assert!(row0.contains("s-four"), "live tab on screen:\n{row0}");
+
+    // Jumping back to the head hides the tail behind the window: the +N
+    // indicator must render again.
+    app.switch_view_to_tab(0, &ctl);
     let frame = crate::ui::dump_frame(&mut app, 30, 15);
     let row0 = frame.lines().next().unwrap_or_default();
     assert!(row0.contains('+'), "overflow indicator rendered in:\n{row0}");
+    assert!(row0.contains("dsh-test"), "head tab on screen:\n{row0}");
+}
+
+/// 8 sessions (dsh-test + sess-01..sess-07). Tab 0 is 13 display cols
+/// (`dsh-test` + padding/arrow), the rest 12 (`sess-0X` + padding/arrow),
+/// so a 64-col row shows a window of five tabs and overflows.
+fn open_eight_tabs() -> (App, Controller, Receiver<AppEvent>) {
+    let (mut app, ctl, rx) = test_app();
+    for i in 1..8 {
+        app.open_new_session(format!("sess-{i:02}"), true);
+    }
+    (app, ctl, rx)
+}
+
+fn strip_window(app: &mut App) -> Vec<usize> {
+    let _ = crate::ui::dump_frame(app, 64, 30);
+    app.tab_rects.iter().map(|(_, idx)| *idx).collect()
+}
+
+/// The drawn rect of one tab (fresh draw happens inside `strip_window`).
+fn drawn_rect(app: &App, tab: usize) -> ratatui::layout::Rect {
+    app.tab_rects
+        .iter()
+        .find(|(_, idx)| *idx == tab)
+        .expect("tab is on screen")
+        .0
+}
+
+fn click_tab(app: &mut App, ctl: &Controller, tab: usize) {
+    let rect = drawn_rect(app, tab);
+    app.handle_mouse(
+        mouse(
+            MouseEventKind::Down(MouseButton::Left),
+            rect.x + rect.width / 2,
+            0,
+        ),
+        ctl,
+    );
+}
+
+fn id_of(tab: usize) -> String {
+    if tab == 0 {
+        "dsh-test".into()
+    } else {
+        format!("sess-{tab:02}")
+    }
+}
+
+#[test]
+fn mouse_edge_clicks_walk_the_strip_to_every_tab_and_back() {
+    let (mut app, ctl, _rx) = open_eight_tabs();
+    // The live session is the newest (tab 7), so the first draw parks the
+    // window at the tail with it at the right edge.
+    let window = strip_window(&mut app);
+    assert_eq!(window, vec![3, 4, 5, 6, 7], "live tab revealed on open");
+    assert_eq!(app.tab_strip_offset, 3);
+
+    // Walk left to the head: clicking the leftmost visible tab switches
+    // to it and reveals its left neighbor.
+    for step in (0..3).rev() {
+        let first = *strip_window(&mut app).first().expect("window");
+        assert!(first > 0, "still tabs to reveal on the left");
+        click_tab(&mut app, &ctl, first);
+        assert_eq!(app.session_id, id_of(first), "edge click switches");
+        assert_eq!(app.tab_strip_offset, step, "strip walked one tab left");
+        let window = strip_window(&mut app);
+        assert!(
+            window.contains(&first) && window.contains(&(first - 1)),
+            "clicked tab stays visible and its left neighbor appears: {window:?}"
+        );
+    }
+    click_tab(&mut app, &ctl, 0);
+    assert_eq!(app.session_id, "dsh-test", "back on the first session");
+    assert_eq!(app.tab_strip_offset, 0, "tab 0 cannot nudge left");
+    assert_eq!(strip_window(&mut app), vec![0, 1, 2, 3, 4], "head window");
+
+    // Walk right to the tail: clicking the rightmost visible tab switches
+    // to it and reveals its right neighbor.
+    for step in 1..=3 {
+        let last = *strip_window(&mut app).last().expect("window");
+        assert!(last < 7, "still tabs to reveal");
+        click_tab(&mut app, &ctl, last);
+        assert_eq!(app.session_id, id_of(last), "edge click switches");
+        assert_eq!(app.tab_strip_offset, step, "strip walked one tab right");
+        let window = strip_window(&mut app);
+        assert!(
+            window.contains(&last) && window.contains(&(last + 1)),
+            "clicked tab stays visible and its neighbor appears: {window:?}"
+        );
+    }
+
+    // The final tab is on screen now; clicking it switches but cannot
+    // nudge further right.
+    let before = app.tab_strip_offset;
+    click_tab(&mut app, &ctl, 7);
+    assert_eq!(app.session_id, "sess-07");
+    assert_eq!(app.tab_strip_offset, before, "no nudge past the last tab");
+}
+
+#[test]
+fn middle_tab_clicks_do_not_nudge_and_switches_out_of_view_reanchor() {
+    let (mut app, ctl, _rx) = open_eight_tabs();
+    assert_eq!(strip_window(&mut app), vec![3, 4, 5, 6, 7]);
+    assert_eq!(app.tab_strip_offset, 3);
+
+    // A middle click switches but leaves the strip where it is.
+    click_tab(&mut app, &ctl, 5);
+    assert_eq!(app.session_id, "sess-05", "switched to the middle tab");
+    assert_eq!(app.tab_strip_offset, 3, "middle click does not nudge");
+    assert_eq!(strip_window(&mut app), vec![3, 4, 5, 6, 7]);
+
+    // Keyboard-style jump far out of the window (back to the head): the
+    // draw re-anchors so the live tab is visible again.
+    app.switch_view_to_tab(0, &ctl);
+    assert_eq!(strip_window(&mut app), vec![0, 1, 2, 3, 4]);
+    assert_eq!(app.tab_strip_offset, 0, "live tab 0 pins the head");
+
+    // And a jump to the far tail parks the live tab at the right edge.
+    app.switch_view_to_tab(7, &ctl);
+    let window = strip_window(&mut app);
+    assert_eq!(window, vec![3, 4, 5, 6, 7], "live tab at the right edge");
+    assert_eq!(app.tab_strip_offset, 3);
+}
+
+#[test]
+fn strip_offset_snaps_to_the_head_once_everything_fits_again() {
+    let (mut app, _ctl, _rx) = test_app();
+    app.open_new_session("s-two".into(), true); // 2 tabs: fits on a 64-col row
+    app.tab_strip_offset = 3; // stale offset from a wider strip
+    assert_eq!(strip_window(&mut app), vec![0, 1]);
+    assert_eq!(app.tab_strip_offset, 0, "no scroll state when nothing overflows");
 }

--- a/tests/unit/app__session_tabs_tests.rs
+++ b/tests/unit/app__session_tabs_tests.rs
@@ -609,3 +609,424 @@ fn plugin_null_ack_after_a_tab_switch_keeps_the_restored_painter_popup() {
         "the null ack only closes compositor-owned overlays"
     );
 }
+
+#[test]
+fn close_removes_the_viewed_tab_and_views_a_neighbor() {
+    let (mut app, _demo_ctl, _rx) = test_app();
+    let (ctl, commands) = crate::controller::tests::test_controller();
+    app.demo = false;
+    app.open_new_session("s-two".into(), true); // live s-two, dsh-test parked
+    app.open_new_session("s-three".into(), true); // live s-three (rightmost)
+    while commands.try_recv().is_ok() {}
+
+    // Close the rightmost tab: the left neighbor (s-two) takes its place.
+    app.run_slash("close", "", &ctl);
+    assert_eq!(app.session_id, "s-two");
+    assert_eq!(app.session_tab_count(), 2);
+    assert_eq!(
+        app.parked.iter().map(|s| s.id.as_str()).collect::<Vec<_>>(),
+        ["dsh-test"]
+    );
+    match commands.try_recv() {
+        Ok(crate::bus::Cmd::ForgetSession { session_id }) => {
+            assert_eq!(session_id, "s-three", "acp forgets the closed session");
+        }
+        other => panic!("expected ForgetSession, got {other:?}"),
+    }
+}
+
+#[test]
+fn close_leftmost_tab_keeps_the_same_slot_index() {
+    let (mut app, _ctl, _rx) = test_app();
+    // Live dsh-test is the leftmost tab; s-two parked to its right.
+    app.open_new_session("s-two".into(), true);
+    app.switch_to_session(0);
+    assert_eq!(app.session_id, "dsh-test");
+    app.transcript.push_user("left prompt".into(), false);
+
+    app.run_slash("close", "", &_ctl);
+    assert_eq!(app.session_id, "s-two", "right neighbor takes slot 0");
+    assert_eq!(app.session_tab_count(), 1);
+    let text = transcript_text(&mut app.transcript);
+    assert!(
+        !text.contains("left prompt"),
+        "closed tab's transcript is gone:\n{text}"
+    );
+}
+
+#[test]
+fn close_refuses_the_last_tab() {
+    let (mut app, _demo_ctl, _rx) = test_app();
+    let (ctl, commands) = crate::controller::tests::test_controller();
+    app.demo = false;
+    app.run_slash("close", "", &ctl);
+    assert_eq!(app.session_id, "dsh-test");
+    assert_eq!(app.session_tab_count(), 1);
+    assert!(
+        commands.try_recv().is_err(),
+        "closing the last tab must not emit ForgetSession"
+    );
+}
+
+#[test]
+fn close_discards_draft_queue_and_cancels_the_parked_ask() {
+    let (mut app, ctl, _rx) = test_app();
+    app.open_new_session("s-two".into(), true); // live s-two
+    // A draft + queued prompts + a pending ask on the doomed live tab.
+    app.input.insert_str("half-typed");
+    app.state = RunState::Running;
+    app.send_agent_text("queued one".into(), &ctl);
+    assert_eq!(app.queued, 1);
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    app.handle(
+        AppEvent::PermissionAsk {
+            session_id: "s-two".into(),
+            title: "rm".into(),
+            options: ask_options(),
+            reply: tx,
+        },
+        &ctl,
+    );
+    assert!(app.permission_ask.is_some());
+
+    app.run_slash("close", "", &ctl);
+    assert_eq!(app.session_id, "dsh-test", "back on the parked tab");
+    assert_eq!(
+        rx.blocking_recv().expect("ask reply"),
+        PermissionAskReply::Cancelled,
+        "closing a tab cancels its pending ACP ask (Drop)"
+    );
+    assert!(app.input.is_empty(), "doomed draft did not leak");
+    assert_eq!(app.queued, 0, "doomed queue did not leak");
+    assert!(!app.session_tabs().iter().any(|t| t.ask_pending));
+}
+
+#[test]
+fn close_of_an_unbound_tab_discards_its_coming_bind() {
+    let (mut app, _demo_ctl, _rx) = test_app();
+    let (ctl, commands) = crate::controller::tests::test_controller();
+    app.demo = false;
+    app.run_slash("new", "", &ctl);
+    while commands.try_recv().is_ok() {} // drain /new's NewSession + FetchSkills
+    let placeholder = app.session_id.clone();
+    assert!(placeholder.starts_with("dsh-") && !app.session_bound);
+
+    // Close the placeholder before session/new resolves.
+    app.run_slash("close", "", &ctl);
+    while commands.try_recv().is_ok() {} // drain close's ForgetSession
+    assert_eq!(app.session_id, "dsh-test", "back on the bound tab");
+
+    // The bind resolves after the close: it must be discarded (and its
+    // session forgotten), never rebind the viewed tab.
+    app.handle(
+        AppEvent::Ctl(CtlEvent::SessionBound {
+            session_id: "acp-late".into(),
+            notice: None,
+        }),
+        &ctl,
+    );
+    assert_eq!(
+        app.session_id, "dsh-test",
+        "a dead bind must not hijack the viewed tab"
+    );
+    assert!(!app.session_bound || app.session_id == "dsh-test");
+    match commands.try_recv() {
+        Ok(crate::bus::Cmd::ForgetSession { session_id }) => {
+            assert_eq!(session_id, "acp-late");
+        }
+        other => panic!("expected ForgetSession for the late bind, got {other:?}"),
+    }
+
+    // A later /new still binds normally — the tombstone kept the FIFO clean.
+    app.run_slash("new", "", &ctl);
+    app.handle(
+        AppEvent::Ctl(CtlEvent::SessionBound {
+            session_id: "acp-next".into(),
+            notice: None,
+        }),
+        &ctl,
+    );
+    assert_eq!(app.session_id, "acp-next", "the next bind lands normally");
+}
+
+#[test]
+fn composer_draft_scroll_model_and_banner_are_bound_to_the_tab() {
+    let (mut app, ctl, _rx) = test_app();
+    app.input.insert_str("draft for dsh-test");
+    app.scroll_up = 42;
+    app.selected_model = Some("deepseek-v3".into());
+    app.show_banner = false; // this tab already prompted
+
+    // A fresh tab starts clean — no draft, no scroll, no model pick.
+    app.run_slash("new", "", &ctl);
+    assert!(app.input.is_empty(), "fresh tab has an empty composer");
+    assert_eq!(app.scroll_up, 0);
+    assert_eq!(app.selected_model, None);
+    assert!(app.show_banner, "a fresh tab still shows the welcome");
+
+    // Round trip restores everything as left.
+    app.switch_to_session(0);
+    assert_eq!(app.session_id, "dsh-test");
+    assert_eq!(app.input.lines().join(""), "draft for dsh-test");
+    assert_eq!(app.scroll_up, 42);
+    assert_eq!(app.selected_model.as_deref(), Some("deepseek-v3"));
+    assert!(!app.show_banner);
+}
+
+#[test]
+fn shell_output_lands_in_the_session_that_ran_it() {
+    let (mut app, ctl, _rx) = test_app();
+    app.run_local_shell("echo hello".into());
+    let (shell_id, session, _cell) = app.shell_pending[0].clone();
+    assert_eq!(session, "dsh-test");
+
+    // Switch away while the command is still running.
+    app.open_new_session("s-two".into(), true);
+    assert!(app.shell_pending[0].1 == "dsh-test");
+
+    app.handle(
+        AppEvent::ShellDone {
+            id: shell_id,
+            code: Some(0),
+            output: "hello".into(),
+        },
+        &ctl,
+    );
+    assert!(app.shell_pending.is_empty());
+    let text = transcript_text(&mut app.transcript);
+    assert!(
+        !text.contains("hello"),
+        "result must not land on the tab in view"
+    );
+    app.switch_to_session(0);
+    let text = transcript_text(&mut app.transcript);
+    assert!(text.contains("hello"), "result landed in its own session:\n{text}");
+}
+
+#[test]
+fn deferred_steer_settles_into_the_owning_parked_slot() {
+    let (mut app, ctl, _rx) = test_app();
+    app.open_new_session("s-two".into(), true); // live s-two
+    app.switch_to_session(0); // back on dsh-test
+    // A Send Now is in flight for the viewed session; the user then leaves.
+    app.pending_steer_cells.insert(
+        77,
+        PendingSteer {
+            cells: Vec::new(),
+            blocks: vec![StagedBlock::Text("steer me".into())],
+            requeue_front: true,
+        },
+    );
+    app.switch_to_session(1); // away again: entry parked with dsh-test
+    assert_eq!(app.session_id, "s-two");
+
+    // The agent defers the steer while its owner is parked: the follow-up
+    // must return to that session's own queue, not vanish.
+    app.handle(
+        AppEvent::Ctl(CtlEvent::SteerSettled {
+            message_id: 77,
+            deferred: true,
+        }),
+        &ctl,
+    );
+    let slot = app
+        .parked
+        .iter()
+        .find(|slot| slot.id == "dsh-test")
+        .expect("dsh-test parked");
+    assert!(
+        slot.pending_steer_cells.is_empty(),
+        "settled entry removed from its slot"
+    );
+    assert_eq!(slot.prompt_queue.len(), 1, "deferred steer requeued");
+    assert!(matches!(
+        slot.prompt_queue[0].blocks.as_slice(),
+        [StagedBlock::Text(text)] if text == "steer me"
+    ));
+    assert!(app.prompt_queue.is_empty(), "never leaks onto the viewed tab");
+
+    // A non-deferred settle for a parked owner just releases the entry.
+    app.switch_to_session(0);
+    app.pending_steer_cells.insert(78, PendingSteer {
+        cells: Vec::new(),
+        blocks: vec![StagedBlock::Text("ok".into())],
+        requeue_front: true,
+    });
+    app.switch_to_session(1);
+    app.handle(
+        AppEvent::Ctl(CtlEvent::SteerSettled {
+            message_id: 78,
+            deferred: false,
+        }),
+        &ctl,
+    );
+    let slot = app.parked.iter().find(|s| s.id == "dsh-test").unwrap();
+    assert!(slot.pending_steer_cells.is_empty());
+    assert_eq!(slot.prompt_queue.len(), 1, "accepted steer stays sent");
+}
+
+#[test]
+fn error_on_an_unbound_tab_does_not_burn_the_queued_prompts() {
+    let (mut app, _demo_ctl, _rx) = test_app();
+    let (ctl, commands) = crate::controller::tests::test_controller();
+    app.demo = false;
+    app.run_slash("new", "", &ctl);
+    while commands.try_recv().is_ok() {}
+    app.send_agent_text("first".into(), &ctl);
+    app.send_agent_text("second".into(), &ctl);
+    assert_eq!(app.queued, 2);
+
+    // A rejection for the placeholder id + a generic connection error must
+    // not pop the queue head and burn the whole FIFO through repeated
+    // rejections — the prompts wait for the real bind.
+    app.handle(
+        AppEvent::Ctl(CtlEvent::SessionError {
+            session_id: app.session_id.clone(),
+            message: "prompt: unknown session dsh-x".into(),
+        }),
+        &ctl,
+    );
+    app.handle(AppEvent::Ctl(CtlEvent::Error("boom".into())), &ctl);
+    assert_eq!(app.queued, 2, "queue intact while the tab is unbound");
+    assert!(
+        commands.try_recv().is_err(),
+        "no prompt may leave with a placeholder id"
+    );
+
+    // The bind dispatches the head normally.
+    app.handle(
+        AppEvent::Ctl(CtlEvent::SessionBound {
+            session_id: "acp-real".into(),
+            notice: None,
+        }),
+        &ctl,
+    );
+    assert_eq!(app.queued, 1);
+    assert!(matches!(
+        commands.try_recv(),
+        Ok(crate::bus::Cmd::Prompt { session_id, text })
+            if session_id == "acp-real" && text == "first"
+    ));
+}
+
+#[test]
+fn bind_failure_clears_the_awaiting_entry_without_poisoning_the_next_bind() {
+    let (mut app, _demo_ctl, _rx) = test_app();
+    let (ctl, commands) = crate::controller::tests::test_controller();
+    app.demo = false;
+    app.run_slash("new", "", &ctl);
+    while commands.try_recv().is_ok() {}
+    let placeholder = app.session_id.clone();
+
+    app.handle(AppEvent::Ctl(CtlEvent::BindFailed), &ctl);
+    assert_eq!(
+        app.awaiting_binds.len(),
+        0,
+        "the dead request no longer owns a FIFO slot"
+    );
+    assert_eq!(app.session_id, placeholder, "tab stays open");
+    assert!(!app.session_bound);
+
+    // A later /new binds normally: the failed request cannot shadow it.
+    app.run_slash("new", "", &ctl);
+    while commands.try_recv().is_ok() {}
+    app.handle(
+        AppEvent::Ctl(CtlEvent::SessionBound {
+            session_id: "acp-2".into(),
+            notice: None,
+        }),
+        &ctl,
+    );
+    assert_eq!(app.session_id, "acp-2", "next bind lands on its own tab");
+}
+
+#[test]
+fn startup_bind_while_a_new_is_in_flight_lands_on_the_parked_startup_tab() {
+    let cfg = test_cfg();
+    let (tx, _rx) = std::sync::mpsc::channel::<AppEvent>();
+    let (ctl, _commands) = crate::controller::tests::test_controller();
+    let mut app = App::new(Some(Theme::dark()), cfg, "dsh-start".into(), false, false, tx);
+    // The user /new's before the startup session/new resolved: the startup
+    // tab (dsh-start) is parked and unbound; the placeholder is live.
+    app.run_slash("new", "", &ctl);
+    let placeholder = app.session_id.clone();
+    assert_eq!(app.parked[0].id, "dsh-start");
+
+    // The unrequested startup bind arrives first. It must rebind the
+    // parked startup tab — never consume the /new placeholder's FIFO slot.
+    app.handle(
+        AppEvent::Ctl(CtlEvent::SessionBound {
+            session_id: "acp-s0".into(),
+            notice: None,
+        }),
+        &ctl,
+    );
+    assert_eq!(
+        app.session_id, placeholder,
+        "the /new placeholder keeps its own pending bind"
+    );
+    assert_eq!(app.parked[0].id, "acp-s0", "startup session found its tab");
+    assert!(app.parked[0].session_bound);
+
+    // The /new bind then lands on its own tab, in order.
+    app.handle(
+        AppEvent::Ctl(CtlEvent::SessionBound {
+            session_id: "acp-s1".into(),
+            notice: None,
+        }),
+        &ctl,
+    );
+    assert_eq!(app.session_id, "acp-s1");
+    assert_eq!(app.session_tab_count(), 2);
+}
+
+#[test]
+fn session_errors_land_in_the_owning_parked_transcript() {
+    let (mut app, ctl, _rx) = test_app();
+    app.open_new_session("s-two".into(), true); // live s-two
+    for slot in &mut app.parked {
+        if slot.id == "dsh-test" {
+            slot.prompt_pending = true;
+        }
+    }
+    app.handle(
+        AppEvent::Ctl(CtlEvent::SessionError {
+            session_id: "dsh-test".into(),
+            message: "prompt: boom".into(),
+        }),
+        &ctl,
+    );
+    let live_text = transcript_text(&mut app.transcript);
+    assert!(
+        !live_text.contains("boom"),
+        "a parked session's failure must not spill onto the viewed tab"
+    );
+    let slot = app.parked.iter_mut().find(|s| s.id == "dsh-test").unwrap();
+    assert!(!slot.prompt_pending, "the failed session's delivery settles");
+    let parked_text = transcript_text(&mut slot.transcript);
+    assert!(parked_text.contains("boom"), "notice lands in its own tab");
+}
+
+#[test]
+fn alt_digit_jumps_to_a_session_tab() {
+    let (mut app, ctl, _rx) = test_app();
+    app.open_new_session("s-two".into(), true);
+    app.open_new_session("s-three".into(), true);
+    assert_eq!(app.session_id, "s-three");
+
+    app.handle_key(
+        KeyEvent::new(KeyCode::Char('1'), KeyModifiers::ALT),
+        &ctl,
+    );
+    assert_eq!(app.session_id, "dsh-test", "alt+1 jumps to the first tab");
+    app.handle_key(
+        KeyEvent::new(KeyCode::Char('3'), KeyModifiers::ALT),
+        &ctl,
+    );
+    assert_eq!(app.session_id, "s-three", "alt+3 jumps to the third tab");
+    app.handle_key(
+        KeyEvent::new(KeyCode::Char('9'), KeyModifiers::ALT),
+        &ctl,
+    );
+    assert_eq!(app.session_id, "s-three", "out-of-range tab is a no-op");
+}

--- a/tests/unit/app__session_tabs_tests.rs
+++ b/tests/unit/app__session_tabs_tests.rs
@@ -88,6 +88,79 @@ fn unknown_session_events_never_reach_any_transcript() {
 }
 
 #[test]
+fn parked_subagent_events_land_in_parked_subagent_transcript() {
+    let (mut app, _ctl, _rx) = test_app();
+    app.apply_ui(crate::events::UiEvent::SubagentStarted {
+        parent: "dsh-test".into(),
+        child: "sub-1".into(),
+    });
+    assert_eq!(app.subagents.len(), 1);
+
+    app.open_new_session("s-two".into(), true);
+    assert_eq!(app.session_id, "s-two");
+    assert_eq!(app.parked[0].id, "dsh-test");
+    assert_eq!(app.parked[0].subagents.len(), 1);
+
+    app.apply_ui(final_event("sub-1", "subagent answer in background"));
+
+    let sub_text = transcript_text(&mut app.parked[0].subagents[0].transcript);
+    assert!(
+        sub_text.contains("subagent answer in background"),
+        "subagent event reached parked subagent transcript:\n{sub_text}"
+    );
+    assert!(!transcript_text(&mut app.transcript).contains("subagent answer"));
+}
+
+#[test]
+fn parked_subagent_permission_ask_does_not_clobber_live_tab() {
+    let (mut app, _ctl, _rx) = test_app();
+    app.apply_ui(crate::events::UiEvent::SubagentStarted {
+        parent: "dsh-test".into(),
+        child: "sub-1".into(),
+    });
+    app.open_new_session("s-two".into(), true);
+
+    let (live_tx, _live_rx) = tokio::sync::oneshot::channel();
+    app.open_permission_ask("s-two", "live prompt ask".into(), Vec::new(), live_tx);
+    assert!(app.permission_ask.is_some());
+
+    let (sub_tx, _sub_rx) = tokio::sync::oneshot::channel();
+    app.open_permission_ask("sub-1", "subagent ask".into(), Vec::new(), sub_tx);
+
+    assert_eq!(app.permission_ask.as_ref().unwrap().title, "live prompt ask");
+    assert!(app.parked[0].permission_ask.is_some());
+    assert_eq!(
+        app.parked[0].permission_ask.as_ref().unwrap().title,
+        "subagent ask"
+    );
+}
+
+#[test]
+fn shell_pending_updated_on_session_bound() {
+    let (mut app, ctl, _rx) = test_app();
+    app.demo = false;
+    app.run_slash("new", "", &ctl);
+    let placeholder = app.session_id.clone();
+    assert!(placeholder.starts_with("dsh-"));
+
+    app.run_local_shell("echo hi".into());
+    assert_eq!(app.shell_pending[0].1, placeholder);
+
+    app.handle(
+        AppEvent::Ctl(CtlEvent::SessionBound {
+            session_id: "acp-real".into(),
+            notice: None,
+        }),
+        &ctl,
+    );
+    assert_eq!(app.session_id, "acp-real");
+    assert_eq!(
+        app.shell_pending[0].1, "acp-real",
+        "shell pending updated to bound id"
+    );
+}
+
+#[test]
 fn parked_completion_edge_badges_the_tab_and_switching_clears_it() {
     let (mut app, _ctl, _rx) = test_app();
     app.open_new_session("s-two".into(), true);
@@ -1029,4 +1102,53 @@ fn alt_digit_jumps_to_a_session_tab() {
         &ctl,
     );
     assert_eq!(app.session_id, "s-three", "out-of-range tab is a no-op");
+}
+
+#[test]
+fn next_and_prev_session_tab_cycles_tabs() {
+    let (mut app, ctl, _rx) = test_app();
+    app.open_new_session("s-two".into(), true);
+    app.open_new_session("s-three".into(), true);
+    assert_eq!(app.session_id, "s-three"); // index 2
+
+    // Next from last wraps to first (0)
+    app.handle_key(
+        KeyEvent::new(KeyCode::Char(']'), KeyModifiers::ALT),
+        &ctl,
+    );
+    assert_eq!(app.session_id, "dsh-test");
+
+    // Next moves to index 1
+    app.handle_key(
+        KeyEvent::new(KeyCode::PageDown, KeyModifiers::CONTROL),
+        &ctl,
+    );
+    assert_eq!(app.session_id, "s-two");
+
+    // Prev moves back to index 0
+    app.handle_key(
+        KeyEvent::new(KeyCode::Char('['), KeyModifiers::ALT),
+        &ctl,
+    );
+    assert_eq!(app.session_id, "dsh-test");
+
+    // Prev from 0 wraps to last (2)
+    app.handle_key(
+        KeyEvent::new(KeyCode::PageUp, KeyModifiers::CONTROL),
+        &ctl,
+    );
+    assert_eq!(app.session_id, "s-three");
+}
+
+#[test]
+fn tab_strip_renders_overflow_indicator_when_narrow() {
+    let (mut app, _ctl, _rx) = test_app();
+    app.open_new_session("s-two".into(), true);
+    app.open_new_session("s-three".into(), true);
+    app.open_new_session("s-four".into(), true);
+
+    // On width 30, not all tabs fit; +N indicator should render
+    let frame = crate::ui::dump_frame(&mut app, 30, 15);
+    let row0 = frame.lines().next().unwrap_or_default();
+    assert!(row0.contains('+'), "overflow indicator rendered in:\n{row0}");
 }

--- a/tests/unit/events__tests.rs
+++ b/tests/unit/events__tests.rs
@@ -1070,3 +1070,27 @@ fn non_update_events_pass_through_untouched() {
     // The tool_call start and the TurnEnd break every run: nothing merges.
     assert_eq!(events.len(), 5);
 }
+
+#[test]
+fn text_chunks_do_not_merge_across_subagents() {
+    let mut events = vec![
+        update_ev(
+            "s1",
+            json!({
+                "sessionUpdate": "agent_message_chunk",
+                "content": { "type": "text", "text": "sub1 " },
+                "_meta": { "dsh": { "subagent": { "childSessionId": "child-1" } } },
+            }),
+        ),
+        update_ev(
+            "s1",
+            json!({
+                "sessionUpdate": "agent_message_chunk",
+                "content": { "type": "text", "text": "sub2 " },
+                "_meta": { "dsh": { "subagent": { "childSessionId": "child-2" } } },
+            }),
+        ),
+    ];
+    coalesce_session_updates(&mut events);
+    assert_eq!(events.len(), 2, "chunks for distinct subagents stay separate");
+}

--- a/tests/unit/input__keymap__tests.rs
+++ b/tests/unit/input__keymap__tests.rs
@@ -298,6 +298,15 @@ fn every_action_has_exactly_one_documented_row_except_typing_insert() {
         Action::SelectLineEnd,
         Action::CopySelection,
         Action::CutSelection,
+        Action::SessionTab(1),
+        Action::SessionTab(2),
+        Action::SessionTab(3),
+        Action::SessionTab(4),
+        Action::SessionTab(5),
+        Action::SessionTab(6),
+        Action::SessionTab(7),
+        Action::SessionTab(8),
+        Action::SessionTab(9),
     ];
     let documented: Vec<Action> = KEY_ROWS.iter().map(|row| row.action).collect();
     assert_eq!(

--- a/tests/unit/input__keymap__tests.rs
+++ b/tests/unit/input__keymap__tests.rs
@@ -307,6 +307,8 @@ fn every_action_has_exactly_one_documented_row_except_typing_insert() {
         Action::SessionTab(7),
         Action::SessionTab(8),
         Action::SessionTab(9),
+        Action::NextSessionTab,
+        Action::PrevSessionTab,
     ];
     let documented: Vec<Action> = KEY_ROWS.iter().map(|row| row.action).collect();
     assert_eq!(
@@ -420,6 +422,7 @@ fn keys_markdown_uses_the_platform_spellings_and_groups_everything() {
         KeyGroup::Navigate,
         KeyGroup::Composer,
         KeyGroup::App,
+        KeyGroup::Session,
         KeyGroup::Mouse,
     ] {
         assert!(

--- a/tests/unit/ui__tests.rs
+++ b/tests/unit/ui__tests.rs
@@ -1819,6 +1819,7 @@ fn mode_picker_renders_modes_and_marks_the_current_one() {
     app.show_banner = false;
     app.modes.agent_preset = Some("minimal".into());
     app.picker = Some(Picker {
+        offset: 0,
         kind: PickerKind::Mode,
         title: " agent mode · enter select · esc close ".into(),
         sel: 2,
@@ -1860,6 +1861,7 @@ fn session_picker_rows_align_label_and_meta_columns() {
     let mut app = test_app();
     app.show_banner = false;
     app.picker = Some(Picker {
+        offset: 0,
         kind: PickerKind::Session,
         title: " resume session · 2 sessions · enter select · esc close ".into(),
         sel: 0,
@@ -1920,6 +1922,7 @@ fn picker_window_follows_the_selection_and_shows_a_scrollbar() {
         })
         .collect();
     app.picker = Some(Picker {
+        offset: 0,
         kind: PickerKind::Session,
         title: " resume session · 40 sessions · enter select · esc close ".into(),
         sel: 0,
@@ -1959,6 +1962,7 @@ fn picker_selection_highlights_the_whole_row() {
     let mut app = test_app();
     app.show_banner = false;
     app.picker = Some(Picker {
+        offset: 0,
         kind: PickerKind::Session,
         title: " resume session · 2 sessions ".into(),
         sel: 0,
@@ -2031,6 +2035,7 @@ fn model_picker_marks_only_the_current_provider_model_pair() {
     app.cfg.provider = "coding-plan-b".into();
     app.cfg.model = "deepseek-v4".into();
     app.picker = Some(Picker {
+        offset: 0,
         kind: PickerKind::Model,
         title: " model ".into(),
         sel: 1,


### PR DESCRIPTION
## Summary

Addresses issue #94 by completing multi-session lifecycle management, tab-bound state encapsulation, and hardening multi-session routing and concurrency.

### Key Changes

1. **/close Flow & Tab-Bound Lifecycle (Issue #94)**:
   - Implements `/close` to leave and drop session tabs while preserving background ACP session execution.
   - Refuses closing the last remaining tab.
   - Fully encapsulates transcript, composer draft, staged images, prompt queue, `@file` browser, scroll state, model pick, and run state to each respective session tab slot (`SessionSlot`).

2. **Subagent Multi-Session Routing**:
   - Fixes bug where streaming updates, deltas, tool calls, and results for subagents of parked (background) sessions were dropped by `apply_ui`.
   - Properly routes subagent permission asks and elicitation requests to their owning session tabs instead of clobbering foreground tab prompts.
   - Prevents `coalesce_session_updates` from erroneously concatenating deltas from distinct subagents.

3. **Bind State Machine & Auth Hardening**:
   - Ensures `Cmd::ResumeSession` emits `BindFailed` on authentication errors to prevent desynchronizing the `awaiting_binds` FIFO queue.
   - Guarantees `session.status: idle` is reported when a prompt finishes even if another session is stalled on auth, and purges stalled prompts for closed sessions in `Cmd::ForgetSession`.
   - Resolves startup race condition where unrequested startup binds could overwrite active tabs that are in-flight awaiting their own binds.
   - Tracks and updates `shell_pending` session IDs when placeholder session IDs are rebound to server-assigned IDs.
   - Prevents ID collision by augmenting placeholder timestamps with a monotonic sequence counter.

4. **Performance & UX Improvements**:
   - **`list_sessions` Optimization**: Pre-sorts session log candidate files by `mtime` before reading/parsing JSONL logs, bounding decompression to the top 50 sessions.
   - **Tab Navigation**: Adds `Alt+]` / `Ctrl+PageDown` (next tab) and `Alt+[` / `Ctrl+PageUp` (previous tab) shortcuts.
   - **Overflow Indicator**: Renders `+N` indicator when tabs exceed terminal width.
   - Clears pending Vim two-key chords on tab switches.

### Verification

- All 661 Rust unit & integration tests pass (`RUSTFLAGS="-C link-arg=-fuse-ld=mold" cargo test --locked`).
- All 226 npm/node test suites pass (`npm test --prefix npm`).
- Additional unit tests added covering parked subagent events, background asks, shell ID rebinding, and tab navigation.