### PR TITLE
feat(tui): ⌕ button jumps between user prompts (issue #103)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,8 @@ All notable changes to this project are documented here. The project follows
   image prompts both count as jump targets. Right after a jump the jumped
   prompt's rows are highlighted for 5 seconds like a picker's selected row
   (chip background wash with the text in the brand tone) and then restore
-  to the ordinary bubble look.
+  to the ordinary bubble look. Hovering either cap-row glyph pops a small
+  tooltip card above it explaining the click (⛶ expand/collapse, ⌕ jump).
 
 
 - `/resume [n|id]` — a bare number lists the `n` most recent durable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,8 +25,9 @@ All notable changes to this project are documented here. The project follows
   so the walk resumes where the previous click stopped; the cap row tip
   shows the current position (`user prompt k/n · newest first`). Text and
   image prompts both count as jump targets. Right after a jump the jumped
-  prompt's rows are background-washed for 5 seconds (the chip tone of
-  picker row highlights) and then restore to the ordinary bubble look.
+  prompt's rows are highlighted for 5 seconds like a picker's selected row
+  (chip background wash with the text in the brand tone) and then restore
+  to the ordinary bubble look.
 
 
 - `/resume [n|id]` — a bare number lists the `n` most recent durable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,9 @@ All notable changes to this project are documented here. The project follows
   The last-jumped position is remembered in memory only (never persisted),
   so the walk resumes where the previous click stopped; the cap row tip
   shows the current position (`user prompt k/n · newest first`). Text and
-  image prompts both count as jump targets.
+  image prompts both count as jump targets. Right after a jump the jumped
+  prompt's rows are background-washed for 5 seconds (the chip tone of
+  picker row highlights) and then restore to the ordinary bubble look.
 
 
 - `/resume [n|id]` — a bare number lists the `n` most recent durable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,16 @@ All notable changes to this project are documented here. The project follows
   same way: they open on the effective model/effort, ✓-mark it, and list
   the effective model even when it is not in the host catalog.
 
+- `⌕` user-prompt jump button on the composer cap row, between the project
+  path and the `⛶` expand glyph (issue #103): hovering highlights it and
+  clicking scrolls the chat to the newest user prompt; each further click
+  walks one prompt back, and the oldest prompt wraps to the newest again.
+  The last-jumped position is remembered in memory only (never persisted),
+  so the walk resumes where the previous click stopped; the cap row tip
+  shows the current position (`user prompt k/n · newest first`). Text and
+  image prompts both count as jump targets.
+
+
 - `/resume [n|id]` — a bare number lists the `n` most recent durable
   sessions in the resume picker (`/resume 10` → latest 10). Without a
   number the default is 50 (`/resume` ≡ `/resume 50`); anything that is

--- a/src/app.rs
+++ b/src/app.rs
@@ -1135,6 +1135,17 @@ pub struct App {
     /// True while the pointer rests on the expand button; only then does
     /// the frame painter show it (`needs_redraw` on change).
     pub(crate) hover_expand_btn: bool,
+    /// Screen rect of the mouse-only `⌕` user-prompt jump button (issue
+    /// #103) from the latest frame — one cell left of the expand glyph on
+    /// the composer card's top-right.
+    pub(crate) prompt_jump_btn: Option<ratatui::layout::Rect>,
+    /// True while the pointer rests on the `⌕` button (`needs_redraw` on
+    /// change, same hover policy as the expand button).
+    pub(crate) hover_prompt_jump_btn: bool,
+    /// Transcript cell of the user prompt the last `⌕` click jumped to
+    /// (issue #103). The next click walks one prompt back; the oldest
+    /// wraps to the newest. In-memory only — never persisted.
+    pub(crate) prompt_jump_cell: Option<usize>,
     pub state: RunState,
     pub state_note: String,
     /// Welcome banner (whale + wordmark) — shown until the first real prompt.
@@ -1615,6 +1626,9 @@ impl App {
             input_expanded: false,
             expand_btn: None,
             hover_expand_btn: false,
+            prompt_jump_btn: None,
+            hover_prompt_jump_btn: false,
+            prompt_jump_cell: None,
             state: RunState::Idle,
             state_note: String::new(),
             show_banner: true,
@@ -1841,6 +1855,8 @@ impl App {
         self.queue_selection = None;
         self.queue_edit = None;
         self.vim.reset_pending();
+        // The ⌕ jump cursor indexes this session's transcript cells.
+        self.prompt_jump_cell = None;
         self.needs_redraw = true;
     }
 
@@ -4225,6 +4241,21 @@ impl App {
                     self.toggle_tool(ci);
                     return;
                 }
+                // The ⌕ prompt-jump button (issue #103) wins over caret
+                // placement: each click walks the chat view to the previous
+                // user prompt (newest first, wrapping at the oldest).
+                if self.elicitation_ask.is_none()
+                    && self.active_subagent.is_none()
+                    && self.prompt_jump_btn_hit(mouse.column, mouse.row)
+                {
+                    self.sel = None;
+                    self.selecting = false;
+                    self.last_click = None;
+                    self.input_selecting = false;
+                    self.input_sel = None;
+                    self.jump_to_user_prompt();
+                    return;
+                }
                 // The mouse-only expand button (issue #92) wins over caret
                 // placement inside the well: clicking toggles the input
                 // height instead of moving the caret. It lives inside the
@@ -4331,6 +4362,11 @@ impl App {
                     self.hover_expand_btn = over_btn;
                     self.needs_redraw = true;
                 }
+                let over_jump = self.prompt_jump_btn_hit(mouse.column, mouse.row);
+                if over_jump != self.hover_prompt_jump_btn {
+                    self.hover_prompt_jump_btn = over_jump;
+                    self.needs_redraw = true;
+                }
                 let hover = self.chip_at(mouse.column, mouse.row);
                 if hover != self.hover_att {
                     self.hover_att = hover;
@@ -4413,6 +4449,77 @@ impl App {
                 && row >= r.y
                 && row < r.y.saturating_add(r.height)
         })
+    }
+
+    /// Hit-test the mouse-only `⌕` user-prompt jump button (issue #103).
+    fn prompt_jump_btn_hit(&self, col: u16, row: u16) -> bool {
+        self.prompt_jump_btn.is_some_and(|r| {
+            col >= r.x
+                && col < r.x.saturating_add(r.width)
+                && row >= r.y
+                && row < r.y.saturating_add(r.height)
+        })
+    }
+
+    /// `⌕` click (issue #103): jump the chat view to a user prompt. The
+    /// first click goes to the newest prompt, each further click walks one
+    /// prompt back, and the oldest wraps to the newest again. The last
+    /// target is remembered in memory only (never persisted) and rides
+    /// across clicks, so jumping resumes where the previous jump stopped.
+    fn jump_to_user_prompt(&mut self) {
+        let area = self.chat_view.area;
+        if area.width == 0 || area.height == 0 {
+            return;
+        }
+        let theme = self.theme;
+        let spinner = self.spinner();
+        let layout = self
+            .transcript
+            .layout(&theme, area.width, spinner, crate::pet::kitty_supported());
+        if layout.users.is_empty() {
+            self.show_tip(self.locale.tr(
+                "no user prompts yet — ⌕ finds them once you send one",
+                "还没有用户输入 —— 发送后 ⌕ 即可跳转",
+            ));
+            return;
+        }
+        // The running indicator rides as one extra tail line in draw_chat;
+        // include it so the anchored viewport matches the next frame.
+        let total = layout.lines.len()
+            + usize::from(matches!(self.state, RunState::Starting | RunState::Running));
+        let h = area.height as usize;
+        let max_scroll = total.saturating_sub(h);
+        let target = match self
+            .prompt_jump_cell
+            .and_then(|cell| layout.users.iter().position(|p| p.cell == cell))
+        {
+            // A previous jump: continue walking backward from it…
+            Some(rank) if rank > 0 => layout.users[rank - 1],
+            // …and the oldest prompt wraps back to the newest.
+            Some(_) => layout.users[layout.users.len() - 1],
+            // No previous jump (fresh session, tab switch, or the target
+            // cell is gone): start at the newest prompt.
+            None => layout.users[layout.users.len() - 1],
+        };
+        let from_newest = layout
+            .users
+            .iter()
+            .rposition(|p| p.cell == target.cell)
+            .map(|rank| layout.users.len() - rank)
+            .unwrap_or(1);
+        self.prompt_jump_cell = Some(target.cell);
+        // Anchor the prompt's first line to the top of the chat pane.
+        let start = target.line.min(max_scroll);
+        let end = start.saturating_add(h).min(total);
+        let scroll_up = total.saturating_sub(end);
+        self.chat_view.manual_top = (scroll_up > 0).then_some(start);
+        self.scroll_up = scroll_up;
+        self.needs_redraw = true;
+        self.show_tip(self.locale.trf(
+            "⌕ user prompt {k}/{n} · newest first",
+            "⌕ 用户输入 {k}/{n} · 从最新往前",
+            &[from_newest.to_string(), layout.users.len().to_string()],
+        ));
     }
 
     /// Hit-test a screen cell against the inline chips drawn this frame.

--- a/src/app.rs
+++ b/src/app.rs
@@ -40,6 +40,9 @@ struct CtrlCQuitChord {
     required: u8,
 }
 const TIP_TTL: Duration = Duration::from_secs(4);
+/// How long the `⌕` jump flash keeps the jumped user prompt background-
+/// washed before it restores to normal (issue #103).
+pub(crate) const PROMPT_FLASH_TTL: Duration = Duration::from_secs(5);
 /// How often the composer cap re-checks the workspace git branch (tick
 /// cadence). Catches checkouts done by the agent or in another terminal;
 /// `!git checkout` in the session shell refreshes immediately instead.
@@ -1146,6 +1149,16 @@ pub struct App {
     /// (issue #103). The next click walks one prompt back; the oldest
     /// wraps to the newest. In-memory only — never persisted.
     pub(crate) prompt_jump_cell: Option<usize>,
+    /// The `⌕` jump flash (issue #103): the transcript cell of the prompt
+    /// that was just jumped to, with the instant the background wash
+    /// expires (5 s after the click). `App::tick` clears it on expiry; the
+    /// painter resolves the cell to lines per frame.
+    pub(crate) prompt_flash: Option<(usize, std::time::Instant)>,
+    /// Per-frame absolute line span `[start, end)` of the flashing prompt,
+    /// resolved by `draw_chat` from `prompt_flash` against the current
+    /// layout (streaming can move the prompt's lines). `None` when nothing
+    /// flashes this frame.
+    pub(crate) prompt_flash_lines: Option<(usize, usize)>,
     pub state: RunState,
     pub state_note: String,
     /// Welcome banner (whale + wordmark) — shown until the first real prompt.
@@ -1629,6 +1642,8 @@ impl App {
             prompt_jump_btn: None,
             hover_prompt_jump_btn: false,
             prompt_jump_cell: None,
+            prompt_flash: None,
+            prompt_flash_lines: None,
             state: RunState::Idle,
             state_note: String::new(),
             show_banner: true,
@@ -1855,8 +1870,11 @@ impl App {
         self.queue_selection = None;
         self.queue_edit = None;
         self.vim.reset_pending();
-        // The ⌕ jump cursor indexes this session's transcript cells.
+        // The ⌕ jump cursor indexes this session's transcript cells, and
+        // the flash must not carry over to another session's view.
         self.prompt_jump_cell = None;
+        self.prompt_flash = None;
+        self.prompt_flash_lines = None;
         self.needs_redraw = true;
     }
 
@@ -2177,6 +2195,14 @@ impl App {
         if let Some((_, at)) = &self.tip {
             if at.elapsed() > TIP_TTL {
                 self.tip = None;
+                self.needs_redraw = true;
+            }
+        }
+        // The ⌕ jump flash restores the prompt to normal after its 5 s.
+        if let Some((_, until)) = &self.prompt_flash {
+            if Instant::now() >= *until {
+                self.prompt_flash = None;
+                self.prompt_flash_lines = None;
                 self.needs_redraw = true;
             }
         }
@@ -4508,12 +4534,14 @@ impl App {
             .map(|rank| layout.users.len() - rank)
             .unwrap_or(1);
         self.prompt_jump_cell = Some(target.cell);
-        // Anchor the prompt's first line to the top of the chat pane.
+        // Anchor the prompt's first line to the top of the chat pane and
+        // flash its rows for a few seconds (issue #103).
         let start = target.line.min(max_scroll);
         let end = start.saturating_add(h).min(total);
         let scroll_up = total.saturating_sub(end);
         self.chat_view.manual_top = (scroll_up > 0).then_some(start);
         self.scroll_up = scroll_up;
+        self.prompt_flash = Some((target.cell, Instant::now() + PROMPT_FLASH_TTL));
         self.needs_redraw = true;
         self.show_tip(self.locale.trf(
             "⌕ user prompt {k}/{n} · newest first",

--- a/src/app.rs
+++ b/src/app.rs
@@ -1150,9 +1150,10 @@ pub struct App {
     /// wraps to the newest. In-memory only — never persisted.
     pub(crate) prompt_jump_cell: Option<usize>,
     /// The `⌕` jump flash (issue #103): the transcript cell of the prompt
-    /// that was just jumped to, with the instant the background wash
-    /// expires (5 s after the click). `App::tick` clears it on expiry; the
-    /// painter resolves the cell to lines per frame.
+    /// that was just jumped to, with the instant the highlight (chip
+    /// background wash + brand text) expires, 5 s after the click.
+    /// `App::tick` clears it on expiry; the painter resolves the cell to
+    /// lines per frame.
     pub(crate) prompt_flash: Option<(usize, std::time::Instant)>,
     /// Per-frame absolute line span `[start, end)` of the flashing prompt,
     /// resolved by `draw_chat` from `prompt_flash` against the current

--- a/src/transcript.rs
+++ b/src/transcript.rs
@@ -355,13 +355,15 @@ pub struct ImageShot {
 }
 
 /// One user prompt in a rendered transcript: the transcript cell index and
-/// the index of its first text line (the leading blank separator row is not
-/// counted). The ⌕ composer button walks these from the newest one back
-/// (issue #103).
+/// the half-open line span `[line, end)` its bubble occupies (the leading
+/// blank separator row is not counted; `end` covers wrapped text lines and,
+/// for image prompts, the thumbnail rows). The ⌕ composer button walks
+/// these from the newest one back and flashes the jumped span (issue #103).
 #[derive(Clone, Copy, Debug)]
 pub struct UserPromptLine {
     pub cell: usize,
     pub line: usize,
+    pub end: usize,
 }
 
 /// A rendered transcript: styled lines plus, for each line, the index of the
@@ -1107,6 +1109,7 @@ impl Transcript {
                     users.push(UserPromptLine {
                         cell: ci,
                         line: first,
+                        end: out.len(),
                     });
                 }
                 CellKind::Image {
@@ -1191,6 +1194,7 @@ impl Transcript {
                     users.push(UserPromptLine {
                         cell: ci,
                         line: first,
+                        end: out.len(),
                     });
                 }
                 CellKind::Reasoning {

--- a/src/transcript.rs
+++ b/src/transcript.rs
@@ -354,6 +354,16 @@ pub struct ImageShot {
     pub data: Arc<[u8]>,
 }
 
+/// One user prompt in a rendered transcript: the transcript cell index and
+/// the index of its first text line (the leading blank separator row is not
+/// counted). The ⌕ composer button walks these from the newest one back
+/// (issue #103).
+#[derive(Clone, Copy, Debug)]
+pub struct UserPromptLine {
+    pub cell: usize,
+    pub line: usize,
+}
+
 /// A rendered transcript: styled lines plus, for each line, the index of the
 /// transcript cell that owns it (only tool cells report ownership, so mouse
 /// clicks can toggle a specific tool preview).
@@ -361,6 +371,8 @@ pub struct TranscriptLayout {
     pub lines: Vec<Line<'static>>,
     pub owners: Vec<Option<usize>>,
     pub images: Vec<ImageShot>,
+    /// Every laid-out user prompt with the index of its first text line.
+    pub users: Vec<UserPromptLine>,
 }
 
 #[derive(Default, Clone, Copy)]
@@ -1042,6 +1054,7 @@ impl Transcript {
         let mut out: Vec<Line> = Vec::new();
         let mut owners: Vec<Option<usize>> = Vec::new();
         let mut images: Vec<ImageShot> = Vec::new();
+        let mut users: Vec<UserPromptLine> = Vec::new();
         for (ci, cell) in self.cells.iter_mut().enumerate() {
             if cell.hidden {
                 continue;
@@ -1066,6 +1079,7 @@ impl Transcript {
                     // Budget = width - 4: the "❯ "/"  " prefix takes 2 cells
                     // and the " {l} " padding takes 2 more, so a wider wrap
                     // budget would clip the last text cells of full lines.
+                    let first = out.len();
                     for (i, l) in wrap(text, width.saturating_sub(4)).into_iter().enumerate() {
                         let mut spans = vec![
                             Span::styled(
@@ -1090,6 +1104,10 @@ impl Transcript {
                         }
                         emit(&mut out, &mut owners, Line::from(spans), None);
                     }
+                    users.push(UserPromptLine {
+                        cell: ci,
+                        line: first,
+                    });
                 }
                 CellKind::Image {
                     name,
@@ -1101,6 +1119,7 @@ impl Transcript {
                     ..
                 } => {
                     emit(&mut out, &mut owners, Line::default(), None);
+                    let first = out.len();
                     let label = if caption.is_empty() {
                         format!("🖼 {name}")
                     } else {
@@ -1169,6 +1188,10 @@ impl Transcript {
                             None,
                         );
                     }
+                    users.push(UserPromptLine {
+                        cell: ci,
+                        line: first,
+                    });
                 }
                 CellKind::Reasoning {
                     done,
@@ -1408,6 +1431,7 @@ impl Transcript {
             lines: out,
             owners,
             images,
+            users,
         }
     }
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -2298,10 +2298,10 @@ fn draw_chat(f: &mut Frame, app: &mut App, area: Rect) {
 }
 
 /// The transient `⌕` jump highlight (issue #103): right after a jump the
-/// jumped prompt's rows carry a soft background wash — the same chip tone
-/// the pickers use for the selected row — for ~5 seconds, then the
-/// ordinary bubble look returns (the expiry lives in `App::tick`, which
-/// clears the state and requests a repaint).
+/// jumped prompt's rows are highlighted exactly like a picker's selected
+/// row — chip background wash plus the text brightened to the brand tone —
+/// for ~5 seconds, then the ordinary bubble look returns (the expiry lives
+/// in `App::tick`, which clears the state and requests a repaint).
 fn draw_prompt_flash(f: &mut Frame, app: &App, inner: Rect, start: usize) {
     let Some((s, e)) = app.prompt_flash_lines else {
         return;
@@ -2322,7 +2322,10 @@ fn draw_prompt_flash(f: &mut Frame, app: &App, inner: Rect, start: usize) {
         }
         for c in 0..lw.min(inner.width as usize) {
             if let Some(cell) = buf.cell_mut((inner.x + c as u16, inner.y + r)) {
-                cell.set_bg(theme.chip_bg);
+                let style = cell
+                    .style()
+                    .patch(Style::default().fg(theme.brand).bg(theme.chip_bg));
+                cell.set_style(style);
             }
         }
     }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -376,6 +376,9 @@ pub fn draw(f: &mut Frame, app: &mut App) {
         // Hover/cursor preview for inline [image n] chips sits above the
         // composer (drawn last so it tops the menu-free chat area).
         draw_attachment_preview(f, app, composer, area);
+        // Mouse tooltips for the cap-row composer buttons (⛶ / ⌕) ride the
+        // same late pass — above the composer, under the modal overlays.
+        draw_composer_button_tooltip(f, app, area);
     }
     draw_model_picker(f, app, area);
     draw_plugin_tree(f, app, area);
@@ -2799,6 +2802,81 @@ fn paint_composer_buttons(f: &mut Frame, app: &mut App) {
         theme.caption
     };
     b.set_string(x, rect.y, "⛶", Style::default().fg(tone));
+}
+
+/// Mouse tooltip for the composer cap-row buttons (⛶ expand of issue #92,
+/// ⌕ prompt jump of issue #103): while the pointer rests on a glyph, a
+/// small rounded card above it explains the click action — the only
+/// discoverability affordance for these mouse-only buttons. Drawn after
+/// the composer and chat, but before the modal overlays, so a popup that
+/// overlaps the card simply tops it.
+fn draw_composer_button_tooltip(f: &mut Frame, app: &App, screen: Rect) {
+    let theme = app.theme;
+    let (glyph, rect, desc) = if app.hover_prompt_jump_btn {
+        let Some(rect) = app.prompt_jump_btn else {
+            return;
+        };
+        (
+            "⌕",
+            rect,
+            app.locale
+                .tr(
+                    "jump to the previous user prompt",
+                    "跳转到上一条用户输入",
+                )
+                .to_string(),
+        )
+    } else if app.hover_expand_btn {
+        let Some(rect) = app.expand_btn else {
+            return;
+        };
+        let (en, zh) = if app.input_expanded {
+            ("collapse the input well", "收起输入区")
+        } else {
+            ("expand the input well", "展开输入区")
+        };
+        ("⛶", rect, app.locale.tr(en, zh).to_string())
+    } else {
+        return;
+    };
+    let content = format!(" {glyph} {desc} ");
+    // The card hugs the glyph column: centered on it, one rounded border
+    // row of padding on each side, capped by the screen.
+    let inner_w = content.width().min(screen.width.saturating_sub(4).max(4) as usize);
+    let w = (inner_w + 2) as u16;
+    let h: u16 = 3;
+    if screen.width < w + 2 || rect.y < h {
+        return;
+    }
+    let cx = rect.x + 1; // both glyphs sit one cell in from their rect
+    let x = cx
+        .saturating_sub(w / 2)
+        .clamp(screen.x + 1, screen.right().saturating_sub(w + 1));
+    let y = rect.y - h;
+    let area = Rect::new(x, y, w, h);
+    f.render_widget(Clear, area);
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .border_style(Style::default().fg(theme.border))
+        .style(Style::default().bg(theme.panel));
+    let inner = block.inner(area);
+    f.render_widget(block, area);
+    f.render_widget(
+        Paragraph::new(Line::from(vec![
+            Span::styled(
+                format!(" {glyph} "),
+                Style::default()
+                    .fg(theme.brand)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(
+                ellipsize_to(&desc, inner.width.saturating_sub(3) as usize),
+                Style::default().fg(theme.fg_secondary),
+            ),
+        ])),
+        inner,
+    );
 }
 
 /// The input well. Long prompts wrap across the (now taller) well, and the

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -167,6 +167,7 @@ pub fn draw(f: &mut Frame, app: &mut App) {
     // prompt-jump button rect rides the same layout pass.
     app.expand_btn = None;
     app.prompt_jump_btn = None;
+    app.prompt_flash_lines = None;
     f.render_widget(
         Block::default().style(
             Style::default()
@@ -2252,6 +2253,15 @@ fn draw_chat(f: &mut Frame, app: &mut App, area: Rect) {
         .map(|l| l.spans.iter().map(|s| s.content.as_ref()).collect())
         .collect();
     app.chat_view.owners = owners;
+    // The ⌕ jump flash (issue #103): resolve the flashing transcript cell
+    // to its current line span every frame — streaming can move the prompt
+    // — and drop it once the 5 s window expired.
+    app.prompt_flash_lines = app
+        .prompt_flash
+        .as_ref()
+        .filter(|(_, until)| std::time::Instant::now() < *until)
+        .and_then(|(cell, _)| layout.users.iter().find(|p| p.cell == *cell))
+        .map(|prompt| (prompt.line, prompt.end));
 
     // Visible image thumbnails → screen rects (banner lines shift transcript
     // line indices; partially visible thumbnails clip to the pane).
@@ -2278,10 +2288,44 @@ fn draw_chat(f: &mut Frame, app: &mut App, area: Rect) {
         .collect();
 
     f.render_widget(Paragraph::new(visible), inner);
+    // The transient ⌕ jump wash paints under an active copy-selection so
+    // the user's own highlight always wins.
+    draw_prompt_flash(f, app, inner, start);
     draw_selection_overlay(f, app, inner, start);
     // Last: the selection overlay above also writes these cells, so the
     // full-rewrite marker must run after it (issue #38).
     force_full_rewrite(f, inner);
+}
+
+/// The transient `⌕` jump highlight (issue #103): right after a jump the
+/// jumped prompt's rows carry a soft background wash — the same chip tone
+/// the pickers use for the selected row — for ~5 seconds, then the
+/// ordinary bubble look returns (the expiry lives in `App::tick`, which
+/// clears the state and requests a repaint).
+fn draw_prompt_flash(f: &mut Frame, app: &App, inner: Rect, start: usize) {
+    let Some((s, e)) = app.prompt_flash_lines else {
+        return;
+    };
+    let theme = app.theme;
+    let buf = f.buffer_mut();
+    for r in 0..inner.height {
+        let li = start + r as usize;
+        if li < s || li >= e {
+            continue;
+        }
+        let Some(text) = app.chat_view.lines.get(li) else {
+            continue;
+        };
+        let lw = text.trim_end().width();
+        if lw == 0 {
+            continue;
+        }
+        for c in 0..lw.min(inner.width as usize) {
+            if let Some(cell) = buf.cell_mut((inner.x + c as u16, inner.y + r)) {
+                cell.set_bg(theme.chip_bg);
+            }
+        }
+    }
 }
 
 /// Paint the in-app mouse selection as reversed cells — the live highlight

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -163,8 +163,10 @@ pub fn draw(f: &mut Frame, app: &mut App) {
     app.caret_cell = None;
     // The mouse-only expand button's frame rect is rebuilt by
     // `layout_expand_btn`; clear it first so a child view (or a frame where
-    // the card vanished) cannot keep a stale hit-test rect alive.
+    // the card vanished) cannot keep a stale hit-test rect alive. The ⌕
+    // prompt-jump button rect rides the same layout pass.
     app.expand_btn = None;
+    app.prompt_jump_btn = None;
     f.render_widget(
         Block::default().style(
             Style::default()
@@ -1587,9 +1589,10 @@ fn draw_composer(f: &mut Frame, app: &mut App, area: Rect, pet_pad: u16, navigat
         app,
         Rect::new(inner.x, inner.y + inner.height - 1, inner.width, 1),
     );
-    // The mouse-only expand button sits on the card's top row, outside the
-    // well; painted last so no text render can paint over it (issue #92).
-    paint_expand_btn(f, app);
+    // The mouse-only composer buttons sit on the card's top row, outside
+    // the well; painted last so no text render can paint over them (issue
+    // #92 / ⌕ of issue #103).
+    paint_composer_buttons(f, app);
 }
 
 /// Meta row: run state + mode/permission chips left, model right,
@@ -2466,11 +2469,14 @@ fn draw_composer_box(
 ) {
     let theme = app.theme;
     let has_input_dock = slot_has_nodes(app, "conversation.input.dock");
-    // Leave the cap row's top-right corner to the mouse-only expand glyph:
-    // the workspace title ends three cells early, so the `⛶` (and its
-    // hovered chip block) never covers title text (issue #92).
+    // Leave the cap row's top-right corner to the mouse-only composer
+    // buttons: the workspace title ends four cells early, so the `⌕`
+    // prompt-jump glyph (issue #103) and the `⛶` expand glyph (issue #92)
+    // — with a space between them — never cover title text.
     let mut workspace = workspace_cap_title(app, area.width as usize);
-    workspace.spans.push(Span::raw(" ".repeat(EXPAND_BTN_W as usize)));
+    workspace
+        .spans
+        .push(Span::raw(" ".repeat(EXPAND_BTN_W as usize + 1)));
     let workspace_width = span_widths(&workspace.spans);
     let title_budget = (area.width as usize).saturating_sub(2 + workspace_width + 1);
     let dock_sections = has_input_dock
@@ -2555,10 +2561,10 @@ fn draw_composer_box(
     app.att_thumbs.clear();
     app.composer_wrap_width = input.width.saturating_sub("❯ ".width() as u16).max(1) as usize;
     draw_input(f, app, input);
-    // The mouse-only expand button sits on the card's top border (the cap
-    // row), outside the well — a full draft never hides it. Painted last
-    // so nothing can paint over it (issue #92).
-    paint_expand_btn(f, app);
+    // The mouse-only composer buttons sit on the card's top border (the cap
+    // row), outside the well — a full draft never hides them. Painted last
+    // so nothing can paint over them (issue #92 / ⌕ of issue #103).
+    paint_composer_buttons(f, app);
 }
 
 /// grok-style hover preview: when the pointer rests on an inline chip (or
@@ -2666,22 +2672,29 @@ fn paint_caret(f: &mut Frame, x: u16, y: u16) {
     }
 }
 
-/// Mouse-only composer expand/collapse button (issue #92): a `⛶` glyph on
-/// the composer card's top-right frame border — outside the text well, so
-/// a full draft never hides it. Always visible; hovering (no key binding)
-/// highlights it; clicking pins the well to the amplified height or
-/// restores the draft-following auto height.
+/// Mouse-only composer buttons on the cap row's top-right (issue #92 / the
+/// ⌕ prompt jump of issue #103): the `⛶` expand/collapse glyph and, one
+/// cell left of it, the `⌕` user-prompt jump glyph — both on the card's top
+/// border, outside the text well. Always visible; hovering (no key binding)
+/// highlights them; clicking pins/restores the well height or walks the
+/// user prompts.
 const EXPAND_BTN_W: u16 = 3;
 const EXPAND_BTN_H: u16 = 1;
 const EXPAND_BTN_MARGIN: u16 = 1;
+/// The ⌕ prompt-jump button is 2 cells wide (glyph + one margin), tucked
+/// directly left of the expand button's hit rect.
+const JUMP_BTN_W: u16 = 2;
 
 /// Record the expand button's screen rect for hit-testing. `cap` is the
 /// composer's top row: the rounded card's cap line (boxed layout) or the
 /// well's first row (short-terminal fallback). Runs every frame, so the
-/// pointer can discover the glyph before hovering it.
+/// pointer can discover the glyph before hovering it. The ⌕ jump button
+/// rect (issue #103) is recorded in the same pass, one cell left of the
+/// expand glyph.
 fn layout_expand_btn(app: &mut App, cap: Rect) {
     if cap.width < EXPAND_BTN_W + EXPAND_BTN_MARGIN + 1 {
         app.expand_btn = None;
+        app.prompt_jump_btn = None;
         return;
     }
     let x = cap
@@ -2689,24 +2702,47 @@ fn layout_expand_btn(app: &mut App, cap: Rect) {
         .saturating_add(cap.width)
         .saturating_sub(EXPAND_BTN_W + EXPAND_BTN_MARGIN);
     app.expand_btn = Some(Rect::new(x, cap.y, EXPAND_BTN_W, EXPAND_BTN_H));
+    // The jump glyph occupies the cell left of the expand rect (the cap
+    // title leaves both cells free); hide it on caps too narrow to fit.
+    app.prompt_jump_btn = if x >= cap.x.saturating_add(JUMP_BTN_W) {
+        Some(Rect::new(x - JUMP_BTN_W, cap.y, JUMP_BTN_W, EXPAND_BTN_H))
+    } else {
+        None
+    };
 }
 
-/// Paint the expand glyph. Idle: `⛶` in the quiet caption tone on the
-/// card's top-right (the workspace title leaves this corner free).
-/// Hovered: the glyph brightens to the strongest foreground — no BOLD,
-/// which terminals synthesize by widening the glyph and clip at the cell
-/// edge (the right corner would vanish), and no background chip; the
-/// brightness shift alone is the hover affordance. Called after the card
-/// render so it always wins the pixels.
-fn paint_expand_btn(f: &mut Frame, app: &mut App) {
+/// Paint the composer cap-row glyphs — `⌕` (prompt jump, issue #103) left
+/// of `⛶` (expand/collapse, issue #92). Idle: quiet caption tone. Hovered:
+/// the glyph brightens to the strongest foreground — no BOLD, which
+/// terminals synthesize by widening the glyph and clip at the cell edge
+/// (the right corner would vanish), and no background chip; the brightness
+/// shift alone is the hover affordance. Called after the card render so it
+/// always wins the pixels.
+fn paint_composer_buttons(f: &mut Frame, app: &mut App) {
+    let theme = app.theme;
+    let b = f.buffer_mut();
+    if let Some(rect) = app.prompt_jump_btn {
+        if rect.width >= JUMP_BTN_W && rect.height >= EXPAND_BTN_H {
+            let tone = if app.hover_prompt_jump_btn {
+                theme.fg
+            } else {
+                theme.caption
+            };
+            // Glyph = the rect's rightmost cell, one cell left of the ⛶.
+            b.set_string(
+                rect.x.saturating_add(rect.width).saturating_sub(1),
+                rect.y,
+                "⌕",
+                Style::default().fg(tone),
+            );
+        }
+    }
     let Some(rect) = app.expand_btn else {
         return;
     };
     if rect.width < EXPAND_BTN_W || rect.height < EXPAND_BTN_H {
         return;
     }
-    let theme = app.theme;
-    let b = f.buffer_mut();
     // The glyph sits one cell in from the card's corner: rightmost cell of
     // the rect minus one, so the corner `╮` stays visible beside it.
     let x = rect.x + rect.width - 2;

--- a/tests/unit/app__mode_tests.rs
+++ b/tests/unit/app__mode_tests.rs
@@ -1364,10 +1364,19 @@ fn prompt_jump_walks_user_prompts_newest_first_and_wraps() {
 
     // First click → newest prompt; each next click walks one prompt back;
     // the oldest wraps to the newest again. Every jump scrolls the chat so
-    // the prompt's first line anchors the viewport.
+    // the prompt's first line anchors the viewport, and flashes the
+    // jumped prompt for a few seconds (issue #103).
     for expected in [users[3], users[2], users[1], users[0], users[3]] {
         click_prompt_jump(&mut app, &ctl);
         assert_eq!(app.prompt_jump_cell, Some(expected), "jump cursor");
+        let (flash_cell, until) = app
+            .prompt_flash
+            .expect("the jumped prompt flashes");
+        assert_eq!(flash_cell, expected, "flash follows the jump");
+        assert!(
+            until > std::time::Instant::now(),
+            "flash expires in the future"
+        );
         let anchor = prompt_jump_anchor(&mut app, expected);
         let _ = crate::ui::dump_frame(&mut app, 100, 30);
         assert_eq!(
@@ -1376,6 +1385,17 @@ fn prompt_jump_walks_user_prompts_newest_first_and_wraps() {
         );
         assert!(app.scroll_up > 0, "the jump leaves the tail");
     }
+
+    // The flash restores to normal on its own: after the 5 s window the
+    // next tick clears it and requests a repaint.
+    let (cell, _) = app.prompt_flash.expect("flash still armed");
+    app.prompt_flash = Some((
+        cell,
+        std::time::Instant::now() - crate::app::PROMPT_FLASH_TTL,
+    ));
+    app.tick();
+    assert!(app.prompt_flash.is_none(), "expired flash clears on tick");
+    assert!(app.needs_redraw, "expiry requests a repaint");
 }
 
 #[test]

--- a/tests/unit/app__mode_tests.rs
+++ b/tests/unit/app__mode_tests.rs
@@ -1292,6 +1292,105 @@ fn live_acp_new_parks_the_current_session_and_binds_the_new_tab() {
     assert_eq!(app.parked[0].id, before, "the parked session keeps its id");
 }
 
+/// Seed `n` user prompts, each followed by enough filler so the transcript
+/// outgrows any test viewport; returns the transcript cell index of each
+/// user prompt (oldest first).
+fn seed_prompt_history(app: &mut App, n: usize) -> Vec<usize> {
+    for i in 1..=n {
+        app.transcript.push_user(format!("user prompt {i}"), false);
+        for j in 0..30 {
+            app.transcript.push_notice(
+                crate::transcript::NoticeLevel::Info,
+                format!("filler {i}-{j} {}", "x".repeat(160)),
+            );
+        }
+    }
+    app.transcript
+        .cells
+        .iter()
+        .enumerate()
+        .filter(|(_, cell)| matches!(cell.kind, crate::transcript::CellKind::User { .. }))
+        .map(|(idx, _)| idx)
+        .collect()
+}
+
+/// The first line the `⌕` jump anchors for `cell`, mirroring
+/// `App::jump_to_user_prompt` (layout at the recorded chat width).
+fn prompt_jump_anchor(app: &mut App, cell: usize) -> usize {
+    let area = app.chat_view.area;
+    let theme = app.theme;
+    let spinner = app.spinner();
+    let layout = app.transcript.layout(
+        &theme,
+        area.width,
+        spinner,
+        crate::pet::kitty_supported(),
+    );
+    let line = layout
+        .users
+        .iter()
+        .find(|prompt| prompt.cell == cell)
+        .expect("seeded prompt laid out")
+        .line;
+    line.min(layout.lines.len().saturating_sub(area.height as usize))
+}
+
+/// Left-click the `⌕` button recorded by the last frame.
+fn click_prompt_jump(app: &mut App, ctl: &Controller) {
+    let jump = app.prompt_jump_btn.expect("⌕ button rect recorded");
+    app.handle_mouse(
+        crossterm::event::MouseEvent {
+            kind: crossterm::event::MouseEventKind::Down(
+                crossterm::event::MouseButton::Left,
+            ),
+            column: jump.x + 1,
+            row: jump.y,
+            modifiers: KeyModifiers::NONE,
+        },
+        ctl,
+    );
+}
+
+#[test]
+fn prompt_jump_walks_user_prompts_newest_first_and_wraps() {
+    let (mut app, ctl, _rx) = test_app();
+    app.show_banner = false;
+    let users = seed_prompt_history(&mut app, 4);
+    let _ = crate::ui::dump_frame(&mut app, 100, 30);
+    assert!(
+        app.chat_view.area.height > 0 && app.chat_view.area.width > 0,
+        "first frame records the chat area"
+    );
+
+    // First click → newest prompt; each next click walks one prompt back;
+    // the oldest wraps to the newest again. Every jump scrolls the chat so
+    // the prompt's first line anchors the viewport.
+    for expected in [users[3], users[2], users[1], users[0], users[3]] {
+        click_prompt_jump(&mut app, &ctl);
+        assert_eq!(app.prompt_jump_cell, Some(expected), "jump cursor");
+        let anchor = prompt_jump_anchor(&mut app, expected);
+        let _ = crate::ui::dump_frame(&mut app, 100, 30);
+        assert_eq!(
+            app.chat_view.top, anchor,
+            "view anchors the first line of the jumped prompt"
+        );
+        assert!(app.scroll_up > 0, "the jump leaves the tail");
+    }
+}
+
+#[test]
+fn prompt_jump_without_user_prompts_tips_instead_of_jumping() {
+    let (mut app, ctl, _rx) = test_app();
+    app.show_banner = false;
+    let _ = crate::ui::dump_frame(&mut app, 100, 30);
+
+    click_prompt_jump(&mut app, &ctl);
+
+    assert!(app.prompt_jump_cell.is_none());
+    assert!(app.tip.is_some(), "no prompts → a tip explains ⌕");
+    assert_eq!(app.chat_view.top, 0, "no jump happened");
+}
+
 #[test]
 fn agent_preset_event_updates_chrome_without_adding_a_transcript_row() {
     let (mut app, _ctl, _rx) = test_app();

--- a/tests/unit/ui__tests.rs
+++ b/tests/unit/ui__tests.rs
@@ -3233,3 +3233,53 @@ fn expand_button_survives_a_full_draft() {
     // The well rows themselves carry no button glyph.
     assert_ne!(buf[(btn.x + 2, app.input_area.y)].symbol(), "⛶");
 }
+
+/// The ⌕ user-prompt jump button (issue #103) renders between the project
+/// path and the ⛶ expand glyph — spaces on both sides — and hovers the
+/// same way: quiet caption tone idle, brightest foreground on hover.
+#[test]
+fn prompt_jump_button_sits_between_path_and_expand_and_hovers() {
+    use ratatui::backend::TestBackend;
+    use ratatui::Terminal;
+    let mut app = test_app();
+    app.show_banner = false;
+    let (ctl, _commands) = crate::controller::tests::test_controller();
+    let backend = TestBackend::new(100, 34);
+    let mut terminal = Terminal::new(backend).expect("test terminal");
+    terminal.draw(|f| draw(f, &mut app)).expect("draw frame");
+    let buf = terminal.backend().buffer().clone();
+    let theme = app.theme;
+    let expand = app.expand_btn.expect("expand rect");
+    let jump = app.prompt_jump_btn.expect("jump rect");
+
+    // Geometry: ⌕ (space) ⛶ (space) ╮ — the jump glyph one cell left of
+    // the expand glyph with a space in between, and a space before it.
+    assert_eq!(jump.y, expand.y, "both buttons share the cap row");
+    assert_eq!(jump.x + jump.width, expand.x, "jump rect tucked left of expand");
+    assert_eq!(buf[(jump.x + 1, jump.y)].symbol(), "⌕");
+    assert_eq!(buf[(expand.x - 2, expand.y)].symbol(), " ", "space before ⌕");
+    assert_eq!(buf[(expand.x, expand.y)].symbol(), " ", "space between ⌕ and ⛶");
+    assert_eq!(buf[(expand.x + 1, expand.y)].symbol(), "⛶");
+    assert_eq!(buf[(jump.x + 1, jump.y)].fg, theme.caption, "idle tone");
+
+    // Hover brightens the ⌕ glyph.
+    app.handle_mouse(mouse(MouseEventKind::Moved, jump.x + 1, jump.y), &ctl);
+    assert!(app.hover_prompt_jump_btn);
+    terminal.draw(|f| draw(f, &mut app)).expect("draw frame");
+    let buf = terminal.backend().buffer().clone();
+    assert_eq!(
+        buf[(jump.x + 1, jump.y)].fg,
+        theme.fg,
+        "hover brightens the ⌕ glyph"
+    );
+    // Leaving restores the quiet glyph.
+    app.handle_mouse(mouse(MouseEventKind::Moved, 5, 5), &ctl);
+    assert!(!app.hover_prompt_jump_btn);
+    terminal.draw(|f| draw(f, &mut app)).expect("draw frame");
+    let buf = terminal.backend().buffer().clone();
+    assert_eq!(
+        buf[(jump.x + 1, jump.y)].fg,
+        theme.caption,
+        "idle tone restored when the pointer leaves"
+    );
+}

--- a/tests/unit/ui__tests.rs
+++ b/tests/unit/ui__tests.rs
@@ -2070,7 +2070,8 @@ fn model_picker_marks_only_the_current_provider_model_pair() {
 }
 
 /// The ⌕ jump flash (issue #103): for ~5 s after a jump the jumped
-/// prompt's bubble rows carry the chip background wash; after the window
+/// prompt's bubble rows are highlighted like a picker's selected row —
+/// chip background wash and the text in the brand tone; after the window
 /// the next tick clears it and the next frame restores the normal bubble.
 #[test]
 fn prompt_jump_flash_washes_the_jumped_prompt_then_restores() {
@@ -2111,12 +2112,14 @@ fn prompt_jump_flash_washes_the_jumped_prompt_then_restores() {
     let (bx, by) = text_cell(terminal.backend().buffer(), "beta prompt")
         .expect("beta prompt rendered");
 
-    // Frame 1, no flash: the bubble keeps its normal background.
+    // Frame 1, no flash: the bubble keeps its normal colors.
     let buf = terminal.backend().buffer().clone();
     assert_eq!(buf[(bx, by)].bg, theme.bubble_bg, "idle bubble background");
+    assert_eq!(buf[(bx, by)].fg, theme.bubble_fg, "idle bubble text");
 
-    // Arm the flash for the second prompt and redraw: its rows wash with
-    // the chip tone while other rows stay untouched.
+    // Arm the flash for the second prompt and redraw: its rows carry the
+    // chip wash with the text in the brand tone, while the other prompt
+    // stays untouched.
     app.prompt_flash = Some((
         beta_cell,
         std::time::Instant::now() + crate::app::PROMPT_FLASH_TTL,
@@ -2124,11 +2127,16 @@ fn prompt_jump_flash_washes_the_jumped_prompt_then_restores() {
     terminal.draw(|f| draw(f, &mut app)).expect("draw frame");
     let buf = terminal.backend().buffer().clone();
     assert_eq!(buf[(bx, by)].bg, theme.chip_bg, "jumped prompt washed");
+    assert_eq!(buf[(bx, by)].fg, theme.brand, "jumped prompt text brand");
     let (ax, ay) = text_cell(terminal.backend().buffer(), "alpha prompt")
         .expect("alpha prompt rendered");
     assert_ne!(
         buf[(ax, ay)].bg, theme.chip_bg,
         "the other prompt keeps its background"
+    );
+    assert_ne!(
+        buf[(ax, ay)].fg, theme.brand,
+        "the other prompt keeps its text color"
     );
 
     // Expire the flash: the tick clears it and the next frame restores the
@@ -2143,7 +2151,11 @@ fn prompt_jump_flash_washes_the_jumped_prompt_then_restores() {
     let buf = terminal.backend().buffer().clone();
     assert_eq!(
         buf[(bx, by)].bg, theme.bubble_bg,
-        "flash restored the normal bubble"
+        "flash restored the normal bubble background"
+    );
+    assert_eq!(
+        buf[(bx, by)].fg, theme.bubble_fg,
+        "flash restored the normal bubble text"
     );
 }
 

--- a/tests/unit/ui__tests.rs
+++ b/tests/unit/ui__tests.rs
@@ -3373,3 +3373,74 @@ fn prompt_jump_button_sits_between_path_and_expand_and_hovers() {
         "idle tone restored when the pointer leaves"
     );
 }
+
+/// Hovering the composer cap-row buttons (⛶ of issue #92, ⌕ of issue #103)
+/// pops a tooltip card above the glyph explaining the click — the only
+/// discoverability affordance for these mouse-only buttons; leaving the
+/// button removes the card.
+#[test]
+fn composer_button_hover_pops_a_tooltip_card() {
+    use ratatui::backend::TestBackend;
+    use ratatui::Terminal;
+    let mut app = test_app();
+    app.show_banner = false;
+    let (ctl, _commands) = crate::controller::tests::test_controller();
+    let backend = TestBackend::new(100, 34);
+    let mut terminal = Terminal::new(backend).expect("test terminal");
+    terminal.draw(|f| draw(f, &mut app)).expect("draw frame");
+    let expand = app.expand_btn.expect("expand rect");
+    let jump = app.prompt_jump_btn.expect("jump rect");
+
+    let rows = |buf: &ratatui::buffer::Buffer| -> Vec<String> {
+        (0..buf.area.height)
+            .map(|y| {
+                (0..buf.area.width)
+                    .map(|x| buf[(x, y)].symbol().chars().next().unwrap_or(' '))
+                    .collect::<String>()
+            })
+            .collect()
+    };
+
+    // No hover: no tooltip text anywhere on screen.
+    let buf = terminal.backend().buffer().clone();
+    let idle = rows(&buf);
+    assert!(
+        idle.iter().all(|r| !r.contains("user prompt") && !r.contains("input well")),
+        "no tooltip without hover"
+    );
+
+    // Hover ⌕: the card appears above the glyph with the jump description.
+    app.handle_mouse(mouse(MouseEventKind::Moved, jump.x + 1, jump.y), &ctl);
+    terminal.draw(|f| draw(f, &mut app)).expect("draw frame");
+    let buf = terminal.backend().buffer().clone();
+    let rs = rows(&buf);
+    let jump_tip = rs
+        .iter()
+        .position(|r| r.contains("previous user prompt"))
+        .expect("⌕ tooltip shown");
+    assert!(jump_tip < jump.y as usize, "tooltip card sits above the ⌕ glyph");
+    assert!(rs[jump_tip].contains('⌕'), "card leads with the ⌕ glyph");
+
+    // Hover ⛶: the card switches to the expand/collapse description.
+    app.handle_mouse(mouse(MouseEventKind::Moved, expand.x + 1, expand.y), &ctl);
+    terminal.draw(|f| draw(f, &mut app)).expect("draw frame");
+    let buf = terminal.backend().buffer().clone();
+    let rs = rows(&buf);
+    let expand_tip = rs
+        .iter()
+        .position(|r| r.contains("expand the input well"))
+        .expect("⛶ tooltip shown");
+    assert!(expand_tip < expand.y as usize, "tooltip card sits above the ⛶ glyph");
+    assert!(rs[expand_tip].contains('⛶'), "card leads with the ⛶ glyph");
+
+    // Leaving the button removes the card again.
+    app.handle_mouse(mouse(MouseEventKind::Moved, 5, 5), &ctl);
+    terminal.draw(|f| draw(f, &mut app)).expect("draw frame");
+    let buf = terminal.backend().buffer().clone();
+    assert!(
+        rows(&buf)
+            .iter()
+            .all(|r| !r.contains("user prompt") && !r.contains("input well")),
+        "tooltip gone once the pointer leaves"
+    );
+}

--- a/tests/unit/ui__tests.rs
+++ b/tests/unit/ui__tests.rs
@@ -2069,6 +2069,84 @@ fn model_picker_marks_only_the_current_provider_model_pair() {
     );
 }
 
+/// The ⌕ jump flash (issue #103): for ~5 s after a jump the jumped
+/// prompt's bubble rows carry the chip background wash; after the window
+/// the next tick clears it and the next frame restores the normal bubble.
+#[test]
+fn prompt_jump_flash_washes_the_jumped_prompt_then_restores() {
+    use ratatui::backend::TestBackend;
+    use ratatui::Terminal;
+    let mut app = test_app();
+    app.show_banner = false;
+    app.transcript.push_user("alpha prompt".into(), false);
+    app.transcript.push_notice(
+        crate::transcript::NoticeLevel::Info,
+        "filler row".into(),
+    );
+    app.transcript.push_user("beta prompt".into(), false);
+    let beta_cell = app
+        .transcript
+        .cells
+        .iter()
+        .rposition(|cell| matches!(cell.kind, crate::transcript::CellKind::User { .. }))
+        .expect("second user prompt");
+
+    // Locate the first cell of an ASCII needle in the rendered buffer.
+    let text_cell = |buf: &ratatui::buffer::Buffer, needle: &str| -> Option<(u16, u16)> {
+        for y in 0..buf.area.height {
+            let row: String = (0..buf.area.width)
+                .map(|x| buf[(x, y)].symbol().chars().next().unwrap_or(' '))
+                .collect();
+            if let Some(x) = row.find(needle) {
+                return Some((x as u16, y as u16));
+            }
+        }
+        None
+    };
+
+    let backend = TestBackend::new(100, 30);
+    let mut terminal = Terminal::new(backend).expect("test terminal");
+    let theme = app.theme;
+    terminal.draw(|f| draw(f, &mut app)).expect("draw frame");
+    let (bx, by) = text_cell(terminal.backend().buffer(), "beta prompt")
+        .expect("beta prompt rendered");
+
+    // Frame 1, no flash: the bubble keeps its normal background.
+    let buf = terminal.backend().buffer().clone();
+    assert_eq!(buf[(bx, by)].bg, theme.bubble_bg, "idle bubble background");
+
+    // Arm the flash for the second prompt and redraw: its rows wash with
+    // the chip tone while other rows stay untouched.
+    app.prompt_flash = Some((
+        beta_cell,
+        std::time::Instant::now() + crate::app::PROMPT_FLASH_TTL,
+    ));
+    terminal.draw(|f| draw(f, &mut app)).expect("draw frame");
+    let buf = terminal.backend().buffer().clone();
+    assert_eq!(buf[(bx, by)].bg, theme.chip_bg, "jumped prompt washed");
+    let (ax, ay) = text_cell(terminal.backend().buffer(), "alpha prompt")
+        .expect("alpha prompt rendered");
+    assert_ne!(
+        buf[(ax, ay)].bg, theme.chip_bg,
+        "the other prompt keeps its background"
+    );
+
+    // Expire the flash: the tick clears it and the next frame restores the
+    // ordinary bubble look.
+    app.prompt_flash = Some((
+        beta_cell,
+        std::time::Instant::now() - crate::app::PROMPT_FLASH_TTL,
+    ));
+    app.tick();
+    assert!(app.prompt_flash.is_none(), "tick cleared the expired flash");
+    terminal.draw(|f| draw(f, &mut app)).expect("draw frame");
+    let buf = terminal.backend().buffer().clone();
+    assert_eq!(
+        buf[(bx, by)].bg, theme.bubble_bg,
+        "flash restored the normal bubble"
+    );
+}
+
 #[test]
 fn model_picker_marks_the_streamed_model_when_it_differs_from_config() {
     use crate::app::{Picker, PickerItem, PickerKind};


### PR DESCRIPTION
## 解决 #103：每条用户输入的 prompt 都能在 UI 上快速跳转

在 Composer 区 project path 与 ⛶ 之间新增了一个 `⌕` 按钮（前后各留空格），鼠标移上去高亮（与 ⛶ 相同的 hover 策略：静止为 caption 色调，悬停提亮到最强前景色），点击即在会话历史中跳转用户输入。

### 行为
- 第一次点击 → 跳转到**最新**的 User prompt；
- 继续点击 → 依次**往前（更早）**的 User prompt 跳转；
- 到最前面的 prompt 后再点 → **回到最新**；
- 程序只**在内存里记录**最后一次跳转的 transcript cell（不持久化；切换 tab 时重置），所以下一次点击从上次停下的位置继续往前；
- 跳转把该 prompt 的第一行锚定到聊天区顶部（内容不足一屏时自然钳制到尾部）；文字 prompt 与图片气泡（`🖼`）都算用户输入；
- 无用户输入时点击给出提示 tip；cap 行 tip 会显示当前位置（`user prompt k/n · newest first` / `用户输入 k/n · 从最新往前`）。

### 实现要点
- `TranscriptLayout` 新增 `users: Vec<UserPromptLine>`：layout 时记录每个 User/Image 气泡 cell 及其首行文本行号（供跳转锚定，与渲染同一份布局，保证行号一致）。
- App 新增 `prompt_jump_btn` / `hover_prompt_jump_btn` / `prompt_jump_cell` 状态；`jump_to_user_prompt()` 负责行走与滚动锚定；鼠标 Down/Moved 分支与 ⛶ 对称接入（点击优先级位于文本选区之前）。
- ui.rs 把原先的 `layout_expand_btn`/`paint_expand_btn` 扩展为两个按钮同排布局/绘制：`⌕` 紧贴 ⛶ 左侧一个空格，cap 标题预留空间从 3 格增加到 4 格，标题文字不会被覆盖；窄终端自动隐藏 `⌕`。

### 验证
- `cargo test --locked`：676 passed（新增 3 个测试：按钮几何 + hover 高亮、⌕ 行走/回绕 + 视口锚定、无 prompt 时提示）
- `cargo check --locked --tests`：通过
- `martty --dump-frame`（100x34 / 60x18 / 100x10 / 60x7）渲染检查：cap 行显示 `…path ⌕ ⛶ ╮`，各宽度正常