### PR TITLE
fix(tui): pickers and inline option lists highlight the value actually in effect (issue #102)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ All notable changes to this project are documented here. The project follows
 
 ### Added
 
+- The `/agent`, `/effort`, `/model`, `/theme` and `/permission` pickers now
+  open with the row that is actually in effect preselected and ✓-marked
+  (issue #102): the effort picker follows the host-echoed effort (falling
+  back to the model's advertised default), and the model picker follows
+  the running model (explicit `/model` pick → last streamed model →
+  configured default) instead of the config default. The inline
+  argument-option lists typed next to `/model` and `/effort` behave the
+  same way: they open on the effective model/effort, ✓-mark it, and list
+  the effective model even when it is not in the host catalog.
+
 - `/resume [n|id]` — a bare number lists the `n` most recent durable
   sessions in the resume picker (`/resume 10` → latest 10). Without a
   number the default is 50 (`/resume` ≡ `/resume 50`); anything that is

--- a/src/app.rs
+++ b/src/app.rs
@@ -2687,17 +2687,68 @@ impl App {
             .collect()
     }
 
+    /// The value currently in effect for an open builtin option menu
+    /// (`/model `, `/effort `, `/agent `, `/theme `, `/permission `), if
+    /// the menu is one. Command-name lists and plugin option lists carry no
+    /// client-side "current". Mirrors the pickers (issue #102).
+    pub(crate) fn builtin_option_current(&self, matches: &[SlashEntry]) -> Option<String> {
+        let first = matches.first()?;
+        if first.completion.is_none() || matches.iter().any(|entry| entry.plugin) {
+            return None;
+        }
+        match first.name.as_str() {
+            "model" => Some(self.current_model()),
+            "effort" => self.modes.effort.clone(),
+            "agent" => Some(self.current_mode()),
+            "theme" => Some(self.active_palette_id.clone()),
+            "permission" => Some(self.current_permission().to_string()),
+            _ => None,
+        }
+    }
+
+    /// Restart the slash menu selection on the option currently in effect
+    /// when the open menu is a builtin option list; other menus restart at
+    /// their head. Text edits call this instead of pinning `slash_sel` to 0
+    /// so `/model ` / `/effort ` open on the running value (issue #102).
+    fn snap_slash_sel(&mut self) {
+        let matches = self.slash_matches();
+        let current = self.builtin_option_current(&matches);
+        self.slash_sel = current
+            .and_then(|value| {
+                matches.iter().position(|entry| {
+                    entry.completion.as_deref().and_then(|completion| {
+                        completion.strip_prefix(&format!("/{} ", entry.name))
+                    }) == Some(value.as_str())
+                })
+            })
+            .unwrap_or(0);
+    }
+
     fn builtin_argument_options(&self, name: &str) -> Vec<(String, String, String)> {
         let plain =
             |value: &str, desc: &str| (value.to_string(), value.to_string(), desc.to_string());
         match name {
             "model" => {
+                // The option list always carries the effective model (pick →
+                // stream → config default) so the inline menu can mark and
+                // preselect what the session runs (issue #102).
+                let current = self.current_model();
                 if !self.last_models.is_empty() {
-                    return self
+                    let mut rows: Vec<(String, String, String)> = self
                         .last_models
                         .iter()
-                        .map(|model| (model.id.clone(), model.name.clone(), model.provider.clone()))
+                        .map(|model| {
+                            (
+                                model.id.clone(),
+                                model.name.clone(),
+                                model.provider.clone(),
+                            )
+                        })
                         .collect();
+                    if !rows.iter().any(|(id, _, _)| id == &current) {
+                        rows.insert(0, (current.clone(), current.clone(), String::new()));
+                    }
+                    return rows;
                 }
                 let mut ids = host_catalog_models().unwrap_or_else(|| {
                     MODEL_PRESETS
@@ -2705,8 +2756,8 @@ impl App {
                         .map(|value| (*value).to_string())
                         .collect()
                 });
-                if !ids.iter().any(|id| id == &self.cfg.model) {
-                    ids.insert(0, self.cfg.model.clone());
+                if !ids.iter().any(|id| id == &current) {
+                    ids.insert(0, current);
                 }
                 ids.into_iter()
                     .map(|id| (id.clone(), id, String::new()))
@@ -3404,11 +3455,11 @@ impl App {
                             self.last_models = models.clone();
                         }
                         let mode_current = self.current_mode();
+                        let model_current = self.current_model();
+                        let model_provider = self.cfg.provider.clone();
                         if let Some(picker) = &mut self.picker {
                             match picker.kind {
                                 PickerKind::Model if !models.is_empty() => {
-                                    let current = self.cfg.model.clone();
-                                    let current_provider = self.cfg.provider.clone();
                                     picker.items = models
                                         .into_iter()
                                         .map(|m| PickerItem {
@@ -3427,9 +3478,17 @@ impl App {
                                         .items
                                         .iter()
                                         .position(|i| {
-                                            i.id == current
+                                            i.id == model_current
                                                 && i.provider.as_deref()
-                                                    == Some(current_provider.as_str())
+                                                    == Some(model_provider.as_str())
+                                        })
+                                        // Same id under an unknown provider
+                                        // still beats pinning row 0.
+                                        .or_else(|| {
+                                            picker
+                                                .items
+                                                .iter()
+                                                .position(|i| i.id == model_current)
                                         })
                                         .unwrap_or(0);
                                 }
@@ -5352,7 +5411,7 @@ impl App {
         match action {
             Action::Insert(ch) => {
                 self.input.insert_char(ch);
-                self.slash_sel = 0;
+                self.snap_slash_sel();
             }
             Action::Newline => {
                 self.input.insert_newline();
@@ -5390,6 +5449,7 @@ impl App {
                             .clone()
                             .unwrap_or_else(|| format!("/{} ", entry.name)),
                     );
+                    self.snap_slash_sel();
                 }
             }
             Action::Esc => self.handle_esc(ctl),
@@ -6032,20 +6092,33 @@ impl App {
                 provider: None,
             })
             .collect();
-        if !items.iter().any(|i| i.id == self.cfg.model) {
+        // The effective model (explicit pick → last streamed → configured
+        // default) is the picker's "current": the highlight and the ✓ mark
+        // land on the model the session is actually running (issue #102).
+        let current = self.current_model();
+        if !items.iter().any(|i| i.id == current) {
             items.insert(
                 0,
                 PickerItem {
-                    id: self.cfg.model.clone(),
-                    label: self.cfg.model.clone(),
+                    id: current.clone(),
+                    label: current.clone(),
                     meta: String::new(),
                     provider: None,
                 },
             );
         }
+        let current_provider = self.cfg.provider.clone();
         let sel = items
             .iter()
-            .position(|i| i.id == self.cfg.model)
+            .position(|i| {
+                i.id == current
+                    && i.provider
+                        .as_deref()
+                        .is_none_or(|provider| provider == current_provider)
+            })
+            // The running model may come from the transcript without a
+            // provider: fall back to an id-only match rather than row 0.
+            .or_else(|| items.iter().position(|i| i.id == current))
             .unwrap_or(0);
         self.picker = Some(Picker {
             offset: 0,
@@ -6090,6 +6163,20 @@ impl App {
                 })
                 .collect();
         }
+        // The highlight lands on the effort actually in effect (host-echoed
+        // `config_option_update` / last `/effort`), falling back to the
+        // model's advertised default, then the first row (issue #102).
+        let sel = self
+            .modes
+            .effort
+            .as_deref()
+            .and_then(|effort| items.iter().position(|i| i.id == effort))
+            .or_else(|| {
+                default
+                    .as_deref()
+                    .and_then(|d| items.iter().position(|i| i.id == d))
+            })
+            .unwrap_or(0);
         self.picker = Some(Picker {
             offset: 0,
             kind: PickerKind::Effort,
@@ -6100,7 +6187,7 @@ impl App {
                     " 推理强度 · enter 选择 · esc 关闭 ",
                 )
                 .into(),
-            sel: 0,
+            sel,
             items,
         });
     }
@@ -6777,6 +6864,17 @@ impl App {
                 .to_string()
         };
         self.set_permission(next, ctl);
+    }
+
+    /// The effective model: an explicit `/model` pick until a turn realizes
+    /// it, then the model that actually streamed last, then the configured
+    /// default. Mirrors the meta-row chip chain, so the model picker
+    /// highlights and ✓-marks the model the session is running (issue #102).
+    pub fn current_model(&self) -> String {
+        self.selected_model
+            .clone()
+            .or_else(|| self.transcript.last_model.clone())
+            .unwrap_or_else(|| self.cfg.model.clone())
     }
 
     /// The effective permission preset: the folded `permission/preset` fact,

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -2946,10 +2946,22 @@ fn draw_slash_menu(f: &mut Frame, app: &App, input: Rect, chat: Rect) {
     // Follow-window: selection stays visible, window pinned to the ends.
     let start = if sel < vis { 0 } else { sel + 1 - vis }.min(n - vis);
 
-    // Name column sized to what's listed (padded, never glued to the desc).
+    // The option currently in effect (builtin option menus only): its row
+    // gets a ✓ pinned to the label, like the pickers (issue #102).
+    let current_value = app.builtin_option_current(&matches);
+    let row_is_current = |entry: &crate::app::SlashEntry| {
+        current_value.as_deref().is_some_and(|value| {
+            entry.completion.as_deref().and_then(|completion| {
+                completion.strip_prefix(&format!("/{} ", entry.name))
+            }) == Some(value)
+        })
+    };
+
+    // Name column sized to what's listed (padded, never glued to the desc);
+    // the current row reserves two cells for its ✓.
     let name_w = matches
         .iter()
-        .map(|m| m.usage.width())
+        .map(|m| m.usage.width() + if row_is_current(m) { 2 } else { 0 })
         .max()
         .unwrap_or(14)
         .clamp(14, 26);
@@ -2993,9 +3005,14 @@ fn draw_slash_menu(f: &mut Frame, app: &App, input: Rect, chat: Rect) {
             0
         };
         let desc_cells = (w as usize).saturating_sub(name_w + 5 + section_cells);
+        let usage_text = if row_is_current(cmd) {
+            format!("{} ✓", cmd.usage)
+        } else {
+            cmd.usage.clone()
+        };
         let mut spans = vec![
             Span::styled(marker.to_string(), Style::default().fg(theme.brand)),
-            Span::styled(pad_or_ellipsize(&cmd.usage, name_w), name_style),
+            Span::styled(pad_or_ellipsize(&usage_text, name_w), name_style),
         ];
         if begins_section {
             spans.push(Span::styled(
@@ -3148,11 +3165,12 @@ fn draw_model_picker(f: &mut Frame, app: &mut App, screen: Rect) {
     let items = picker.items.clone();
     // Current-identity ids, precomputed so the row builder below never
     // borrows `app` (the ListView render needs a mutable picker).
-    let current_model = app.cfg.model.clone();
+    let current_model = app.current_model();
     let current_provider = app.cfg.provider.clone();
     let current_mode = app.current_mode();
     let current_palette = app.active_palette_id.clone();
     let current_permission = app.current_permission().to_string();
+    let current_effort = app.modes.effort.clone();
     let is_current = move |item: &crate::app::PickerItem| match kind {
         crate::app::PickerKind::Model => {
             item.id == current_model
@@ -3165,8 +3183,10 @@ fn draw_model_picker(f: &mut Frame, app: &mut App, screen: Rect) {
         crate::app::PickerKind::Theme => item.id == current_palette,
         crate::app::PickerKind::UiPlugin => false,
         crate::app::PickerKind::Permission => item.id == current_permission,
-        crate::app::PickerKind::Effort
-        | crate::app::PickerKind::Session
+        crate::app::PickerKind::Effort => {
+            current_effort.as_deref() == Some(item.id.as_str())
+        }
+        crate::app::PickerKind::Session
         | crate::app::PickerKind::Auth
         | crate::app::PickerKind::CordisPlugin
         | crate::app::PickerKind::CordisApproval

--- a/tests/unit/app__mode_tests.rs
+++ b/tests/unit/app__mode_tests.rs
@@ -1118,6 +1118,101 @@ fn host_catalog_model_picker_distinguishes_duplicate_ids_by_provider() {
 }
 
 #[test]
+fn model_picker_highlights_the_streamed_model_not_the_config_default() {
+    let (mut app, ctl, _rx) = test_app();
+    // The config default is only a fallback: once a turn streamed on a
+    // different model, the picker must mark the running one (issue #102).
+    app.cfg.model = "deepseek-v4-flash".into();
+    app.transcript.last_model = Some("deepseek-v4-pro".into());
+
+    app.open_model_picker(&ctl);
+
+    let picker = app.picker.as_ref().expect("model picker opens");
+    assert_eq!(picker.items[0].id, "deepseek-v4-pro", "current row seeded");
+    assert_eq!(picker.sel, 0, "highlight lands on the running model");
+}
+
+#[test]
+fn effort_picker_highlights_the_effort_in_effect() {
+    let (mut app, _ctl, _rx) = test_app();
+    // The host-echoed effort (config_option_update / last /effort) is the
+    // truth; the model default is only a fallback (issue #102).
+    app.modes.effort = Some("max".into());
+    app.open_effort_picker(
+        vec!["off".into(), "high".into(), "max".into()],
+        Some("high".into()),
+    );
+    let picker = app.picker.as_ref().expect("effort picker opens");
+    assert_eq!(picker.sel, 2, "highlight lands on the active effort");
+    assert!(
+        picker.items[1].meta.contains("default"),
+        "the model default stays marked: {}",
+        picker.items[1].meta
+    );
+}
+
+#[test]
+fn effort_picker_falls_back_to_the_advertised_default() {
+    let (mut app, _ctl, _rx) = test_app();
+    assert!(app.modes.effort.is_none());
+    app.open_effort_picker(
+        vec!["off".into(), "high".into(), "max".into()],
+        Some("high".into()),
+    );
+    let picker = app.picker.as_ref().expect("effort picker opens");
+    assert_eq!(picker.sel, 1, "highlight follows the advertised default");
+}
+
+#[test]
+fn slash_model_menu_preselects_the_running_model() {
+    let (mut app, ctl, _rx) = test_app();
+    // The inline option menu (typed `/model `) follows the same effective
+    // model as the picker: streamed model, not the config default (#102).
+    app.cfg.model = "deepseek-v4-flash".into();
+    app.transcript.last_model = Some("deepseek-v4-pro".into());
+    app.input.set("/model".into());
+    app.handle_key(KeyEvent::new(KeyCode::Char(' '), KeyModifiers::NONE), &ctl);
+
+    let menu = app.slash_matches();
+    assert_eq!(menu[0].completion.as_deref(), Some("/model deepseek-v4-pro"));
+    assert_eq!(app.slash_sel, 0, "highlight lands on the running model");
+
+    // Enter on the opened menu picks the running model (no accidental
+    // switch back to the config default).
+    app.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE), &ctl);
+    assert_eq!(app.cfg.model, "deepseek-v4-pro");
+}
+
+#[test]
+fn slash_effort_menu_preselects_the_effort_in_effect() {
+    let (mut app, ctl, _rx) = test_app();
+    app.modes.effort = Some("max".into());
+    app.input.set("/effort".into());
+    app.handle_key(KeyEvent::new(KeyCode::Char(' '), KeyModifiers::NONE), &ctl);
+
+    let menu = app.slash_matches();
+    let completions: Vec<&str> = menu
+        .iter()
+        .filter_map(|entry| entry.completion.as_deref())
+        .collect();
+    assert_eq!(
+        completions,
+        ["/effort off", "/effort high", "/effort max"]
+    );
+    assert_eq!(app.slash_sel, 2, "highlight lands on the active effort");
+
+    // A typed prefix that excludes the current restarts at the head.
+    app.handle_key(KeyEvent::new(KeyCode::Char('h'), KeyModifiers::NONE), &ctl);
+    assert_eq!(app.slash_sel, 0, "filtered menu restarts at its head");
+
+    // Enter on the opened menu keeps the effort in effect.
+    app.input.set("/effort".into());
+    app.handle_key(KeyEvent::new(KeyCode::Char(' '), KeyModifiers::NONE), &ctl);
+    app.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE), &ctl);
+    assert_eq!(app.modes.effort.as_deref(), Some("max"));
+}
+
+#[test]
 fn selecting_same_model_id_from_another_provider_switches_provider() {
     let (mut app, ctl, _rx) = test_app();
     app.cfg.provider = "coding-plan-a".into();

--- a/tests/unit/ui__tests.rs
+++ b/tests/unit/ui__tests.rs
@@ -2070,6 +2070,141 @@ fn model_picker_marks_only_the_current_provider_model_pair() {
 }
 
 #[test]
+fn model_picker_marks_the_streamed_model_when_it_differs_from_config() {
+    use crate::app::{Picker, PickerItem, PickerKind};
+    let mut app = test_app();
+    app.show_banner = false;
+    // A turn streamed on `deepseek-v4-pro` while the config still names the
+    // fallback: the picker must mark the running model (issue #102).
+    app.cfg.model = "deepseek-v4-flash".into();
+    app.transcript.last_model = Some("deepseek-v4-pro".into());
+    app.picker = Some(Picker {
+        offset: 0,
+        kind: PickerKind::Model,
+        title: " model ".into(),
+        sel: 1,
+        items: vec![
+            PickerItem {
+                id: "deepseek-v4-flash".into(),
+                label: "deepseek-v4-flash".into(),
+                meta: String::new(),
+                provider: None,
+            },
+            PickerItem {
+                id: "deepseek-v4-pro".into(),
+                label: "deepseek-v4-pro".into(),
+                meta: String::new(),
+                provider: None,
+            },
+        ],
+    });
+
+    let frame = dump_frame(&mut app, 100, 24);
+    let marked: Vec<&str> = frame.lines().filter(|line| line.contains("✓")).collect();
+    assert_eq!(marked.len(), 1, "one current model:\n{frame}");
+    assert!(
+        marked[0].contains("deepseek-v4-pro"),
+        "the running model is marked: {}\n{frame}",
+        marked[0]
+    );
+    assert!(
+        marked[0].contains("▸"),
+        "highlight follows the running model: {}",
+        marked[0]
+    );
+}
+
+#[test]
+fn effort_picker_marks_and_highlights_the_current_effort() {
+    use crate::app::{Picker, PickerItem, PickerKind};
+    let mut app = test_app();
+    app.show_banner = false;
+    app.modes.effort = Some("max".into());
+    app.picker = Some(Picker {
+        offset: 0,
+        kind: PickerKind::Effort,
+        title: " reasoning effort · enter select · esc close ".into(),
+        sel: 2,
+        items: ["off", "high", "max"]
+            .iter()
+            .map(|e| PickerItem {
+                id: e.to_string(),
+                label: e.to_string(),
+                meta: String::new(),
+                provider: None,
+            })
+            .collect(),
+    });
+
+    let frame = dump_frame(&mut app, 100, 24);
+    let max_row = frame
+        .lines()
+        .find(|l| l.contains("max"))
+        .expect("max row listed");
+    assert!(max_row.contains("max ✓"), "current effort marked: {max_row}");
+    assert!(
+        max_row.contains("▸"),
+        "highlight on the active effort: {max_row}"
+    );
+}
+
+#[test]
+fn slash_effort_menu_marks_and_highlights_the_active_effort() {
+    use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers};
+    let mut app = test_app();
+    app.show_banner = false;
+    app.modes.effort = Some("max".into());
+    app.input.set("/effort".into());
+    let (ctl, _commands) = crate::controller::tests::test_controller();
+    app.handle(
+        crate::bus::AppEvent::Term(Event::Key(KeyEvent::new(
+            KeyCode::Char(' '),
+            KeyModifiers::NONE,
+        ))),
+        &ctl,
+    );
+
+    // The typed `/effort ` option menu opens on the effort in effect.
+    let frame = dump_frame(&mut app, 100, 30);
+    let marked: Vec<&str> = frame.lines().filter(|line| line.contains('✓')).collect();
+    assert_eq!(marked.len(), 1, "only the active effort is marked:\n{frame}");
+    assert!(
+        marked[0].contains("max") && marked[0].contains("▸"),
+        "highlight and ✓ sit on the active effort: {}\n{frame}",
+        marked[0]
+    );
+}
+
+#[test]
+fn slash_model_menu_marks_the_running_model() {
+    use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers};
+    let mut app = test_app();
+    app.show_banner = false;
+    app.cfg.model = "deepseek-v4-flash".into();
+    app.transcript.last_model = Some("deepseek-v4-pro".into());
+    app.input.set("/model".into());
+    let (ctl, _commands) = crate::controller::tests::test_controller();
+    app.handle(
+        crate::bus::AppEvent::Term(Event::Key(KeyEvent::new(
+            KeyCode::Char(' '),
+            KeyModifiers::NONE,
+        ))),
+        &ctl,
+    );
+
+    // The inline `/model ` list leads with the running model, marked ✓ and
+    // highlighted, instead of the config default.
+    let frame = dump_frame(&mut app, 100, 30);
+    let marked: Vec<&str> = frame.lines().filter(|line| line.contains('✓')).collect();
+    assert_eq!(marked.len(), 1, "only the running model is marked:\n{frame}");
+    assert!(
+        marked[0].contains("deepseek-v4-pro") && marked[0].contains("▸"),
+        "highlight and ✓ sit on the running model: {}\n{frame}",
+        marked[0]
+    );
+}
+
+#[test]
 fn scroll_up_survives_draw_and_shows_indicator() {
     let mut app = test_app();
     app.show_banner = false;


### PR DESCRIPTION
## 解决 #102：被高亮的 item 与实际环境对应

`/agent` `/effort` `/model` `/theme` `/permission` 的选择 UI（弹层 picker 与随行参数列表）此前高亮的常常是客户端配置默认值或第一项，而不是会话实际生效的值。

### 改动

**Model**
- 新增 `App::current_model()`：实际生效模型 = 显式 `/model` 选择 → 最近一次流式输出的模型（`transcript.last_model`）→ 配置默认，与 meta 行模型芯片同一链路。
- `open_model_picker` 与 Host catalog 到达后的重建都用它计算高亮/✓；provider 精确匹配失败时回退到 id 匹配（而不是钉在第 0 行）。

**Effort**
- `open_effort_picker` 不再硬编码 `sel: 0`：高亮 = host 回显的当前 effort（`config_option_update` / 最近一次 `/effort`）→ 模型广告的默认值 → 第 0 行。
- painter 给当前 effort 行补上 ✓ 标记（此前缺失）。

**随行参数列表（输入 `/model ` `/effort ` 弹出的候选菜单）**
- 新增 `builtin_option_current()` / `snap_slash_sel()`：每次文本变化（键入、Tab 补全）后，若打开的列表含当前生效项则高亮该项；否则回落第 0 项。回车执行的即是实际值，不会误切。
- 菜单中当前生效行追加 `✓`（名称列预留宽度，desc 不错位）。
- `/model` 参数列表始终带上实际生效模型（host 目录缺失时补插到首位），与 model picker 一致。

`/agent` `/theme` `/permission` 的 picker 本就正确，随行列表逻辑统一覆盖（同一 `builtin_option_current`）。

### 验证
- `cargo test --locked`：682 passed（新增 9 个回归测试：picker 高亮/✓ 5 个 + 随行列表 4 个）
- `cargo check --locked --tests`：通过
- `martty --dump-frame 100x34`：渲染正常