### PR TITLE
fix(tui): code-review sweep — correctness, protocol, rendering, packaging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,84 @@ All notable changes to this project are documented here. The project follows
 
 ### Fixed
 
+- Code-review sweep (2026-09-03):
+
+  - **Terminal output integrity** — `terminal/output` no longer corrupts
+    multi-byte characters split across 4096-byte reads: partial UTF-8
+    sequences are carried across chunks instead of being decoded per read
+    into U+FFFD. Unknown terminal ids now return protocol errors for
+    `output`/`wait`/`kill`/`release` instead of a fake success.
+  - **Terminal Auth keystrokes** — the crossterm input reader parks during
+    Terminal Auth (and stays parked until the auth subprocess exits), so
+    the login child no longer loses keystrokes to the UI reader.
+  - **Background tab errors** — a failed image prompt (no image support,
+    spill failure, empty payload) now reports through the requesting
+    session, so a parked tab's running badge can no longer stick forever
+    while the error lands on the viewed tab. `PromptQueued` carries the
+    session id and only settles that session.
+  - **Persistent shell** — `!` commands run with stdin from `/dev/null` and
+    a 120-second silence deadline: a command that used to eat the control
+    stream (`!cat`) or hang silently now kills the shell and the next `!`
+    restarts it, instead of wedging the single shell worker forever.
+  - **Cross-tab bind state** — same-session `/resume` keeps a FIFO bind
+    entry (a concurrent `/new` can no longer steal the bind and cross-wire
+    tabs), and both resume paths release plugin overlays with their cancel
+    events like a tab click does, instead of leaking them onto the new
+    tab.
+  - **Modal keys** — vim mode only intercepts keys when no modal is up:
+    one Esc cancels a permission ask / picker / overlay while vim Insert
+    is active, and normal-mode letters no longer land in a hidden composer
+    under a modal.
+  - **ACP turn lifecycle** — in-flight prompts carry a generation tag so a
+    stale finish after `/close` + `/resume` can never clear the new turn's
+    occupancy marker (no more double `session/prompt` per session), and a
+    `session/cancel` racing an already-settling turn trusts the agent's
+    stop reason instead of reporting a successful turn as interrupted.
+  - **ACP robustness** — every request the command loop awaits gets a
+    120s deadline (a hung agent can no longer freeze Interrupt/Shutdown);
+    the queue/agents snapshots stay silent for agents that never
+    negotiated `_dsh/cordis`; second and later sessions now update the
+    mode catalog from their own `configOptions`; `file://` URIs are
+    percent-encoded (spaces, `#`, `?`, CJK paths); and `terminal/create`
+    asks through the permission overlay before running an agent-supplied
+    command.
+  - **Runtime writer deadlock** — the legacy transport's stdin writer is
+    taken out of the shared slot while a write blocks, so a wedged child
+    can no longer deadlock `kill()` or starve the frame reader; the
+    reader's best-effort replies never block on the write path.
+  - **Editing** — vim `O` lands the cursor on the new blank line above;
+    explicit range kills and chip deletion ignore an active shift
+    selection (an image chip can no longer survive as literal
+    `[image n]` text with its attachment removed); the form editor
+    deletes whole grapheme clusters and gives combining marks zero width;
+    plain ctrl+c (not ctrl+shift+c) cancels elicitation forms.
+  - **Transcript rendering** — `/clear` invalidates stale cell-index
+    handles (shell results and steer echoes can no longer leak into a
+    fresh transcript); 4+ backtick fences with literal ```` ``` ````
+    content render as one frame; the composer input dock measures at its
+    real width (pet inset included) so PLAN summaries are not truncated;
+    collapsed shell output keeps the tail like tool output; the
+    navigation rail trims its last section instead of overlapping the
+    trailing actions; user-node and injected-context wrap budgets use
+    display width; zero-width characters are consistent across the
+    markdown paths; and the chat pane's selection snapshot is
+    viewport-sized instead of cloning the whole scrollback every frame
+    (long streaming sessions no longer allocate O(history) text per
+    frame — hit-testing translates through the viewport anchor, and the
+    render window borrows the assembled lines instead of copying them).
+  - **npm packaging** — a corrupt `settings.json` no longer blocks boot
+    (it is moved aside and settings restart fresh) and theme preferences
+    are written atomically; `package-alias.mjs` skips `node_modules` and
+    the lockfile, asserts source/alias version parity, and tells you how
+    to replace a stale alias; `release.mjs` warns when a stale local
+    `npm-martty` checkout would publish an old version; the painter exit
+    path maps signals to 130/143/1 consistently, `MARTTY_BIN` falling
+    back is announced, spawn failures print a diagnostic; shell scripts
+    honor `CARGO_TARGET_DIR` in the local installer, tolerate `du`/`df`
+    failures, clean stale `dist/*.tgz`, and use `mktemp` for diagnostics;
+    the old-ACP install-matrix case skips when the registry is
+    unreachable.
+
 - The session tab strip now scrolls instead of cutting off: clicking the
   leftmost or rightmost visible tab switches to it **and** nudges the
   strip by one, so the adjacent tab appears — repeated edge clicks walk

--- a/npm/bin/martty.js
+++ b/npm/bin/martty.js
@@ -14,11 +14,19 @@ const vendorDir = path.join(__dirname, '..', 'vendor')
 const binaryName = process.platform === 'win32' ? 'martty.exe' : 'martty'
 const packaged = path.join(vendorDir, platformKey, binaryName)
 const configuredBin = process.env.MARTTY_BIN || process.env.DSH_TUI_BIN
-const binaryPath = typeof configuredBin === 'string'
-  && configuredBin.length > 0
-  && fs.existsSync(configuredBin)
-  ? configuredBin
-  : packaged
+let binaryPath = packaged
+if (typeof configuredBin === 'string' && configuredBin.length > 0) {
+  if (fs.existsSync(configuredBin)) {
+    binaryPath = configuredBin
+  } else {
+    // Never silently fall back: the user believes they are running their
+    // own build (devlocalinstall.sh has caught this confusion before).
+    console.error(
+      `martty: ${configuredBin} (from ${process.env.MARTTY_BIN ? 'MARTTY_BIN' : 'DSH_TUI_BIN'})`
+        + ' does not exist — falling back to the bundled binary',
+    )
+  }
+}
 
 const argv = process.argv.slice(2)
 const wantDemoSkin = argv.includes('--demo-skin')
@@ -74,9 +82,14 @@ if (!fs.existsSync(binaryPath)) {
 }
 
 function exitFromSpawn(result) {
+  if (result.error) {
+    // A failed spawn (ENOENT, EACCES) sets status/signal to null; without
+    // a diagnostic the process would just exit 1 with no explanation.
+    console.error('martty: failed to launch the native binary: ' + result.error.message)
+  }
   process.exit(
-    result.status ??
-      (result.signal === 'SIGINT' ? 130 : result.signal === 'SIGTERM' ? 143 : 1),
+    result.status
+      ?? (result.signal === 'SIGINT' ? 130 : result.signal === 'SIGTERM' ? 143 : 1),
   )
 }
 

--- a/npm/lib/acp-client.js
+++ b/npm/lib/acp-client.js
@@ -24,6 +24,14 @@ export const inject = []
 let liveAgent = null
 
 /**
+ * One kill-on-exit hook per process, replaced (not accumulated) whenever a
+ * new agent is spawned. Registering `process.once('exit', …)` per apply()
+ * would stack listeners and kill every past child again on exit.
+ * @type {null | (() => void)}
+ */
+let liveAgentExitHook = null
+
+/**
  * @typedef {{ command: string, args?: string[], env?: Record<string, string> }} AgentSpec
  */
 
@@ -115,13 +123,17 @@ export function apply(ctx, config = {}) {
   }
   liveAgent = service
   provide(ctx, service)
-  process.once('exit', () => {
+  if (liveAgentExitHook !== null) {
+    process.removeListener('exit', liveAgentExitHook)
+  }
+  liveAgentExitHook = () => {
     try {
       child.kill('SIGTERM')
     } catch {
       // already gone
     }
-  })
+  }
+  process.once('exit', liveAgentExitHook)
 }
 
 function provide(ctx, service) {

--- a/npm/lib/harnesses.js
+++ b/npm/lib/harnesses.js
@@ -28,12 +28,26 @@ function readSettings(settingsPath) {
   try {
     value = JSON.parse(readFileSync(settingsPath, 'utf8'))
   } catch (error) {
-    throw new Error(`invalid Martty settings: ${error.message}`)
+    // A corrupt settings file must never block boot (boot.js: "must not
+    // block boot"). Park the unreadable file for diagnosis and start
+    // over — the same resilience tui-theme/tui-presets apply.
+    quarantineSettings(settingsPath, `invalid Martty settings: ${error.message}`)
+    return {}
   }
   if (value === null || typeof value !== 'object' || Array.isArray(value)) {
-    throw new Error('invalid Martty settings: root must be an object')
+    quarantineSettings(settingsPath, 'invalid Martty settings: root must be an object')
+    return {}
   }
   return value
+}
+
+function quarantineSettings(settingsPath, reason) {
+  process.stderr.write(`martty: ${reason} — moving it aside and starting fresh\n`)
+  try {
+    renameSync(settingsPath, `${settingsPath}.corrupt-${Date.now()}`)
+  } catch {
+    // Best effort only; the fresh settings write below still proceeds.
+  }
 }
 
 function writeSettings(settingsPath, value) {

--- a/npm/lib/index.js
+++ b/npm/lib/index.js
@@ -180,7 +180,9 @@ export async function applyShell(ctx, options = {}) {
           if (!shouldQuitOnPainterExit(signal)) return
           shellState.refuseRespawn = true
           if (shellState.livePainter?.child === child) shellState.livePainter = null
-          process.exit(code ?? (signal === 'SIGINT' ? 130 : 0))
+          // Signal exits must not read as success: 130/143 match the
+          // bin/martty.js convention; any other signal is a failure.
+          process.exit(code ?? (signal === 'SIGINT' ? 130 : signal === 'SIGTERM' ? 143 : 1))
         })
         child.on('error', (err) => {
           console.error(`dsh-tui: ${err.message}`)

--- a/npm/lib/tui-theme.js
+++ b/npm/lib/tui-theme.js
@@ -7,7 +7,7 @@
  * flushed from `bindNotify`.
  */
 
-import { mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { mkdirSync, readFileSync, renameSync, writeFileSync } from 'node:fs'
 import { dirname, isAbsolute } from 'node:path'
 import { CORDIS_METHODS } from './cordis-protocol.js'
 
@@ -92,7 +92,12 @@ function writePreferred(settingsPath, id) {
   const settings = readSettings(settingsPath)
   settings.theme = id
   mkdirSync(dirname(settingsPath), { recursive: true })
-  writeFileSync(settingsPath, `${JSON.stringify(settings, null, 2)}\n`)
+  // Atomic write (temp + rename), matching harnesses.writeSettings: a
+  // crash mid-write must never leave a truncated settings.json behind —
+  // every later launch would otherwise start from an unreadable file.
+  const temporary = `${settingsPath}.${process.pid}.${Date.now()}.tmp`
+  writeFileSync(temporary, `${JSON.stringify(settings, null, 2)}\n`)
+  renameSync(temporary, settingsPath)
 }
 
 /**

--- a/scripts/build-npm.sh
+++ b/scripts/build-npm.sh
@@ -26,6 +26,9 @@ node scripts/package-native.mjs stage \
   --vendor-root npm/vendor
 
 mkdir -p dist
+# Stale tgz files from earlier builds make `ls | tail` report (and the
+# release flow pick up) the wrong artifact — clear them first.
+rm -f dist/*.tgz
 (cd npm && npm pack --pack-destination ../dist)
 
 echo "tgz written to: $(ls -1 dist/*.tgz | tail -n 1)"

--- a/scripts/cargo-guard.sh
+++ b/scripts/cargo-guard.sh
@@ -53,9 +53,18 @@ esac
 
 size_kib=0
 if [ -d "$target_dir" ]; then
+  # Fall back to 0 on failure (permissions, racing deletion) so the guard
+  # degrades to "skip the size check" instead of aborting the build with
+  # an "Illegal number" test error.
   size_kib=$(du -sk "$target_dir" 2>/dev/null | awk '{print $1}')
+  case "$size_kib" in
+    ''|*[!0-9]*) size_kib=0 ;;
+  esac
 fi
 available_kib=$(df -Pk "$project_root" | awk 'NR == 2 {print $4}')
+case "$available_kib" in
+  ''|*[!0-9]*) available_kib=0 ;;
+esac
 max_kib=$((max_gib * 1024 * 1024))
 min_free_kib=$((min_free_gib * 1024 * 1024))
 

--- a/scripts/collect-freeze-diag.sh
+++ b/scripts/collect-freeze-diag.sh
@@ -1,9 +1,12 @@
 #!/usr/bin/env bash
 # Collect diagnostics when the martty TUI looks frozen (issue: freeze after
 # tab switches). Run this in ANOTHER terminal while the TUI is still wedged,
-# then share /tmp/martty-freeze-diag.txt.
-set -u
-out=/tmp/martty-freeze-diag.txt
+# then share the file path the script prints at the end.
+#
+# mktemp, not a fixed /tmp path: a predictable world-writable location is a
+# symlink-attack target on multi-user machines.
+set -euo pipefail
+out=$(mktemp /tmp/martty-freeze-diag.XXXXXX.txt)
 : > "$out"
 
 pids=$(pgrep -f 'vendor/[^ ]*/martty|target/(devlocal|debug|release)/martty' || true)
@@ -20,14 +23,16 @@ fi
   for pid in $pids; do
     echo
     echo "== pid $pid: $(tr '\0' ' ' < /proc/$pid/cmdline 2>/dev/null)"
-    ps -o pid,ppid,stat,%cpu,%mem,etime -p "$pid" 2>/dev/null
-    echo "-- wchan: $(cat /proc/$pid/wchan 2>/dev/null)"
+    ps -o pid,ppid,stat,%cpu,%mem,etime -p "$pid" 2>/dev/null || true
+    echo "-- wchan: $(cat /proc/$pid/wchan 2>/dev/null || true)"
     echo "-- threads: $(ls /proc/$pid/task 2>/dev/null | wc -l)"
     if command -v rust-gdb >/dev/null 2>&1; then
       echo "-- backtraces (rust-gdb):"
+      # The process may vanish mid-collection; every step stays best-effort
+      # (set -e must not abort the report halfway).
       timeout 30 rust-gdb -batch -p "$pid" \
         -ex 'set pagination off' -ex 'thread apply all bt' 2>/dev/null \
-        | grep -v '^\[Thread debugging' | head -160
+        | grep -v '^\[Thread debugging' | head -160 || true
     else
       echo "-- rust-gdb not found; install gdb for userspace backtraces"
     fi

--- a/scripts/devlocalinstall.sh
+++ b/scripts/devlocalinstall.sh
@@ -14,7 +14,15 @@ PROFILE="${1:-${DSH_TUI_PROFILE:-martty}}"
 CARGO_PROFILE="${DSH_TUI_CARGO_PROFILE:-devlocal}"
 
 # 1. Build first so the installed copy always reflects the current source.
-BIN="target/${CARGO_PROFILE}/martty"
+# The target dir must match where cargo actually writes (CARGO_TARGET_DIR
+# wins over the default) — otherwise an old binary from a previous default
+# location could be installed and the change would look like it never
+# landed.
+TARGET_DIR="${DSH_TUI_CARGO_TARGET_DIR:-${CARGO_TARGET_DIR:-target}}"
+if [ "$TARGET_DIR" = "target" ]; then
+  TARGET_DIR="$(pwd)/target"
+fi
+BIN="${TARGET_DIR}/${CARGO_PROFILE}/martty"
 echo "building $BIN (cargo build --profile $CARGO_PROFILE --locked)…" >&2
 cargo build --profile "$CARGO_PROFILE" --locked
 

--- a/scripts/package-alias.mjs
+++ b/scripts/package-alias.mjs
@@ -12,14 +12,22 @@ import path from 'node:path'
 
 const legacyName = '@openma/deepseek-harness-tui'
 const textExtensions = new Set(['.js', '.json', '.md', '.mjs', '.yaml', '.yml'])
+// Never carried into the alias package: installed dependencies and the
+// lockfile are build artifacts of the source checkout, not shippable
+// content — rewriting (or packing) them would leak the alias rename into
+// dependency internals.
+const skippedEntries = new Set(['node_modules', 'package-lock.json'])
 
 function rewriteTextFiles(root, aliasName) {
   for (const entry of readdirSync(root, { withFileTypes: true })) {
     const file = path.join(root, entry.name)
     if (entry.isDirectory()) {
-      if (entry.name !== 'vendor') rewriteTextFiles(file, aliasName)
+      if (entry.name !== 'vendor' && !skippedEntries.has(entry.name)) {
+        rewriteTextFiles(file, aliasName)
+      }
       continue
     }
+    if (skippedEntries.has(entry.name)) continue
     if (!entry.isFile() || !textExtensions.has(path.extname(entry.name))) continue
     const before = readFileSync(file, 'utf8')
     const after = before.replaceAll(legacyName, aliasName)
@@ -38,7 +46,11 @@ try {
     throw new Error(`source package directory not found: ${source}`)
   }
   if (existsSync(destination)) {
-    throw new Error(`destination already exists: ${destination}`)
+    throw new Error(
+      `destination already exists: ${destination}\n`
+      + `  the alias is generated fresh per release — delete the stale copy first:\n`
+      + `  rm -rf ${destination}`,
+    )
   }
   const packageJson = JSON.parse(readFileSync(path.join(source, 'package.json'), 'utf8'))
   if (packageJson.name !== legacyName) {
@@ -47,6 +59,15 @@ try {
 
   cpSync(source, destination, { recursive: true, errorOnExist: true, force: false })
   rewriteTextFiles(destination, aliasName)
+  // The alias is generated fresh for every release: if it were ever
+  // published stale (an old checkout lingering on disk), the version and
+  // dependency ranges would silently diverge from the source package.
+  const aliasJson = JSON.parse(readFileSync(path.join(destination, 'package.json'), 'utf8'))
+  if (aliasJson.version !== packageJson.version) {
+    throw new Error(
+      `alias version ${aliasJson.version} does not match source ${packageJson.version}`,
+    )
+  }
   process.stdout.write(`${destination}\n`)
 } catch (error) {
   process.stderr.write(`${error.message}\n`)

--- a/scripts/profile-install-matrix.test.mjs
+++ b/scripts/profile-install-matrix.test.mjs
@@ -307,7 +307,15 @@ test('one TUI command handles the complete profile installation matrix', async (
       const home = path.join(root, 'old-acp')
       writeWorkspaceOverride(home, packages)
       initExistingProfile(home)
-      installAcp(home, '@openma/deepseek-harness-acp@0.4.8')
+      // The pinned old ACP comes from the real registry: a sandboxed or
+      // offline CI runner must skip the case instead of failing forever
+      // (an unpublish or rename upstream would otherwise red this suite).
+      try {
+        installAcp(home, '@openma/deepseek-harness-acp@0.4.8')
+      } catch (error) {
+        process.stderr.write(`skipping old-acp case (registry install failed): ${error.message}\n`)
+        return
+      }
       assert.equal(manifest(home).dependencies['@openma/deepseek-harness-acp'], '0.4.8')
       installTui(home, packages.tui)
       assert.equal(

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -9,7 +9,7 @@
 // branch or when a tag for the version already exists.
 
 import { execFileSync, spawnSync } from 'node:child_process'
-import { readFileSync, writeFileSync } from 'node:fs'
+import { existsSync, readFileSync, writeFileSync } from 'node:fs'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 
@@ -100,6 +100,20 @@ try {
   const lockAfter = bumpCargoLock(lockBefore, cargoPackageName(cargoBefore), version)
   if (lockAfter === lockBefore) {
     throw new Error(`Cargo.lock is already at ${version}`)
+  }
+
+  // A stale local alias package is a publish hazard: it is gitignored and
+  // generated per release, so an old checkout copy would silently ship an
+  // old version if published without regenerating. Warn loudly.
+  const aliasPackage = path.join(repoRoot, 'npm-martty', 'package.json')
+  if (existsSync(aliasPackage)) {
+    const aliasVersion = JSON.parse(readFileSync(aliasPackage, 'utf8')).version
+    if (aliasVersion !== version) {
+      process.stdout.write(
+        `warning: local npm-martty/package.json is at ${aliasVersion} — regenerate the alias`
+          + ` (rm -rf npm-martty && node scripts/package-alias.mjs npm npm-martty martty) before publishing it\n`,
+      )
+    }
   }
 
   if (dryRun) {

--- a/src/acp.rs
+++ b/src/acp.rs
@@ -6,8 +6,10 @@
 //! compositor state arrives as `_dsh/cordis/tui/*` extension notifications.
 
 use std::collections::{HashMap, VecDeque};
+use std::future::Future;
 use std::sync::mpsc::{Receiver, Sender};
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
 
 use anyhow::{Context, Result};
 use serde_json::{json, Value};
@@ -33,7 +35,7 @@ use agent_client_protocol::schema::v1::{
 use agent_client_protocol::schema::ProtocolVersion;
 use agent_client_protocol::{
     on_receive_notification, on_receive_request, AcpAgent, Agent, ByteStreams, Client, ConnectTo,
-    ConnectionTo, Error as AcpError, Handled, UntypedMessage,
+    ConnectionTo, Error as AcpError, Handled, SentRequest, UntypedMessage,
 };
 
 use crate::acp_auth::{
@@ -98,32 +100,39 @@ impl Surface {
                         .map(|(id, _, _)| id)
                         .collect();
             }
-            if self.modes.is_empty() {
-                if let Some(mode) = arr
-                    .iter()
-                    .find(|o| o.get("id").and_then(Value::as_str) == Some("mode"))
-                {
-                    self.modes =
-                        flatten_select_options(mode.get("options").unwrap_or(&Value::Null))
-                            .into_iter()
-                            .map(|(id, name, description)| CatalogPreset {
-                                id,
-                                name,
-                                description,
-                                broken: false,
-                            })
-                            .collect();
-                    if !self.modes.is_empty() {
-                        let _ = bus.send(AppEvent::Ctl(CtlEvent::SessionModes {
-                            session_id: session_id.map(str::to_string),
-                            modes: self.modes.clone(),
-                            current: mode
-                                .get("currentValue")
-                                .or_else(|| mode.get("current_value"))
-                                .and_then(Value::as_str)
-                                .map(str::to_string),
-                        }));
-                    }
+            // ACP config options are per-session: refresh whenever an
+            // actual mode list shows up, even after an earlier session
+            // filled the catalog — later sessions may carry a different
+            // (or changed) set. The event still carries each session's
+            // own currentValue, so per-session state is not lost.
+            if let Some(mode) = arr
+                .iter()
+                .find(|o| o.get("id").and_then(Value::as_str) == Some("mode"))
+            {
+                let list: Vec<CatalogPreset> =
+                    flatten_select_options(mode.get("options").unwrap_or(&Value::Null))
+                        .into_iter()
+                        .map(|(id, name, description)| CatalogPreset {
+                            id,
+                            name,
+                            description,
+                            broken: false,
+                        })
+                        .collect();
+                let changed = !list.is_empty() && list != self.modes;
+                if changed {
+                    self.modes = list;
+                }
+                if !self.modes.is_empty() {
+                    let _ = bus.send(AppEvent::Ctl(CtlEvent::SessionModes {
+                        session_id: session_id.map(str::to_string),
+                        modes: self.modes.clone(),
+                        current: mode
+                            .get("currentValue")
+                            .or_else(|| mode.get("current_value"))
+                            .and_then(Value::as_str)
+                            .map(str::to_string),
+                    }));
                 }
             }
         }
@@ -187,7 +196,7 @@ pub fn check_blocking(argv: Vec<String>) -> Result<String> {
             .builder()
             .name("martty")
             .connect_with(agent, |cx: ConnectionTo<Agent>| async move {
-                let init = cx.send_request(initialize_request()).block_task().await?;
+                let init = cx.send_request(initialize_request()).block_task_deadline().await?;
                 Ok(init
                     .agent_info
                     .map(|info| info.name)
@@ -251,6 +260,9 @@ struct PromptFinish {
     session_id: String,
     result: Result<agent_client_protocol::schema::v1::PromptResponse, AcpError>,
     payload: ParkedPromptKind,
+    /// Turn generation: matches the `inflight` tag when this finish is the
+    /// one that currently owns the session handle.
+    gen: u64,
 }
 
 /// Per-session turn state on one shared ACP connection. The server allows one
@@ -258,10 +270,13 @@ struct PromptFinish {
 /// handle; completions are demultiplexed by the id inside `PromptFinish`.
 #[derive(Default)]
 struct SessionHandle {
-    /// Occupancy marker for the in-flight `session/prompt` task. The task
-    /// reports through the prompt-done channel, so the handle is only ever
-    /// cleared, never awaited.
-    inflight: Option<tokio::task::JoinHandle<()>>,
+    /// Occupancy marker for the in-flight `session/prompt` task, tagged
+    /// with the turn's generation. The task reports through the prompt-done
+    /// channel, so the handle is only ever cleared, never awaited. The
+    /// generation lets a stale finish (its session was forgotten and
+    /// re-bound while the old task was still unwinding) be recognized and
+    /// dropped instead of clearing the *new* turn's marker.
+    inflight: Option<(u64, tokio::task::JoinHandle<()>)>,
     /// Follow-ups waiting for this session's active turn to settle.
     queue: VecDeque<Cmd>,
     /// `session/cancel` was sent for the in-flight prompt; its finish is
@@ -341,6 +356,7 @@ fn spawn_session_prompt(
     sid: SessionId,
     content: Vec<ContentBlock>,
     payload: ParkedPromptKind,
+    gen: u64,
     done: tokio::sync::mpsc::UnboundedSender<PromptFinish>,
 ) -> tokio::task::JoinHandle<()> {
     tokio::spawn(async move {
@@ -354,15 +370,17 @@ fn spawn_session_prompt(
         });
         let _ = bus.send(AppEvent::Ctl(CtlEvent::PromptQueued {
             message_id: sid.to_string(),
+            session_id: Some(sid.to_string()),
         }));
         let result = cx
             .send_request(PromptRequest::new(sid.clone(), content))
-            .block_task()
+            .block_task_deadline()
             .await;
         let _ = done.send(PromptFinish {
             session_id: sid.to_string(),
             result,
             payload,
+            gen,
         });
     })
 }
@@ -380,12 +398,13 @@ fn spawn_steer_prompt(
     tokio::spawn(async move {
         let result = cx
             .send_request(PromptRequest::new(sid, content))
-            .block_task()
+            .block_task_deadline()
             .await;
         let _ = done.send(SteerFinish { message_id, result });
     });
 }
 
+#[allow(clippy::too_many_arguments)]
 #[allow(clippy::too_many_arguments)]
 fn begin_prompt(
     cmd: Cmd,
@@ -397,6 +416,7 @@ fn begin_prompt(
     selected: Option<&AuthMethodInfo>,
     surface: &Arc<Mutex<Surface>>,
     workspace: &str,
+    gen: u64,
     done: &tokio::sync::mpsc::UnboundedSender<PromptFinish>,
 ) -> Option<tokio::task::JoinHandle<()>> {
     match cmd {
@@ -420,6 +440,7 @@ fn begin_prompt(
                 sid,
                 vec![text.clone().into()],
                 ParkedPromptKind::Text(text),
+                gen,
                 done.clone(),
             ))
         }
@@ -443,6 +464,7 @@ fn begin_prompt(
                 sid,
                 vec![text.clone().into()],
                 ParkedPromptKind::Text(text),
+                gen,
                 done.clone(),
             ))
         }
@@ -472,14 +494,23 @@ fn begin_prompt(
                     sid,
                     content,
                     payload,
+                    gen,
                     done.clone(),
                 )),
                 Ok(_) => {
-                    let _ = bus.send(AppEvent::Ctl(CtlEvent::Error("empty image prompt".into())));
+                    // Session-scoped: the failure belongs to the requesting
+                    // tab (possibly parked), never to the viewed one.
+                    let _ = bus.send(AppEvent::Ctl(CtlEvent::SessionError {
+                        session_id: sid.to_string(),
+                        message: "empty image prompt".into(),
+                    }));
                     None
                 }
                 Err(err) => {
-                    let _ = bus.send(AppEvent::Ctl(CtlEvent::Error(err)));
+                    let _ = bus.send(AppEvent::Ctl(CtlEvent::SessionError {
+                        session_id: sid.to_string(),
+                        message: err,
+                    }));
                     None
                 }
             }
@@ -510,14 +541,21 @@ fn begin_prompt(
                     sid,
                     content,
                     payload,
+                    gen,
                     done.clone(),
                 )),
                 Ok(_) => {
-                    let _ = bus.send(AppEvent::Ctl(CtlEvent::Error("empty image prompt".into())));
+                    let _ = bus.send(AppEvent::Ctl(CtlEvent::SessionError {
+                        session_id: sid.to_string(),
+                        message: "empty image prompt".into(),
+                    }));
                     None
                 }
                 Err(err) => {
-                    let _ = bus.send(AppEvent::Ctl(CtlEvent::Error(err)));
+                    let _ = bus.send(AppEvent::Ctl(CtlEvent::SessionError {
+                        session_id: sid.to_string(),
+                        message: err,
+                    }));
                     None
                 }
             }
@@ -538,6 +576,7 @@ fn drain_ready_sessions(
     selected: Option<&AuthMethodInfo>,
     surface: &Arc<Mutex<Surface>>,
     workspace: &str,
+    next_gen: &mut u64,
     done: &tokio::sync::mpsc::UnboundedSender<PromptFinish>,
 ) {
     // While any prompt is stalled on auth, new prompts are not started:
@@ -557,6 +596,7 @@ fn drain_ready_sessions(
         let Some(next) = handle.queue.pop_front() else {
             continue;
         };
+        *next_gen += 1;
         handle.inflight = begin_prompt(
             next,
             cx,
@@ -567,8 +607,10 @@ fn drain_ready_sessions(
             selected,
             surface,
             workspace,
+            *next_gen,
             done,
-        );
+        )
+        .map(|task| (*next_gen, task));
         // If the begin parked a prompt (only possible without a session,
         // which drain never passes) stop starting more.
         if !parked.is_empty() {
@@ -728,7 +770,7 @@ async fn create_prompt_session(
 ) -> std::result::Result<Option<SessionId>, AcpError> {
     match cx
         .send_request(NewSessionRequest::new(cwd.to_path_buf()))
-        .block_task()
+        .block_task_deadline()
         .await
     {
         Ok(created) => {
@@ -914,9 +956,24 @@ fn abs_fs_path(path: &str, workspace: &str) -> Option<std::path::PathBuf> {
     Some(normalize_abs(abs))
 }
 
-/// Unix `file://` + absolute path (`file:///tmp/a.png`).
+/// Unix `file://` + absolute path with percent-encoding (`file:///tmp/a%20b.png`).
+/// `#`, `?`, `%`, spaces and non-ASCII bytes are encoded so agents parsing
+/// the URI (RFC 8089) recover the original path instead of treating `#` as
+/// a fragment or `?` as a query.
 fn unix_file_uri(path: &std::path::Path) -> String {
-    format!("file://{}", path.display())
+    let raw = path.to_string_lossy();
+    let mut encoded = String::with_capacity(raw.len());
+    for byte in raw.as_bytes() {
+        match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'.' | b'_' | b'~' | b'!' | b'$'
+            | b'&' | b'\'' | b'(' | b')' | b'*' | b'+' | b',' | b';' | b'=' | b'@' | b':' => {
+                encoded.push(*byte as char)
+            }
+            b'/' => encoded.push('/'),
+            other => encoded.push_str(&format!("%{other:02X}")),
+        }
+    }
+    format!("file://{encoded}")
 }
 
 fn resolve_image_uri(path: &str, workspace: &str) -> Option<String> {
@@ -1131,13 +1188,38 @@ fn static_plugins_from_value(value: &Value) -> std::result::Result<Vec<StaticPlu
         .collect()
 }
 
+/// Deadline for one ACP request round-trip. Generous on purpose — it only
+/// exists so a hung agent (half-open stdio, dead process) cannot freeze
+/// the command loop: Interrupt and Shutdown are unreachable while an arm
+/// awaits forever.
+const REQUEST_DEADLINE: Duration = Duration::from_secs(120);
+
+/// [`SentRequest::block_task`] with [`REQUEST_DEADLINE`] applied. Every
+/// request the command loop awaits directly goes through this.
+trait BlockTaskDeadline {
+    type Output;
+    fn block_task_deadline(self) -> impl Future<Output = Result<Self::Output, AcpError>>;
+}
+
+impl<T> BlockTaskDeadline for SentRequest<T> {
+    type Output = T;
+    fn block_task_deadline(self) -> impl Future<Output = Result<T, AcpError>> {
+        async move {
+            match tokio::time::timeout(REQUEST_DEADLINE, self.block_task()).await {
+                Ok(result) => result,
+                Err(_) => Err(AcpError::new(-32001, "agent request timed out")),
+            }
+        }
+    }
+}
+
 async fn call_tui_extension(
     cx: &ConnectionTo<Agent>,
     method: &str,
     params: Value,
 ) -> std::result::Result<Value, AcpError> {
     let request = UntypedMessage::new(method, params)?;
-    cx.send_request(request).block_task().await
+    cx.send_request(request).block_task_deadline().await
 }
 
 async fn fetch_dynamic_plugins(
@@ -1180,6 +1262,16 @@ fn ensure_agent_cordis(surface: &Arc<Mutex<Surface>>, bus: &Sender<AppEvent>) ->
     advertised
 }
 
+/// Silent check for high-frequency projection traffic: snapshots must
+/// never ping an un-negotiated agent (protocol 0 requires the
+/// `initialize._meta.dsh.cordis` handshake first) nor spam the transcript.
+fn agent_cordis_negotiated(surface: &Arc<Mutex<Surface>>) -> bool {
+    surface
+        .lock()
+        .unwrap_or_else(|error| error.into_inner())
+        .cordis
+}
+
 async fn connect<T>(
     transport: T,
     cfg: RuntimeConfig,
@@ -1203,6 +1295,8 @@ where
     let workspace_write = workspace.clone();
     let terms = Arc::new(crate::acp_term::TerminalBroker::new(workspace.clone()));
     let terms_create = Arc::clone(&terms);
+    let bus_create = bus.clone();
+    let workspace_create = workspace.clone();
     let terms_output = Arc::clone(&terms);
     let terms_wait = Arc::clone(&terms);
     let terms_kill = Arc::clone(&terms);
@@ -1479,22 +1573,60 @@ where
         .on_receive_request(
             {
                 let terms = terms_create;
+                let bus = bus_create;
                 async move |req: CreateTerminalRequest, responder, _cx| {
+                    // Asking the user takes an async round-trip through the
+                    // permission overlay — the handler offloads like the
+                    // fs/write handler does. Everything the spawned task
+                    // needs is cloned per call: the handler itself must
+                    // stay callable.
+                    let terms = Arc::clone(&terms);
                     let env: Vec<(String, String)> = req
                         .env
                         .iter()
                         .map(|e| (e.name.clone(), e.value.clone()))
                         .collect();
-                    match terms.create(
-                        &req.command,
-                        &req.args,
-                        req.cwd,
-                        &env,
-                        req.output_byte_limit,
-                    ) {
-                        Ok(id) => responder.respond(CreateTerminalResponse::new(id)),
-                        Err(err) => responder.respond_with_error(AcpError::new(-32603, err)),
-                    }
+                    let session_id = req.session_id.to_string();
+                    let command = req.command;
+                    let args = req.args;
+                    let cwd = req.cwd;
+                    let output_byte_limit = req.output_byte_limit;
+                    let bus = bus.clone();
+                    let workspace = workspace_create.clone();
+                    tokio::spawn(async move {
+                        let resolved_cwd = cwd
+                            .map(|c| {
+                                crate::acp_fs::resolve_with_cwd(
+                                    &c,
+                                    std::path::Path::new(&workspace),
+                                )
+                            })
+                            .unwrap_or_else(|| workspace.clone().into());
+                        let allowed = crate::acp_fs::confirm_terminal_spawn(
+                            &bus,
+                            &session_id,
+                            &command,
+                            &args,
+                            &resolved_cwd,
+                        )
+                        .await;
+                        let result = if allowed {
+                            terms.create(
+                                &command,
+                                &args,
+                                Some(resolved_cwd),
+                                &env,
+                                output_byte_limit,
+                            )
+                        } else {
+                            Err("user denied createTerminal".to_string())
+                        };
+                        match result {
+                            Ok(id) => responder.respond(CreateTerminalResponse::new(id)),
+                            Err(err) => responder.respond_with_error(AcpError::new(-32603, err)),
+                        }
+                    });
+                    Ok(())
                 }
             },
             on_receive_request!(),
@@ -1503,12 +1635,16 @@ where
             {
                 let terms = terms_output;
                 async move |req: TerminalOutputRequest, responder, _cx| {
-                    let (output, truncated, exit) = terms.output(&req.terminal_id.to_string());
-                    let mut resp = TerminalOutputResponse::new(output, truncated);
-                    if let Some(exit) = exit {
-                        resp = resp.exit_status(exit);
+                    match terms.output(&req.terminal_id.to_string()) {
+                        Ok((output, truncated, exit)) => {
+                            let mut resp = TerminalOutputResponse::new(output, truncated);
+                            if let Some(exit) = exit {
+                                resp = resp.exit_status(exit);
+                            }
+                            responder.respond(resp)
+                        }
+                        Err(err) => responder.respond_with_error(AcpError::new(-32602, err)),
                     }
-                    responder.respond(resp)
                 }
             },
             on_receive_request!(),
@@ -1518,9 +1654,16 @@ where
                 let terms = terms_wait;
                 async move |req: WaitForTerminalExitRequest, responder, _cx| {
                     let terms = Arc::clone(&terms);
+                    let terminal_id = req.terminal_id.to_string();
                     tokio::spawn(async move {
-                        let status = terms.wait(&req.terminal_id.to_string()).await;
-                        let _ = responder.respond(WaitForTerminalExitResponse::new(status));
+                        match terms.wait(&terminal_id).await {
+                            Ok(status) => {
+                                let _ = responder.respond(WaitForTerminalExitResponse::new(status));
+                            }
+                            Err(err) => {
+                                let _ = responder.respond_with_error(AcpError::new(-32602, err));
+                            }
+                        }
                     });
                     Ok(())
                 }
@@ -1531,8 +1674,10 @@ where
             {
                 let terms = terms_kill;
                 async move |req: KillTerminalRequest, responder, _cx| {
-                    terms.kill(&req.terminal_id.to_string());
-                    responder.respond(KillTerminalResponse::new())
+                    match terms.kill(&req.terminal_id.to_string()) {
+                        Ok(()) => responder.respond(KillTerminalResponse::new()),
+                        Err(err) => responder.respond_with_error(AcpError::new(-32602, err)),
+                    }
                 }
             },
             on_receive_request!(),
@@ -1541,8 +1686,10 @@ where
             {
                 let terms = terms_release;
                 async move |req: ReleaseTerminalRequest, responder, _cx| {
-                    terms.release(&req.terminal_id.to_string());
-                    responder.respond(ReleaseTerminalResponse::new())
+                    match terms.release(&req.terminal_id.to_string()) {
+                        Ok(()) => responder.respond(ReleaseTerminalResponse::new()),
+                        Err(err) => responder.respond_with_error(AcpError::new(-32602, err)),
+                    }
                 }
             },
             on_receive_request!(),
@@ -1608,7 +1755,7 @@ where
                                 config_id,
                                 config_value,
                             ))
-                            .block_task()
+                            .block_task_deadline()
                             .await
                         {
                             Ok(response) => match serde_json::to_value(&response) {
@@ -1651,7 +1798,7 @@ where
                 let _ = bus.send(AppEvent::Ctl(CtlEvent::Starting {
                     runtime: "acp".into(),
                 }));
-                let init = cx.send_request(initialize_request()).block_task().await?;
+                let init = cx.send_request(initialize_request()).block_task_deadline().await?;
                 let agent_name = init
                     .agent_info
                     .as_ref()
@@ -1755,6 +1902,10 @@ where
                     tokio::sync::mpsc::unbounded_channel::<PromptFinish>();
                 let (steer_done_tx, mut steer_done_rx) =
                     tokio::sync::mpsc::unbounded_channel::<SteerFinish>();
+                // Monotonic turn generation: every started prompt task is
+                // tagged, finishes carry the tag back, and a stale finish
+                // can never clear a newer turn's occupancy marker.
+                let mut prompt_gen: u64 = 0;
                 loop {
                     tokio::select! {
                         cmd = fwd_rx.recv() => {
@@ -1827,8 +1978,10 @@ where
                                             selected.as_ref(),
                                             &surface,
                                             &cfg.workspace,
+                                            prompt_gen,
                                             &prompt_done_tx,
-                                        );
+                                        )
+                                        .map(|task| (prompt_gen, task));
                                     }
                                 }
                                 Ok(None) => pending.push_back(next),
@@ -1861,6 +2014,7 @@ where
                                         }));
                                     } else {
                                         let handle = sessions.entry(sid.to_string()).or_default();
+                                        prompt_gen += 1;
                                         handle.inflight = begin_prompt(
                                             Cmd::Steer {
                                                 session_id: cmd_session,
@@ -1875,8 +2029,10 @@ where
                                             selected.as_ref(),
                                             &surface,
                                             &cfg.workspace,
+                                            prompt_gen,
                                             &prompt_done_tx,
-                                        );
+                                        )
+                                        .map(|task| (prompt_gen, task));
                                         let _ = bus.send(AppEvent::Ctl(CtlEvent::SteerSettled {
                                             message_id,
                                             deferred: false,
@@ -1908,6 +2064,7 @@ where
                                     if handle.inflight.is_some() || !parked.is_empty() {
                                         handle.queue.push_back(next);
                                     } else {
+                                        prompt_gen += 1;
                                         handle.inflight = begin_prompt(
                                             next,
                                             &cx,
@@ -1918,8 +2075,10 @@ where
                                             selected.as_ref(),
                                             &surface,
                                             &cfg.workspace,
+                                            prompt_gen,
                                             &prompt_done_tx,
-                                        );
+                                        )
+                                        .map(|task| (prompt_gen, task));
                                     }
                                 }
                                 Ok(None) => pending.push_back(next),
@@ -1969,6 +2128,7 @@ where
                                         }));
                                     } else {
                                         let handle = sessions.entry(sid.to_string()).or_default();
+                                        prompt_gen += 1;
                                         handle.inflight = begin_prompt(
                                             Cmd::SteerImages {
                                                 session_id: cmd_session,
@@ -1983,8 +2143,10 @@ where
                                             selected.as_ref(),
                                             &surface,
                                             &cfg.workspace,
+                                            prompt_gen,
                                             &prompt_done_tx,
-                                        );
+                                        )
+                                        .map(|task| (prompt_gen, task));
                                         let _ = bus.send(AppEvent::Ctl(CtlEvent::SteerSettled {
                                             message_id,
                                             deferred: false,
@@ -2057,7 +2219,7 @@ where
                                         "model",
                                         SessionConfigOptionValue::value_id(value),
                                     ))
-                                    .block_task()
+                                    .block_task_deadline()
                                     .await
                                     .map_err(|err| {
                                         if is_auth_required_error(&err) {
@@ -2077,7 +2239,7 @@ where
                                         "effort",
                                         SessionConfigOptionValue::value_id(effort),
                                     ))
-                                    .block_task()
+                                    .block_task_deadline()
                                     .await
                                     .map_err(|err| {
                                         if is_auth_required_error(&err) {
@@ -2325,7 +2487,7 @@ where
                             };
                             match cx
                                 .send_request(SetSessionModeRequest::new(sid.clone(), preset.clone()))
-                                .block_task()
+                                .block_task_deadline()
                                 .await
                             {
                                 Ok(_) => {
@@ -2348,7 +2510,7 @@ where
                                             "mode",
                                             SessionConfigOptionValue::value_id(preset.clone()),
                                         ))
-                                        .block_task()
+                                        .block_task_deadline()
                                         .await;
                                     let _ = bus.send(AppEvent::Ctl(CtlEvent::TuiOpDone(format!(
                                         "permission → {preset} ({err})"
@@ -2380,7 +2542,7 @@ where
                                     config_id,
                                     SessionConfigOptionValue::value_id(preset.clone()),
                                 ))
-                                .block_task()
+                                .block_task_deadline()
                                 .await
                             {
                                 Ok(response) => {
@@ -2445,7 +2607,7 @@ where
                                     config_id,
                                     SessionConfigOptionValue::value_id(value),
                                 ))
-                                .block_task()
+                                .block_task_deadline()
                                 .await
                             {
                                 Ok(response) => {
@@ -2524,7 +2686,7 @@ where
                             if let Some(meta) = authenticate_meta_from_method(&method, &values) {
                                 req = req.meta(meta);
                             }
-                            match cx.send_request(req).block_task().await {
+                            match cx.send_request(req).block_task_deadline().await {
                                 Ok(_) => {
                                     if current.is_none() {
                                         match create_prompt_session(
@@ -2599,7 +2761,7 @@ where
                         Cmd::NewSession => {
                             match cx
                                 .send_request(NewSessionRequest::new(cwd.clone()))
-                                .block_task()
+                                .block_task_deadline()
                                 .await
                             {
                                 Ok(created) => {
@@ -2654,7 +2816,7 @@ where
                             }
                             match cx
                                 .send_request(ListSessionsRequest::new().cwd(cwd.clone()))
-                                .block_task()
+                                .block_task_deadline()
                                 .await
                             {
                                 Ok(listed) => {
@@ -2701,7 +2863,7 @@ where
                                         sid.clone(),
                                         cwd.clone(),
                                     ))
-                                    .block_task()
+                                    .block_task_deadline()
                                     .await
                                 {
                                     Ok(resumed) => Ok((
@@ -2715,7 +2877,7 @@ where
                                             sid.clone(),
                                             cwd.clone(),
                                         ))
-                                        .block_task()
+                                        .block_task_deadline()
                                         .await
                                         .map(|loaded| {
                                             (
@@ -2729,7 +2891,7 @@ where
                                 }
                             } else {
                                 cx.send_request(LoadSessionRequest::new(sid.clone(), cwd.clone()))
-                                    .block_task()
+                                    .block_task_deadline()
                                     .await
                                     .map(|loaded| {
                                         (
@@ -2797,7 +2959,11 @@ where
                             // This method belongs to the local Client compositor.
                             // Direct native launches may not have one, so absence is
                             // intentionally silent and never affects prompt flow.
-                            let _ = call_tui_extension(
+                            // Guarded by the initialize negotiation: an
+                            // un-negotiated agent gets no `_dsh/cordis`
+                            // traffic at all (protocol 0 rule).
+                            if agent_cordis_negotiated(&surface) {
+                                let _ = call_tui_extension(
                                 &cx,
                                 crate::cordis::QUEUE_UPDATE,
                                 serde_json::json!({
@@ -2808,8 +2974,9 @@ where
                                     "editingId": snapshot.editing_id,
                                     "deleteConfirm": snapshot.delete_confirm,
                                 }),
-                            )
-                            .await;
+                                )
+                                .await;
+                            }
                         }
                         Cmd::AgentsSnapshot { snapshot } => {
                             let items = snapshot
@@ -2827,7 +2994,9 @@ where
                                 .collect::<Vec<_>>();
                             // Agent transcript navigation is Client chrome;
                             // it never becomes an ACP prompt or timeline cell.
-                            let _ = call_tui_extension(
+                            // Same negotiation guard as the queue snapshot.
+                            if agent_cordis_negotiated(&surface) {
+                                let _ = call_tui_extension(
                                 &cx,
                                 crate::cordis::AGENTS_UPDATE,
                                 serde_json::json!({
@@ -2836,8 +3005,9 @@ where
                                     "selectedId": snapshot.selected_id,
                                     "items": items,
                                 }),
-                            )
-                            .await;
+                                )
+                                .await;
+                            }
                         }
                         Cmd::ForgetSession { session_id } => {
                             // `/close`: this client stopped viewing the
@@ -2873,6 +3043,7 @@ where
                                 selected.as_ref(),
                                 &surface,
                                 &cfg.workspace,
+                                &mut prompt_gen,
                                 &prompt_done_tx,
                             );
                         }
@@ -2893,6 +3064,7 @@ where
                                 selected.as_ref(),
                                 &surface,
                                 &cfg.workspace,
+                                &mut prompt_gen,
                                 &prompt_done_tx,
                             );
                         }
@@ -2907,9 +3079,28 @@ where
                             let Some(handle) = sessions.get_mut(&key) else {
                                 continue;
                             };
+                            // Stale finish (the session was forgotten and
+                            // re-bound; a new turn owns the handle now):
+                            // clear nothing — the new turn's occupancy
+                            // marker must survive a late old finish.
+                            if handle.inflight.as_ref().map(|(gen, _)| *gen) != Some(done.gen) {
+                                continue;
+                            }
                             handle.inflight = None;
                             let aborted = std::mem::take(&mut handle.turn_aborted);
-                            if aborted {
+                            // `session/cancel` can race an already-settling
+                            // turn: trust the agent's stop reason. A real
+                            // interruption surfaces as `Cancelled` (or an
+                            // error); a turn that completed despite the
+                            // cancel still reports its own result.
+                            let agent_cancelled = matches!(
+                                &done.result,
+                                Ok(response) if matches!(
+                                    response.stop_reason,
+                                    agent_client_protocol::schema::v1::StopReason::Cancelled
+                                )
+                            );
+                            if aborted && (done.result.is_err() || agent_cancelled) {
                                 let _ = bus.send(AppEvent::Ui(
                                     crate::events::UiEvent::TurnEnd {
                                         session: key.clone(),
@@ -2953,6 +3144,7 @@ where
                                     selected.as_ref(),
                                     &surface,
                                     &cfg.workspace,
+                                    &mut prompt_gen,
                                     &prompt_done_tx,
                                 );
                             } else {

--- a/src/acp_fs.rs
+++ b/src/acp_fs.rs
@@ -125,6 +125,53 @@ pub fn denied_write() -> AcpError {
     AcpError::new(-32603, "user denied write")
 }
 
+/// Ask through the permission overlay before the agent may spawn a local
+/// process. `terminal/create` runs arbitrary `command + args + env` —
+/// strictly more powerful than the writes this module gates, so it always
+/// asks (cwd inside the workspace does not shrink the blast radius). The
+/// ask is tagged with `session_id` so it follows that session's tab.
+pub async fn confirm_terminal_spawn(
+    bus: &Sender<AppEvent>,
+    session_id: &str,
+    command: &str,
+    args: &[String],
+    cwd: &Path,
+) -> bool {
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    let options = vec![
+        PermissionAskOption {
+            option_id: "deny".into(),
+            kind: "reject_once".into(),
+            name: "Deny".into(),
+        },
+        PermissionAskOption {
+            option_id: "allow".into(),
+            kind: "allow_once".into(),
+            name: "Allow command".into(),
+        },
+    ];
+    let mut shown = command.to_string();
+    if !args.is_empty() {
+        shown.push(' ');
+        shown.push_str(&args.join(" "));
+    }
+    if bus
+        .send(AppEvent::PermissionAsk {
+            session_id: session_id.into(),
+            title: format!("run {} · in {}", shown, cwd.display()),
+            options,
+            reply: tx,
+        })
+        .is_err()
+    {
+        return false;
+    }
+    matches!(
+        rx.await.unwrap_or(PermissionAskReply::Cancelled),
+        PermissionAskReply::Selected(id) if id == "allow"
+    )
+}
+
 fn io_err(err: std::io::Error) -> AcpError {
     AcpError::new(-32603, err.to_string())
 }

--- a/src/acp_term.rs
+++ b/src/acp_term.rs
@@ -5,7 +5,7 @@
 //! children when the broker drops.
 
 use std::collections::HashMap;
-use std::io::Read;
+use std::io::{ErrorKind, Read};
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
@@ -93,19 +93,22 @@ impl TerminalBroker {
         Ok(id)
     }
 
-    pub fn output(&self, terminal_id: &str) -> (String, bool, Option<TerminalExitStatus>) {
+    pub fn output(
+        &self,
+        terminal_id: &str,
+    ) -> Result<(String, bool, Option<TerminalExitStatus>), String> {
         let Some(rec) = self.get(terminal_id) else {
-            return (String::new(), false, None);
+            return Err(format!("unknown terminal: {terminal_id}"));
         };
         let output = rec.buf.lock().unwrap_or_else(|e| e.into_inner()).clone();
         let truncated = rec.truncated.load(Ordering::Relaxed);
         let exit = rec.exit.lock().unwrap_or_else(|e| e.into_inner()).clone();
-        (output, truncated, exit)
+        Ok((output, truncated, exit))
     }
 
-    pub async fn wait(&self, terminal_id: &str) -> TerminalExitStatus {
+    pub async fn wait(&self, terminal_id: &str) -> Result<TerminalExitStatus, String> {
         let Some(rec) = self.get(terminal_id) else {
-            return TerminalExitStatus::new();
+            return Err(format!("unknown terminal: {terminal_id}"));
         };
         loop {
             // Register interest *before* re-checking the status:
@@ -116,24 +119,27 @@ impl TerminalBroker {
             tokio::pin!(notified);
             notified.as_mut().enable();
             if let Some(status) = rec.exit.lock().unwrap_or_else(|e| e.into_inner()).clone() {
-                return status;
+                return Ok(status);
             }
             notified.await;
         }
     }
 
-    pub fn kill(&self, terminal_id: &str) {
-        if let Some(rec) = self.get(terminal_id) {
-            let _ = rec.child.lock().unwrap_or_else(|e| e.into_inner()).kill();
-        }
+    pub fn kill(&self, terminal_id: &str) -> Result<(), String> {
+        let rec = self
+            .get(terminal_id)
+            .ok_or_else(|| format!("unknown terminal: {terminal_id}"))?;
+        let _ = rec.child.lock().unwrap_or_else(|e| e.into_inner()).kill();
+        Ok(())
     }
 
-    pub fn release(&self, terminal_id: &str) {
-        self.kill(terminal_id);
+    pub fn release(&self, terminal_id: &str) -> Result<(), String> {
+        self.kill(terminal_id)?;
         self.terms
             .lock()
             .unwrap_or_else(|e| e.into_inner())
             .remove(terminal_id);
+        Ok(())
     }
 
     fn get(&self, terminal_id: &str) -> Option<Arc<TerminalRec>> {
@@ -165,11 +171,49 @@ fn spawn_reader(rec: Arc<TerminalRec>, mut stream: impl Read + Send + 'static) {
         .name("dsh-acp-term-io".into())
         .spawn(move || {
             let mut chunk = [0u8; 4096];
+            // Carry bytes that may be the start of a truncated multi-byte
+            // UTF-8 sequence across reads, so characters split at the read
+            // boundary do not turn into U+FFFD.
+            let mut carry: Vec<u8> = Vec::new();
             loop {
                 match stream.read(&mut chunk) {
-                    Ok(0) => break,
-                    Ok(n) => append_output(&rec, &chunk[..n]),
-                    Err(_) => break,
+                    Ok(0) => {
+                        if !carry.is_empty() {
+                            append_output(&rec, &carry);
+                        }
+                        break;
+                    }
+                    Ok(n) => {
+                        carry.extend_from_slice(&chunk[..n]);
+                        // Flush the longest prefix that is valid UTF-8 and
+                        // keeps the remainder as carry. A read boundary may
+                        // only split a sequence that is already invalid, in
+                        // which case everything is emitted (with U+FFFD) so
+                        // the carry buffer cannot grow unbounded.
+                        let keep = match std::str::from_utf8(&carry) {
+                            Ok(_) => carry.len(),
+                            Err(err) => {
+                                if err.valid_up_to() > 0 {
+                                    err.valid_up_to()
+                                } else if err.error_len().is_some() {
+                                    carry.len()
+                                } else {
+                                    0
+                                }
+                            }
+                        };
+                        if keep > 0 {
+                            append_output(&rec, &carry[..keep]);
+                            carry.drain(..keep);
+                        }
+                    }
+                    Err(err) if err.kind() == ErrorKind::Interrupted => continue,
+                    Err(_) => {
+                        if !carry.is_empty() {
+                            append_output(&rec, &carry);
+                        }
+                        break;
+                    }
                 }
             }
         })

--- a/src/app.rs
+++ b/src/app.rs
@@ -7,7 +7,9 @@
 //! history on an empty prompt.
 
 use std::collections::{HashMap, HashSet, VecDeque};
-use std::io::{BufRead, BufReader, Write};
+use std::io::{BufReader, Read, Write};
+#[cfg(not(unix))]
+use std::io::BufRead;
 use std::sync::mpsc::Sender;
 use std::time::{Duration, Instant};
 
@@ -511,12 +513,34 @@ pub struct ChatView {
     /// the streaming tail; a scroll gesture is resolved into a fresh anchor
     /// by the next draw.
     pub(crate) manual_top: Option<usize>,
+    /// The frame's selection snapshot, **viewport-sized**: the plain text of
+    /// the `top..top+len` layout lines this frame actually showed (L25 —
+    /// hit-testing and copy extraction never need more). `total` carries the
+    /// absolute line count for scroll math.
     pub lines: Vec<String>,
-    /// Per layout line, the transcript cell that owns it (only tool cells
-    /// claim ownership) — the seam for click-to-expand.
+    /// Per snapshot line (same viewport window), the transcript cell that
+    /// owns it (only tool cells claim ownership) — the seam for
+    /// click-to-expand.
     pub owners: Vec<Option<usize>>,
+    /// Total layout line count of the last frame (viewport-relative lines
+    /// exist only for `top..top+lines.len()`).
+    pub total: usize,
     /// Visible image thumbnails, filled by `ui::draw_chat` every frame.
     pub images: Vec<ThumbPlacement>,
+}
+
+impl ChatView {
+    /// The frame's snapshot text for an absolute layout line — `None`
+    /// outside the viewport this frame captured.
+    pub fn line_text(&self, line: usize) -> Option<&str> {
+        self.lines.get(line.checked_sub(self.top)?).map(String::as_str)
+    }
+
+    /// The transcript cell owning an absolute layout line — `None` outside
+    /// the viewport or for lines no tool cell owns.
+    pub fn line_owner(&self, line: usize) -> Option<usize> {
+        self.owners.get(line.checked_sub(self.top)?).copied().flatten()
+    }
 }
 
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -989,6 +1013,23 @@ struct PersistentShell {
     marker: String,
 }
 
+/// Silence deadline for one `!` command. A wedged command (or a closed
+/// control fd) must not block the single-shell worker forever; on timeout
+/// the shell is killed and the next request spawns a fresh one.
+#[cfg(unix)]
+const SHELL_SILENCE: Duration = Duration::from_secs(120);
+
+/// Outcome of the marker wait.
+#[cfg(unix)]
+enum ShellRead {
+    /// Marker found; carries the parsed exit status.
+    Done(Option<i32>),
+    /// Shell stdout closed.
+    Eof,
+    /// No output within `SHELL_SILENCE`.
+    Silent,
+}
+
 impl PersistentShell {
     fn spawn(cwd: &str) -> std::io::Result<Self> {
         let mut child = std::process::Command::new("sh")
@@ -1018,7 +1059,11 @@ impl PersistentShell {
 
     fn run(&mut self, id: u64, command: &str) -> std::io::Result<(Option<i32>, String, bool)> {
         let marker = format!("\x1e{}:{id}:", self.marker);
-        writeln!(self.stdin, "eval {} 2>&1", shell_quote(command))?;
+        // stdin from /dev/null: the persistent shell's stdin is the command
+        // pipe itself, so a command that reads it (`!cat`, `!ssh …`) would
+        // otherwise swallow the status/marker lines and hang the marker
+        // wait forever.
+        writeln!(self.stdin, "eval {} 2>&1 < /dev/null", shell_quote(command))?;
         writeln!(self.stdin, "__martty_shell_status=$?")?;
         writeln!(
             self.stdin,
@@ -1028,27 +1073,115 @@ impl PersistentShell {
         self.stdin.flush()?;
 
         let mut captured = Vec::new();
-        loop {
-            let read = self.stdout.read_until(0x1f, &mut captured)?;
-            if read == 0 {
-                let code = self.child.wait().ok().and_then(|status| status.code());
-                return Ok((code, shell_output(captured), false));
+        #[cfg(unix)]
+        {
+            match self.read_marker(&marker, &mut captured)? {
+                ShellRead::Done(status) => return Ok((status, shell_output(captured), true)),
+                ShellRead::Eof => {
+                    let code = self.child.wait().ok().and_then(|status| status.code());
+                    return Ok((code, shell_output(captured), false));
+                }
+                ShellRead::Silent => {
+                    // No output within the deadline: the command is wedged
+                    // (the single worker thread must never block forever).
+                    // Kill the shell; the next `!` request spawns a fresh one.
+                    let _ = self.child.kill();
+                    let _ = self.child.wait();
+                    return Ok((
+                        None,
+                        format!(
+                            "command killed: no output for {}s — the next `!` restarts the shell",
+                            SHELL_SILENCE.as_secs()
+                        ),
+                        false,
+                    ));
+                }
             }
-            let Some(start) = find_bytes(&captured, marker.as_bytes()) else {
+        }
+        #[cfg(not(unix))]
+        {
+            loop {
+                let read = self.stdout.read_until(0x1f, &mut captured)?;
+                if read == 0 {
+                    let code = self.child.wait().ok().and_then(|status| status.code());
+                    return Ok((code, shell_output(captured), false));
+                }
+                let Some(start) = find_bytes(&captured, marker.as_bytes()) else {
+                    continue;
+                };
+                let status_start = start + marker.len();
+                let Some(status_len) = captured[status_start..]
+                    .iter()
+                    .position(|byte| *byte == 0x1f)
+                else {
+                    continue;
+                };
+                let status =
+                    std::str::from_utf8(&captured[status_start..status_start + status_len])
+                        .ok()
+                        .and_then(|value| value.parse::<i32>().ok());
+                captured.truncate(start);
+                return Ok((status, shell_output(captured), true));
+            }
+        }
+    }
+
+    /// Read stdout until the status marker arrives. Poll-based so the
+    /// silence deadline can fire even though `BufReader` has no
+    /// non-blocking mode; every byte of progress resets the deadline.
+    #[cfg(unix)]
+    fn read_marker(
+        &mut self,
+        marker: &str,
+        captured: &mut Vec<u8>,
+    ) -> std::io::Result<ShellRead> {
+        use std::os::unix::io::AsRawFd;
+        let fd = self.stdout.get_ref().as_raw_fd();
+        let mut pollfd = [libc::pollfd {
+            fd,
+            events: libc::POLLIN,
+            revents: 0,
+        }];
+        let mut chunk = [0u8; 8192];
+        let marker_bytes = marker.as_bytes();
+        let timeout_ms = SHELL_SILENCE.as_millis().min(i32::MAX as u128) as i32;
+        loop {
+            let ready = unsafe { libc::poll(pollfd.as_mut_ptr(), 1, timeout_ms) };
+            if ready < 0 {
+                let err = std::io::Error::last_os_error();
+                if err.kind() == std::io::ErrorKind::Interrupted {
+                    continue;
+                }
+                return Err(err);
+            }
+            if ready == 0 {
+                return Ok(ShellRead::Silent);
+            }
+            if pollfd[0].revents & libc::POLLNVAL != 0 {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::BrokenPipe,
+                    "shell stdout closed",
+                ));
+            }
+            // POLLIN (and/or POLLHUP) — a read never blocks here.
+            let read = self.stdout.read(&mut chunk)?;
+            if read == 0 {
+                return Ok(ShellRead::Eof);
+            }
+            captured.extend_from_slice(&chunk[..read]);
+            let Some(start) = find_bytes(captured, marker_bytes) else {
                 continue;
             };
-            let status_start = start + marker.len();
-            let Some(status_len) = captured[status_start..]
-                .iter()
-                .position(|byte| *byte == 0x1f)
-            else {
+            let status_start = start + marker_bytes.len();
+            let Some(status_len) = captured[status_start..].iter().position(|b| *b == 0x1f) else {
                 continue;
             };
-            let status = std::str::from_utf8(&captured[status_start..status_start + status_len])
-                .ok()
-                .and_then(|value| value.parse::<i32>().ok());
+            let status =
+                std::str::from_utf8(&captured[status_start..status_start + status_len])
+                    .ok()
+                    .and_then(|value| value.parse::<i32>().ok());
             captured.truncate(start);
-            return Ok((status, shell_output(captured), true));
+            return Ok(ShellRead::Done(status));
         }
     }
 }
@@ -1335,7 +1468,7 @@ pub struct App {
     /// ACP request task yet. Runtime startup alone does not make a turn busy.
     prompt_pending: bool,
     shell_seq: u64,
-    shell_pending: Vec<(u64, String, usize)>, // (id, session id, cell idx)
+    shell_pending: Vec<(u64, String, usize, u64)>, // (id, session id, cell idx, transcript gen)
     shell_worker: Option<ShellWorker>,
     bus_tx: Sender<AppEvent>,
     pub server_info: Option<String>,
@@ -1427,6 +1560,9 @@ pub(crate) struct PendingSteer {
     blocks: Vec<StagedBlock>,
     /// Queue-head retries keep their original FIFO position when deferred.
     requeue_front: bool,
+    /// Transcript generation at echo time — a `/clear` invalidates the
+    /// hide handles (stale indexes must not touch the new transcript).
+    gen: u64,
 }
 
 fn token_spans_in(
@@ -2083,6 +2219,12 @@ impl App {
         let Some(slot) = self.parked.iter_mut().find(|slot| slot.id == session) else {
             return;
         };
+        if !slot.session_bound {
+            // Mirror of the live path's guard (dispatch_next_queued): an
+            // unbound placeholder must never burn its queue — the prompts
+            // would be addressed to an id acp.rs does not know.
+            return;
+        }
         let Some(prompt) = slot.prompt_queue.pop_front() else {
             return;
         };
@@ -2124,7 +2266,7 @@ impl App {
     fn settle_steer(&mut self, message_id: u64, deferred: bool) {
         if let Some(pending) = self.pending_steer_cells.remove(&message_id) {
             if deferred {
-                self.transcript.hide_cells(&pending.cells);
+                self.transcript.hide_cells(&pending.cells, pending.gen);
                 let queued = ClientQueuedPrompt {
                     id: message_id,
                     blocks: pending.blocks,
@@ -2146,7 +2288,7 @@ impl App {
         for slot in &mut self.parked {
             if let Some(pending) = slot.pending_steer_cells.remove(&message_id) {
                 if deferred {
-                    slot.transcript.hide_cells(&pending.cells);
+                    slot.transcript.hide_cells(&pending.cells, pending.gen);
                     let queued = ClientQueuedPrompt {
                         id: message_id,
                         blocks: pending.blocks,
@@ -3363,7 +3505,28 @@ impl App {
                             self.state_note.clear();
                         }
                     }
-                    CtlEvent::PromptQueued { .. } => {
+                    CtlEvent::PromptQueued {
+                        session_id: Some(sid),
+                        ..
+                    } => {
+                        // Per-session: only the session the prompt belongs
+                        // to settles — a background tab's prompt must not
+                        // flip the viewed tab out of Starting.
+                        if sid == self.session_id {
+                            self.prompt_pending = false;
+                            if self.state == RunState::Starting {
+                                self.state = RunState::Running;
+                            }
+                            self.state_note.clear();
+                        } else if let Some(slot) =
+                            self.parked.iter_mut().find(|slot| slot.id == *sid)
+                        {
+                            slot.prompt_pending = false;
+                        }
+                    }
+                    CtlEvent::PromptQueued { session_id: None, .. } => {
+                        // Legacy attach transport: no session attribution,
+                        // settle the viewed tab as before.
                         self.prompt_pending = false;
                         if self.state == RunState::Starting {
                             self.state = RunState::Running;
@@ -3707,7 +3870,7 @@ impl App {
                                         slot.transcript
                                             .push_notice(NoticeLevel::Info, notice);
                                     }
-                                    for (_, sid, _) in &mut self.shell_pending {
+                                    for (_, sid, _, _) in &mut self.shell_pending {
                                         if sid == &old_id {
                                             *sid = session_id.clone();
                                         }
@@ -3729,7 +3892,7 @@ impl App {
                                             self.transcript
                                                 .push_notice(NoticeLevel::Info, notice);
                                         }
-                                        for (_, sid, _) in &mut self.shell_pending {
+                                        for (_, sid, _, _) in &mut self.shell_pending {
                                             if sid == &old_id {
                                                 *sid = session_id.clone();
                                             }
@@ -3776,7 +3939,7 @@ impl App {
                                 if let Some(notice) = notice {
                                     self.transcript.push_notice(NoticeLevel::Info, notice);
                                 }
-                                for (_, sid, _) in &mut self.shell_pending {
+                                for (_, sid, _, _) in &mut self.shell_pending {
                                     if sid == &old_id || sid == &awaiting.id {
                                         *sid = session_id.clone();
                                     }
@@ -3792,7 +3955,7 @@ impl App {
                                 if let Some(notice) = notice {
                                     slot.transcript.push_notice(NoticeLevel::Info, notice);
                                 }
-                                for (_, sid, _) in &mut self.shell_pending {
+                                for (_, sid, _, _) in &mut self.shell_pending {
                                     if sid == &old_id || sid == &awaiting.id {
                                         *sid = session_id.clone();
                                     }
@@ -3827,7 +3990,7 @@ impl App {
                             if let Some(notice) = notice {
                                 self.transcript.push_notice(NoticeLevel::Info, notice);
                             }
-                            for (_, sid, _) in &mut self.shell_pending {
+                            for (_, sid, _, _) in &mut self.shell_pending {
                                 if sid == &old_id {
                                     *sid = session_id.clone();
                                 }
@@ -3875,18 +4038,19 @@ impl App {
                 if let Some(pos) = self
                     .shell_pending
                     .iter()
-                    .position(|(sid, _, _)| *sid == id)
+                    .position(|(sid, _, _, _)| *sid == id)
                 {
-                    let (_, session, cell) = self.shell_pending.remove(pos);
+                    let (_, session, cell, gen) = self.shell_pending.remove(pos);
                     // The shell is workspace-wide but its cell lives in the
                     // transcript of the session that ran it — the user may
-                    // have switched tabs while the command ran.
+                    // have switched tabs while the command ran. The gen
+                    // guard drops results for cells a /clear removed.
                     if session == self.session_id {
-                        self.transcript.finish_shell(cell, code, output);
+                        self.transcript.finish_shell(cell, code, output, gen);
                     } else if let Some(slot) =
                         self.parked.iter_mut().find(|slot| slot.id == session)
                     {
-                        slot.transcript.finish_shell(cell, code, output);
+                        slot.transcript.finish_shell(cell, code, output, gen);
                     }
                     self.needs_redraw = true;
                 }
@@ -4575,8 +4739,11 @@ impl App {
         {
             return None;
         }
+        // The snapshot covers only the viewport: clamp the screen row to it
+        // (content shorter than the pane) — absolute line = top + rel.
+        let rel = ((row - a.y) as usize).min(self.chat_view.lines.len() - 1);
         Some(SelPoint {
-            line: (self.chat_view.top + (row - a.y) as usize).min(self.chat_view.lines.len() - 1),
+            line: self.chat_view.top + rel,
             col: (col - a.x) as usize,
         })
     }
@@ -4594,7 +4761,7 @@ impl App {
     /// The transcript cell that owns the line under a screen cell, if any.
     fn tool_at(&self, col: u16, row: u16) -> Option<usize> {
         let p = self.chat_hit(col, row)?;
-        self.chat_view.owners.get(p.line).copied().flatten()
+        self.chat_view.line_owner(p.line)
     }
 
     /// Mouse wheel always scrolls the conversation, including over tool cards.
@@ -4801,19 +4968,28 @@ impl App {
     }
 
     /// Extract the selected text from the layout snapshot: cell-range slices
-    /// per line, trailing whitespace trimmed, joined with newlines.
+    /// per line, trailing whitespace trimmed, joined with newlines. The
+    /// snapshot is viewport-sized: a selection anchored above/below what the
+    /// frame showed (stale after scrolling) copies its visible part.
     pub fn selection_text(&self, sel: Selection) -> String {
         let lines = &self.chat_view.lines;
         if lines.is_empty() {
             return String::new();
         }
+        let top = self.chat_view.top;
         let (s, e) = sel.ordered();
-        let last = lines.len() - 1;
-        let (sl, el) = (s.line.min(last), e.line.min(last));
-        let mut out = Vec::with_capacity(el - sl + 1);
-        for (li, text) in lines.iter().enumerate().take(el + 1).skip(sl) {
-            let c0 = if li == sl { s.col } else { 0 };
-            let c1 = if li == el { e.col + 1 } else { usize::MAX };
+        if e.line < top {
+            return String::new(); // selection entirely above the viewport
+        }
+        let first = s.line.saturating_sub(top);
+        let last = (e.line - top).min(lines.len() - 1);
+        if first > last {
+            return String::new(); // starts below the captured viewport
+        }
+        let mut out = Vec::with_capacity(last - first + 1);
+        for (li, text) in lines.iter().enumerate().take(last + 1).skip(first) {
+            let c0 = if li + top == s.line { s.col } else { 0 };
+            let c1 = if li + top == e.line { e.col + 1 } else { usize::MAX };
             out.push(slice_by_cells(text, c0, c1).trim_end().to_string());
         }
         out.join("\n")
@@ -4822,7 +4998,7 @@ impl App {
     /// Double-click: select the whitespace-delimited word under the pointer
     /// and copy it right away (grok's word select & copy).
     fn select_word_at(&mut self, p: SelPoint) {
-        let Some(line) = self.chat_view.lines.get(p.line) else {
+        let Some(line) = self.chat_view.line_text(p.line) else {
             return;
         };
         let Some((col, width, word)) = word_span(line, p.col) else {
@@ -4930,8 +5106,7 @@ impl App {
         // viewport from the top of scrollback to just above the tail).
         let cur = if self.scroll_up == usize::MAX {
             self.chat_view
-                .lines
-                .len()
+                .total
                 .saturating_sub(self.chat_view.area.height as usize) as i64
         } else {
             self.scroll_up as i64
@@ -5125,19 +5300,12 @@ impl App {
             ));
         }
 
-        // Vim mode intercepts plain keys while it is active; overlays and
-        // forms keep their own key handling.
-        if self.vim.is_active()
-            && self.elicitation_ask.is_none()
-            && self.queue_edit.is_none()
-            && !self.slash_completion_open()
-        {
-            if self.vim.handle_key(&key, &mut self.input) {
-                self.reconcile_attachments();
-                self.refresh_file_menu();
-                return;
-            }
-        }
+        // Vim mode intercepts plain keys while it is active — but only
+        // once every modal has had its chance: overlays and forms keep
+        // their own key handling (the intercept therefore lives after the
+        // modal blocks, so a vim Insert-mode Esc cancels the ask/picker
+        // instead of toggling vim, and normal-mode letters never land in
+        // a hidden composer while a modal is up).
 
         if key.modifiers == KeyModifiers::ALT && !self.pending_cordis_approvals.is_empty() {
             let decision = match key.code {
@@ -5235,6 +5403,20 @@ impl App {
                 }
             }
             return;
+        }
+
+        // Vim mode: plain keys become vim commands, but only with no
+        // modal above (see the note at the top of this function).
+        if self.vim.is_active()
+            && self.elicitation_ask.is_none()
+            && self.queue_edit.is_none()
+            && !self.slash_completion_open()
+        {
+            if self.vim.handle_key(&key, &mut self.input) {
+                self.reconcile_attachments();
+                self.refresh_file_menu();
+                return;
+            }
         }
 
         // The @file browser owns its navigation keys while open; everything
@@ -6453,7 +6635,11 @@ impl App {
         if self.session_id != session.id {
             if let Some(tab) = self.tab_index_of(&session.id) {
                 // Already open in a tab — switching to it is the resume.
-                self.switch_to_session(tab);
+                // The view path (not the raw switch) releases compositor-
+                // owned overlays with their cancel events first, exactly
+                // like a tab click; a raw switch would leak the plugin's
+                // single-overlay slot and float the popup onto the tab.
+                self.switch_view_to_tab(tab, ctl);
                 self.resume_candidates = Vec::new();
                 self.transcript.push_notice(
                     NoticeLevel::Info,
@@ -6682,13 +6868,22 @@ impl App {
         // (composer chrome is tab-bound), and the same-session branch resets
         // its own fields.
         if self.session_id == id {
-            // Resuming the viewed session: reset its UI and re-stream.
+            // Resuming the viewed session: reset its UI and re-stream. The
+            // resume still re-binds on the ACP side (acp.rs emits
+            // SessionBound unconditionally), so this tab keeps a FIFO
+            // entry — without it a concurrent /new's SessionBound would
+            // be consumed by this bind and the tabs would cross-bind.
             self.reset_session_ui();
             self.session_id = id.to_string();
             self.transcript.set_root_session(id.to_string());
+            self.awaiting_binds.push_back(AwaitingBind {
+                id: id.to_string(),
+                open: true,
+            });
         } else if let Some(tab) = self.tab_index_of(id) {
-            // Already open in a tab — switching to it is the resume.
-            self.switch_to_session(tab);
+            // Already open in a tab — switching to it is the resume. Same
+            // as the local path: release plugin overlays on the way out.
+            self.switch_view_to_tab(tab, ctl);
             return;
         } else {
             // Park the live session; the resumed session binds this fresh
@@ -8221,6 +8416,7 @@ impl App {
                     cells,
                     blocks: blocks.clone(),
                     requeue_front: true,
+                    gen: self.transcript.gen(),
                 },
             );
             self.show_tip(self.locale.tr(
@@ -8553,6 +8749,7 @@ impl App {
                     cells,
                     blocks: staged.clone(),
                     requeue_front: false,
+                    gen: self.transcript.gen(),
                 },
             );
         }
@@ -8693,6 +8890,7 @@ impl App {
                         cells: vec![cell],
                         blocks: vec![StagedBlock::Text(text.clone())],
                         requeue_front: false,
+                        gen: self.transcript.gen(),
                     },
                 );
                 Cmd::Steer {
@@ -8723,7 +8921,7 @@ impl App {
         let cell = self.transcript.push_shell(cmd.clone());
         // Tag the pending cell with its session: the worker is shared and
         // the user may switch tabs before the command settles.
-        self.shell_pending.push((id, self.session_id.clone(), cell));
+        self.shell_pending.push((id, self.session_id.clone(), cell, self.transcript.gen()));
         let request = ShellRequest { id, command: cmd };
         let worker = self.shell_worker.get_or_insert_with(|| {
             ShellWorker::spawn(self.cfg.workspace.clone(), self.bus_tx.clone())

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -81,8 +81,14 @@ pub enum CtlEvent {
     Starting { runtime: String },
     /// initialize returned.
     Ready { server: String },
-    /// session/prompt accepted into the durable inbox.
-    PromptQueued { message_id: String },
+    /// session/prompt accepted into the durable inbox. `session_id` names
+    /// the session the prompt belongs to when the sender knows it — the
+    /// App must not settle the viewed tab's state for another session's
+    /// prompt. Legacy attach transports (no session context) send `None`.
+    PromptQueued {
+        message_id: String,
+        session_id: Option<String>,
+    },
     /// A Send Now request settled. Rejected concurrent prompts degrade to
     /// the client FIFO without changing the active turn lifecycle.
     SteerSettled { message_id: u64, deferred: bool },
@@ -232,7 +238,7 @@ pub struct CatalogModel {
 /// One advertised composition choice (`agent` / `preset` / `agent-preset`,
 /// or the first extra uncategorized select). Demo seeds stock ids including
 /// `cordis`.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct CatalogPreset {
     pub id: String,
     pub name: String,

--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -54,10 +54,13 @@ fn native_copy(text: &str) -> bool {
     false
 }
 
-/// Spawn `cmd` with `text` on stdin. These tools exit immediately after
-/// reading stdin, so a plain wait is fine at this project's scale (grok
-/// bounds the wait with a 2s deadline for wedged tmux servers).
+/// Spawn `cmd` with `text` on stdin. Both the write and the wait are
+/// bounded: wedged tmux servers or blocked `xclip` forks must never
+/// freeze the UI thread (grok bounds the same wait with a 2s deadline).
+const PIPE_DEADLINE: std::time::Duration = std::time::Duration::from_secs(2);
+
 fn pipe_cmd(cmd: &str, args: &[&str], text: &str) -> bool {
+    use std::time::Instant;
     let Ok(mut child) = Command::new(cmd)
         .args(args)
         .stdin(Stdio::piped())
@@ -67,14 +70,33 @@ fn pipe_cmd(cmd: &str, args: &[&str], text: &str) -> bool {
     else {
         return false;
     };
-    if let Some(mut stdin) = child.stdin.take() {
-        if stdin.write_all(text.as_bytes()).is_err() {
-            let _ = child.kill();
-            let _ = child.wait();
-            return false;
+    // Write on its own thread: a child that never reads must not block us
+    // on a full pipe. Killing the child below unblocks the writer with
+    // EPIPE; dropping `stdin` at thread end delivers EOF.
+    let writer = child.stdin.take().map(|mut stdin| {
+        let text = text.to_string();
+        std::thread::spawn(move || {
+            let _ = stdin.write_all(text.as_bytes());
+            let _ = stdin.flush();
+        })
+    });
+    let deadline = Instant::now() + PIPE_DEADLINE;
+    let status = loop {
+        match child.try_wait() {
+            Ok(Some(status)) => break Some(status),
+            Ok(None) if Instant::now() >= deadline => break None,
+            Ok(None) => std::thread::sleep(std::time::Duration::from_millis(10)),
+            Err(_) => break None,
         }
+    };
+    if status.is_none() {
+        let _ = child.kill();
     }
-    matches!(child.wait(), Ok(status) if status.success())
+    let _ = child.wait();
+    if let Some(writer) = writer {
+        let _ = writer.join();
+    }
+    matches!(status, Some(status) if status.success())
 }
 
 fn osc52_copy(text: &str) -> bool {

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -237,16 +237,30 @@ fn controller_loop(
                 if attached {
                     // Forward to the host runner: agent.cancel({ kind: 'user' })
                     // aborts the active turn; a followup sent after this lands
-                    // as the next turn.
+                    // as the next turn. A failed interrupt must not report
+                    // success — the agent-side turn would keep running and
+                    // stream updates into a UI that already went idle.
                     let guard = runtime.lock().unwrap();
-                    if let Some(rt) = guard.as_ref() {
-                        let params = json!({ "sessionId": session_id });
-                        let _ =
-                            rt.request("session/interrupt", Some(params), Duration::from_secs(10));
+                    let interrupt = guard
+                        .as_ref()
+                        .map(|rt| {
+                            let params = json!({ "sessionId": session_id });
+                            rt.request("session/interrupt", Some(params), Duration::from_secs(10))
+                        });
+                    drop(guard);
+                    match interrupt {
+                        Some(Ok(_)) | None => {
+                            let _ = bus.send(AppEvent::Ctl(CtlEvent::Interrupted {
+                                session_id: session_id.clone(),
+                            }));
+                        }
+                        Some(Err(err)) => {
+                            let _ = bus.send(AppEvent::Ctl(CtlEvent::SessionError {
+                                session_id: session_id.clone(),
+                                message: format!("session/interrupt failed: {err:#}"),
+                            }));
+                        }
                     }
-                    let _ = bus.send(AppEvent::Ctl(CtlEvent::Interrupted {
-                        session_id: session_id.clone(),
-                    }));
                     continue;
                 }
                 // The kill itself happens in interrupt_now(); this is the
@@ -750,7 +764,7 @@ fn send_attached_prompt(rt: &Arc<RuntimeProcess>, bus: &Sender<AppEvent>, params
                 .and_then(Value::as_str)
                 .unwrap_or_default()
                 .to_string();
-            let _ = bus.send(AppEvent::Ctl(CtlEvent::PromptQueued { message_id }));
+            let _ = bus.send(AppEvent::Ctl(CtlEvent::PromptQueued { message_id, session_id: None }));
         }
         Err(err) => {
             let _ = bus.send(AppEvent::Ctl(CtlEvent::Error(format!(
@@ -841,7 +855,10 @@ fn handle_prompt(
                 .and_then(Value::as_str)
                 .unwrap_or_default()
                 .to_string();
-            let _ = bus.send(AppEvent::Ctl(CtlEvent::PromptQueued { message_id }));
+            let _ = bus.send(AppEvent::Ctl(CtlEvent::PromptQueued {
+                message_id,
+                session_id: Some(session_id.to_string()),
+            }));
         }
         Err(err) => {
             if interrupted.swap(false, Ordering::SeqCst) {

--- a/src/elicitation.rs
+++ b/src/elicitation.rs
@@ -429,8 +429,14 @@ impl ElicitationFormState {
 
     pub fn handle_key(&mut self, key: KeyEvent) -> Option<ElicitationReply> {
         if key.code == KeyCode::Esc
-            || (key.code == KeyCode::Char('c') && key.modifiers.contains(KeyModifiers::CONTROL))
+            || (key.code == KeyCode::Char('c')
+                && key
+                    .modifiers
+                    .contains(KeyModifiers::CONTROL)
+                && !key.modifiers.intersects(KeyModifiers::SHIFT | KeyModifiers::ALT))
         {
+            // Only plain ctrl+c cancels the form; ctrl+shift+c (copy
+            // selection) and other chorded variants must not wipe input.
             return Some(ElicitationReply::Cancelled);
         }
         if key.code == KeyCode::BackTab {

--- a/src/events.rs
+++ b/src/events.rs
@@ -151,7 +151,13 @@ pub fn parse_notification(method: &str, params: &Value) -> Vec<UiEvent> {
         }],
         "subagent.finished" => vec![UiEvent::SubagentFinished {
             child: str_field(params, "childSessionId"),
-            failed: false,
+            // Mirror the ACP path: the notification carries the child's
+            // stop status — hardcoding success hid failed tasks.
+            failed: params
+                .get("status")
+                .or_else(|| params.get("stopReason"))
+                .and_then(Value::as_str)
+                == Some("failed"),
         }],
         "session.event" => parse_session_event(params),
         "session/update" => parse_session_update(params),

--- a/src/input/composer.rs
+++ b/src/input/composer.rs
@@ -320,8 +320,11 @@ impl ComposerEditor {
     }
 
     /// Cut the whole buffer range `[start, end)` (char offsets) —
-    /// deleting into an inline `[image n]` token.
+    /// deleting into an inline `[image n]` token. An active keyboard
+    /// selection is cancelled first: the widget's `delete_str` would
+    /// otherwise delete the selection instead of the requested range.
     pub fn delete_char_range(&mut self, start: usize, end: usize) {
+        self.textarea_mut().cancel_selection();
         let (row, col) = self.char_to_rowcol(start);
         self.move_cursor(CursorMove::Jump(row as u16, col as u16));
         self.textarea_mut().delete_str(end.saturating_sub(start));
@@ -643,6 +646,8 @@ impl ComposerEditor {
     }
 
     /// Kill from the cursor to the end of the current rendered row.
+    /// Cancels an active selection first so the requested range dies
+    /// (the widget's `delete_str` prefers the selection).
     pub fn kill_to_end(&mut self, wrap_width: usize) {
         let end = self
             .cursor_screen_row(wrap_width)
@@ -650,12 +655,15 @@ impl ComposerEditor {
         let Some(end) = end else { return };
         let cur = self.cursor_char();
         if end > cur {
+            self.textarea_mut().cancel_selection();
             self.textarea_mut().delete_str(end - cur);
             self.hist_pos = None;
         }
     }
 
     /// Kill from the start of the current rendered row to the cursor.
+    /// Cancels an active selection first so the requested range dies
+    /// (the widget's `delete_str` prefers the selection).
     pub fn kill_to_start(&mut self, wrap_width: usize) {
         let start = self
             .cursor_screen_row(wrap_width)
@@ -663,6 +671,7 @@ impl ComposerEditor {
         let Some(start) = start else { return };
         let cur = self.cursor_char();
         if start < cur {
+            self.textarea_mut().cancel_selection();
             let (r, c) = self.char_to_rowcol(start);
             self.textarea_mut()
                 .move_cursor(CursorMove::Jump(r as u16, c as u16));

--- a/src/input/editor.rs
+++ b/src/input/editor.rs
@@ -5,7 +5,19 @@
 //! those migrate too.
 #![allow(dead_code)]
 
+use unicode_segmentation::UnicodeSegmentation;
 use unicode_width::UnicodeWidthChar;
+
+/// Display width of one char: combining marks and other zero-width chars
+/// take no cell (the terminal paints them over the previous one); control
+/// chars keep a safe 1-cell budget.
+fn char_width(ch: char) -> usize {
+    if ch.is_control() {
+        1
+    } else {
+        UnicodeWidthChar::width(ch).unwrap_or(0)
+    }
+}
 
 /// Editable prompt state. `cursor` is a char index (not bytes).
 pub struct Input {
@@ -66,12 +78,25 @@ impl Input {
         if self.cursor == 0 {
             return;
         }
-        let start = self.byte_at(self.cursor - 1);
+        // Delete one grapheme cluster, not one char: a combining mark or
+        // a ZWJ sequence dies together with its base character instead of
+        // leaving a dangling mark behind.
+        let start = self.prev_grapheme_boundary(self.cursor);
+        let start_byte = self.byte_at(start);
         let end = self.byte_at(self.cursor);
-        self.buf.replace_range(start..end, "");
-        self.cursor -= 1;
+        self.buf.replace_range(start_byte..end, "");
+        self.cursor = start;
         self.preferred_visual_col = None;
         self.cursor_at_wrap_end = false;
+    }
+
+    /// Char index of the boundary one grapheme cluster before `char_idx`.
+    fn prev_grapheme_boundary(&self, char_idx: usize) -> usize {
+        let end = self.byte_at(char_idx);
+        match self.buf[..end].graphemes(true).last() {
+            Some(cluster) => char_idx - cluster.chars().count(),
+            None => char_idx,
+        }
     }
 
     pub fn delete_word_back(&mut self) {
@@ -125,7 +150,13 @@ impl Input {
             return;
         }
         let start = self.byte_at(self.cursor);
-        let end = self.byte_at(self.cursor + 1);
+        // One grapheme cluster dies, not one char (see `backspace`).
+        let cluster_chars = self.buf[start..]
+            .graphemes(true)
+            .next()
+            .map(|cluster| cluster.chars().count())
+            .unwrap_or(1);
+        let end = self.byte_at(self.cursor + cluster_chars);
         self.buf.replace_range(start..end, "");
         self.preferred_visual_col = None;
         self.cursor_at_wrap_end = false;
@@ -213,7 +244,7 @@ impl Input {
                 break;
             }
             let start = carets[i].1;
-            let w = UnicodeWidthChar::width(chars[i]).unwrap_or(0).max(1);
+            let w = char_width(chars[i]);
             if col >= start && col < start + w {
                 if w > 1 && col >= start + w / 2 {
                     return i + 1; // right half of a wide char → after it
@@ -248,7 +279,7 @@ impl Input {
                 break;
             }
             let start = carets[i].1;
-            let w = UnicodeWidthChar::width(chars[i]).unwrap_or(0).max(1);
+            let w = char_width(chars[i]);
             if col >= start && col < start + w {
                 return i + 1;
             }
@@ -393,7 +424,7 @@ impl Input {
             return None;
         }
         let (row, col) = carets[index - 1];
-        let end = col + UnicodeWidthChar::width(previous).unwrap_or(0).max(1);
+        let end = col + char_width(previous);
         (carets[index].0 > row).then_some((row, end))
     }
 
@@ -410,13 +441,13 @@ impl Input {
                 carets[index + 1] = (row, col);
                 continue;
             }
-            let char_width = UnicodeWidthChar::width(ch).unwrap_or(0).max(1);
-            if col + char_width > width {
+            let cw = char_width(ch);
+            if col + cw > width {
                 row += 1;
                 col = 0;
             }
             carets[index] = (row, col);
-            col += char_width;
+            col += cw;
             carets[index + 1] = (row, col);
         }
         if !chars.is_empty() && chars.last() != Some(&'\n') && col >= width {

--- a/src/input/vim.rs
+++ b/src/input/vim.rs
@@ -139,6 +139,10 @@ impl VimState {
             (_, 'O') => {
                 editor.line_head();
                 editor.insert_newline();
+                // `insert_newline` leaves the cursor at (row+1, 0) — the
+                // head of the original text shifted down. Lift back onto
+                // the new blank line above, as vim's `O` does.
+                editor.move_up();
                 self.mode = VimMode::Insert;
             }
             // Anything else (letters, digits, punctuation) is consumed as

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,7 +29,9 @@ mod transcript;
 mod ui;
 
 use std::io::Write;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc;
+use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::{bail, Context, Result};
@@ -386,11 +388,26 @@ fn main() -> Result<()> {
     let mut thumbnails = pet::Thumbnails::new();
 
     // input pump
+    let input_gate = Arc::new(InputGate::default());
     {
         let tx = bus_tx.clone();
+        let gate = Arc::clone(&input_gate);
         std::thread::Builder::new()
             .name("input".into())
             .spawn(move || loop {
+                if gate.paused.load(Ordering::SeqCst) {
+                    // Parked: Terminal Auth (or another TTY owner) has the
+                    // terminal — never compete for keystrokes.
+                    gate.parked.store(true, Ordering::SeqCst);
+                    std::thread::sleep(Duration::from_millis(20));
+                    continue;
+                }
+                gate.parked.store(false, Ordering::SeqCst);
+                match crossterm::event::poll(Duration::from_millis(50)) {
+                    Ok(true) => {}
+                    Ok(false) => continue,
+                    Err(_) => break,
+                }
                 match crossterm::event::read() {
                     Ok(crossterm::event::Event::Key(key)) => {
                         // Recover terminal-lost physical modifiers at read
@@ -516,6 +533,9 @@ fn main() -> Result<()> {
                 last_tick = std::time::Instant::now();
             }
             if let Some(launch) = app.take_terminal_auth() {
+                // Park the input reader first: the auth subprocess inherits
+                // the TTY and must not race crossterm for keystrokes.
+                input_gate.park();
                 restore_terminal();
                 eprintln!(
                     "\n{} — finish setup in this terminal, then Martty resumes.\n",
@@ -523,6 +543,7 @@ fn main() -> Result<()> {
                 );
                 let result = crate::acp_auth::run_terminal_auth(&launch, app.locale);
                 enter_tui()?;
+                input_gate.unpark();
                 app.needs_redraw = true;
                 while let Ok(ev) = bus_rx.try_recv() {
                     if !matches!(ev, AppEvent::Term(_)) {
@@ -580,6 +601,34 @@ fn enter_tui() -> Result<()> {
     Ok(())
 }
 
+/// Keeps the crossterm input thread from competing for TTY keystrokes
+/// while Terminal Auth owns the terminal. `parked` lets the main thread
+/// wait until the reader is actually out of the poll/read path, so the
+/// auth subprocess inherits an uncontended input queue.
+#[derive(Default)]
+struct InputGate {
+    paused: AtomicBool,
+    parked: AtomicBool,
+}
+
+impl InputGate {
+    /// Park the input thread. Bounded wait: a wedged reader must not
+    /// hang the run loop — at worst one keystroke in the transition
+    /// window is still lost (unavoidable with a blocked reader).
+    fn park(&self) {
+        self.paused.store(true, Ordering::SeqCst);
+        let deadline = std::time::Instant::now() + Duration::from_millis(300);
+        while !self.parked.load(Ordering::SeqCst) && std::time::Instant::now() < deadline {
+            std::thread::sleep(Duration::from_millis(5));
+        }
+    }
+
+    fn unpark(&self) {
+        self.parked.store(false, Ordering::SeqCst);
+        self.paused.store(false, Ordering::SeqCst);
+    }
+}
+
 #[cfg(unix)]
 fn install_termination_handler(tx: mpsc::Sender<AppEvent>) -> Result<()> {
     let mut signals = signal_hook::iterator::Signals::new([
@@ -590,7 +639,11 @@ fn install_termination_handler(tx: mpsc::Sender<AppEvent>) -> Result<()> {
     std::thread::Builder::new()
         .name("termination-signal".into())
         .spawn(move || {
-            if signals.forever().next().is_some() {
+            // Stay registered for the process lifetime: dropping the
+            // iterator would unregister the handlers and leave a second
+            // Ctrl+C to hit the default disposition (raw mode + alternate
+            // screen intact, terminal left broken).
+            for _sig in signals.forever() {
                 let _ = tx.send(AppEvent::Terminate);
             }
         })

--- a/src/markdown.rs
+++ b/src/markdown.rs
@@ -69,13 +69,18 @@ pub fn render(text: &str, theme: &Theme, width: usize) -> Vec<Line<'static>> {
         };
         if is_code {
             let text: String = segs.iter().map(|s| s.text.as_str()).collect();
-            if !segs.is_empty() && text.starts_with("```") {
+            // Delimiters are sentinel-prefixed (see `code_block_fence`);
+            // literal ```` ``` ```` content lines — including inside longer
+            // fences — never toggle the frame anymore.
+            if !segs.is_empty() && text.starts_with(CODE_FENCE_SENTINEL) {
                 if in_code {
                     out.push(code_frame_bottom(width, theme));
                     in_code = false;
                 } else {
                     out.push(code_frame_top(
-                        text.trim_start_matches('`').trim(),
+                        text.strip_prefix(CODE_FENCE_SENTINEL)
+                            .unwrap_or("")
+                            .trim(),
                         width,
                         theme,
                     ));
@@ -165,6 +170,11 @@ pub fn render(text: &str, theme: &Theme, width: usize) -> Vec<Line<'static>> {
     out
 }
 
+/// Sentinel prefix that marks fence delimiter lines (see
+/// `DeepSeekStyleSheet::code_block_fence`). Two NUL bytes: never produced
+/// by real markdown content.
+const CODE_FENCE_SENTINEL: &str = "\u{0}\u{0}";
+
 /// tui-markdown style sheet mapping markdown constructs onto the DeepSeek
 /// palette. Only non-default choices are overridden.
 #[derive(Clone)]
@@ -178,6 +188,18 @@ impl StyleSheet for DeepSeekStyleSheet {
     /// Headings read through color alone; the `#` markers are omitted.
     fn heading_marker(&self, _level: u8) -> &str {
         ""
+    }
+
+    /// Fence delimiter lines carry a sentinel prefix instead of bare
+    /// backticks. tui-markdown normalizes every fence delimiter to
+    /// `"```"`, which is indistinguishable from a literal ```` ``` ````
+    /// *content* line inside a 4+ backtick fence (a CommonMark way to
+    /// show fenced examples). The sentinel makes delimiters unambiguous:
+    /// the frame logic only toggles on it, and backtick-looking content
+    /// lines render as code rows. The sentinel is never displayed — the
+    /// frame edges replace the delimiter lines.
+    fn code_block_fence(&self) -> &str {
+        CODE_FENCE_SENTINEL
     }
 
     /// Inline code and fenced blocks share one look: light gray on the
@@ -294,7 +316,7 @@ fn table_row_separator(row: &Line, theme: &Theme) -> Line<'static> {
             if c == '│' {
                 bars.push(w);
             }
-            w += UnicodeWidthChar::width(c).unwrap_or(0).max(1);
+            w += UnicodeWidthChar::width(c).unwrap_or(0);
         }
     }
     let mut sep = String::with_capacity(w);
@@ -486,11 +508,20 @@ fn code_frame_top(lang: &str, width: usize, theme: &Theme) -> Line<'static> {
     let label = if lang.is_empty() {
         String::new()
     } else {
-        // Language names are ASCII in practice; clamp anyway so a hostile
-        // info string can't blow the frame width.
+        // Clamp by display width (not char count) so a hostile CJK info
+        // string can't blow the frame width either.
         let max = width.saturating_sub(8);
-        let lang: String = lang.chars().take(max).collect();
-        format!("─ {lang} ")
+        let mut cut = 0usize;
+        let mut used = 0usize;
+        for c in lang.chars() {
+            let cw = UnicodeWidthChar::width(c).unwrap_or(0);
+            if used + cw > max {
+                break;
+            }
+            used += cw;
+            cut += c.len_utf8();
+        }
+        format!("─ {} ", &lang[..cut])
     };
     let pad = width
         .saturating_sub(2)
@@ -540,7 +571,7 @@ fn wrap_pre(segs: Vec<Seg>, width: usize) -> Vec<Line<'static>> {
     let mut w = 0usize;
     for seg in segs {
         for c in seg.text.chars() {
-            let cw = UnicodeWidthChar::width(c).unwrap_or(0).max(1);
+            let cw = UnicodeWidthChar::width(c).unwrap_or(0);
             if w + cw > width && w > 0 {
                 if !buf.is_empty() {
                     spans.push(Span::styled(std::mem::take(&mut buf), style));
@@ -548,8 +579,13 @@ fn wrap_pre(segs: Vec<Seg>, width: usize) -> Vec<Line<'static>> {
                 out.push(Line::from(std::mem::take(&mut spans)));
                 w = 0;
             }
-            if !buf.is_empty() && style != seg.style {
-                spans.push(Span::styled(std::mem::take(&mut buf), style));
+            // Switch style *before* pushing the char: a width flush may
+            // have left `buf` empty, and the first char of the new span
+            // must not inherit the previous span's style.
+            if style != seg.style {
+                if !buf.is_empty() {
+                    spans.push(Span::styled(std::mem::take(&mut buf), style));
+                }
                 style = seg.style;
             }
             buf.push(c);
@@ -596,7 +632,7 @@ fn truncate_line(segs: Vec<Seg>, width: usize, theme: &Theme) -> Line<'static> {
     for seg in segs {
         let mut buf = String::new();
         for c in seg.text.chars() {
-            let cw = UnicodeWidthChar::width(c).unwrap_or(0).max(1);
+            let cw = UnicodeWidthChar::width(c).unwrap_or(0);
             if w + cw > budget {
                 stopped = true;
                 break;
@@ -777,7 +813,7 @@ fn chunk_str(s: &str, width: usize) -> Vec<&str> {
     let mut start = 0usize;
     let mut w = 0usize;
     for (i, ch) in s.char_indices() {
-        let cw = UnicodeWidthChar::width(ch).unwrap_or(0).max(1);
+        let cw = UnicodeWidthChar::width(ch).unwrap_or(0);
         if w + cw > width && w > 0 {
             out.push(&s[start..i]);
             start = i;

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -22,6 +22,11 @@ type SharedWriter = Arc<Mutex<Option<Box<dyn Write + Send>>>>;
 pub struct RuntimeProcess {
     child: Arc<Mutex<Option<Child>>>,
     stdin: SharedWriter,
+    /// Serializes writers. Never held across the blocking write itself:
+    /// `write_line` *takes the writer out* of `stdin` for the duration, so
+    /// a wedged child blocking a write can never starve `kill()` or the
+    /// reader thread (they only ever need the shared slot, briefly).
+    write_turn: Arc<Mutex<()>>,
     pending: Arc<Mutex<HashMap<String, SyncSender<Result<Value, RpcFailure>>>>>,
     next_id: AtomicU64,
     pub stderr_tail: Arc<Mutex<Vec<String>>>,
@@ -72,6 +77,7 @@ impl RuntimeProcess {
         let proc = RuntimeProcess {
             child: Arc::new(Mutex::new(Some(child))),
             stdin: Arc::new(Mutex::new(Some(Box::new(stdin) as Box<dyn Write + Send>))),
+            write_turn: Arc::new(Mutex::new(())),
             pending: Arc::new(Mutex::new(HashMap::new())),
             next_id: AtomicU64::new(1),
             stderr_tail: Arc::new(Mutex::new(Vec::new())),
@@ -115,6 +121,7 @@ impl RuntimeProcess {
         let proc = RuntimeProcess {
             child: Arc::new(Mutex::new(None)),
             stdin: Arc::new(Mutex::new(Some(Box::new(writer) as Box<dyn Write + Send>))),
+            write_turn: Arc::new(Mutex::new(())),
             pending: Arc::new(Mutex::new(HashMap::new())),
             next_id: AtomicU64::new(1),
             stderr_tail: Arc::new(Mutex::new(Vec::new())),
@@ -128,6 +135,7 @@ impl RuntimeProcess {
     fn start_reader(&self, stream: impl Read + Send + 'static, bus: Sender<AppEvent>) {
         let pending = Arc::clone(&self.pending);
         let stdin_slot = Arc::clone(&self.stdin);
+        let write_turn = Arc::clone(&self.write_turn);
         let child_slot = Arc::clone(&self.child);
         std::thread::Builder::new()
             .name("dsh-frames".into())
@@ -141,7 +149,7 @@ impl RuntimeProcess {
                     let Ok(msg) = serde_json::from_str::<Value>(&line) else {
                         continue;
                     };
-                    route_message(msg, &pending, &stdin_slot, &bus);
+                    route_message(msg, &pending, &stdin_slot, &write_turn, &bus);
                 }
                 let waiters: Vec<_> = pending.lock().unwrap().drain().collect();
                 for (_, tx) in waiters {
@@ -174,13 +182,28 @@ impl RuntimeProcess {
     }
 
     fn write_line(&self, value: &Value) -> Result<()> {
+        let _turn = self.write_turn.lock().unwrap();
+        // Take the writer out for the duration of the (possibly blocking)
+        // write: nobody else ever blocks on the shared slot behind a stuck
+        // pipe — kill() clears the slot instead of waiting for this write.
+        let mut writer = {
+            let mut guard = self.stdin.lock().unwrap();
+            guard.take().context("harness runtime stdin closed")?
+        };
+        let result = (|| {
+            let mut payload = serde_json::to_vec(value)?;
+            payload.push(b'\n');
+            writer.write_all(&payload)?;
+            writer.flush()?;
+            Ok(())
+        })();
+        // Put the writer back unless kill() already claimed the slot.
         let mut guard = self.stdin.lock().unwrap();
-        let stdin = guard.as_mut().context("harness runtime stdin closed")?;
-        let mut payload = serde_json::to_vec(value)?;
-        payload.push(b'\n');
-        stdin.write_all(&payload)?;
-        stdin.flush()?;
-        Ok(())
+        if guard.is_none() {
+            return result; // runtime killed; the writer dies with it
+        }
+        *guard = Some(writer);
+        result
     }
 
     /// Blocking JSON-RPC request. Call off the UI thread.
@@ -263,6 +286,7 @@ fn route_message(
     msg: Value,
     pending: &Arc<Mutex<HashMap<String, SyncSender<Result<Value, RpcFailure>>>>>,
     stdin_slot: &SharedWriter,
+    write_turn: &Mutex<()>,
     bus: &Sender<AppEvent>,
 ) {
     let id = msg.get("id");
@@ -270,18 +294,30 @@ fn route_message(
     match (id, method) {
         // Server-initiated request (e.g. interaction plugins). The minimal
         // composition never sends one; answer method-not-found so the runtime
-        // never deadlocks waiting on us.
+        // never deadlocks waiting on us. Best-effort: the reply only goes out
+        // when the write path is idle — a wedged runtime must never stop the
+        // reader thread from draining stdout.
         (Some(id), Some(method)) => {
             let reply = json!({
                 "jsonrpc": "2.0",
                 "id": id,
                 "error": { "code": -32601, "message": format!("dsb: unhandled server request {method}") }
             });
-            if let Some(stdin) = stdin_slot.lock().unwrap().as_mut() {
-                if let Ok(mut payload) = serde_json::to_vec(&reply) {
-                    payload.push(b'\n');
-                    let _ = stdin.write_all(&payload);
-                    let _ = stdin.flush();
+            if let Ok(_turn) = write_turn.try_lock() {
+                let writer = stdin_slot.lock().unwrap().take();
+                if let Some(mut stdin) = writer {
+                    if let Ok(mut payload) = serde_json::to_vec(&reply) {
+                        payload.push(b'\n');
+                        let _ = stdin.write_all(&payload);
+                        let _ = stdin.flush();
+                    }
+                    let mut guard = stdin_slot.lock().unwrap();
+                    if guard.is_none() {
+                        // kill() claimed the slot while we wrote: let the
+                        // writer die with the runtime.
+                    } else {
+                        *guard = Some(stdin);
+                    }
                 }
             }
             let _ = bus.send(AppEvent::RuntimeStderr(format!(

--- a/src/slots.rs
+++ b/src/slots.rs
@@ -435,10 +435,13 @@ fn render_node(node: &TuiNode, theme: &Theme, width: usize) -> Vec<Line<'static>
         }
         TuiNode::User { text, queued, .. } => {
             let prefix = if *queued { "› queued · " } else { "› " };
+            // Budget by display width, not byte length — the prefix
+            // contains multi-byte glyphs (`›`/`·`), which made wrapped
+            // CJK text fold early.
             indent(
                 styled_wrapped(
                     text,
-                    width.saturating_sub(prefix.len()),
+                    width.saturating_sub(UnicodeWidthStr::width(prefix)),
                     Style::default().fg(theme.bubble_fg),
                 ),
                 prefix,

--- a/src/transcript.rs
+++ b/src/transcript.rs
@@ -309,10 +309,13 @@ fn build_body(
                     .flat_map(|raw| wrap(raw, body_w))
                     .collect();
                 let total = all.len();
+                // Collapsed view keeps the *tail* — errors and results live
+                // at the end of shell output, and the Tool cell collapses
+                // the same direction (last N lines).
                 let shown = if expanded || total <= COLLAPSED_SHELL_LINES {
                     all
                 } else {
-                    all.into_iter().take(COLLAPSED_SHELL_LINES).collect()
+                    all.into_iter().skip(total - COLLAPSED_SHELL_LINES).collect()
                 };
                 let shown_len = shown.len();
                 for l in shown {
@@ -424,6 +427,10 @@ pub struct Transcript {
     /// UI language for the notices this transcript renders (set by the App
     /// that owns it; cells already pushed keep the language they had).
     pub locale: Locale,
+    /// Bumped by `clear()`. Long-lived cell-index handles (shell results,
+    /// steer echoes) carry the generation they were pushed in, so stale
+    /// indexes can never land in a freshly cleared transcript.
+    gen: u64,
 }
 
 impl Transcript {
@@ -447,7 +454,14 @@ impl Transcript {
             last_model: None,
             expand_all: false,
             locale: Locale::default(),
+            gen: 0,
         }
+    }
+
+    /// Transcript generation: changes whenever `clear()` empties the cells,
+    /// invalidating cell-index handles held elsewhere.
+    pub fn gen(&self) -> u64 {
+        self.gen
     }
 
     pub fn set_root_session(&mut self, session: String) {
@@ -471,6 +485,7 @@ impl Transcript {
         self.tools.clear();
         self.plan_cell = None;
         self.last_finish = None;
+        self.gen = self.gen.wrapping_add(1);
     }
 
     fn agent_label(&self, session: &str) -> Option<String> {
@@ -521,7 +536,10 @@ impl Transcript {
         self.cells.len() - 1
     }
 
-    pub fn finish_shell(&mut self, idx: usize, code: Option<i32>, output: String) {
+    pub fn finish_shell(&mut self, idx: usize, code: Option<i32>, output: String, gen: u64) {
+        if gen != self.gen {
+            return; // the cell died with a /clear or resume replay
+        }
         if let Some(cell) = self.cells.get_mut(idx) {
             if let CellKind::Shell { output: slot, .. } = &mut cell.kind {
                 *slot = Some((code, output));
@@ -530,7 +548,10 @@ impl Transcript {
         }
     }
 
-    pub fn hide_cells(&mut self, cells: &[usize]) {
+    pub fn hide_cells(&mut self, cells: &[usize], gen: u64) {
+        if gen != self.gen {
+            return; // stale handles from before a clear
+        }
         for &index in cells {
             if let Some(cell) = self.cells.get_mut(index) {
                 cell.hidden = true;
@@ -1383,7 +1404,12 @@ impl Transcript {
                                 Style::default().fg(theme.caption),
                             ),
                             Span::styled(
-                                clamp_str(preview, width.saturating_sub(source.len() + 14)),
+                                clamp_str(
+                                    preview,
+                                    width.saturating_sub(
+                                        UnicodeWidthStr::width(source.as_str()) + 15,
+                                    ),
+                                ),
                                 Style::default().fg(theme.fg_tertiary),
                             ),
                         ]),

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,5 +1,6 @@
 //! Rendering: banner, scrollback, tips row, status bar, prompt, hints, overlays.
 
+use ratatui::buffer::Buffer;
 use ratatui::layout::{Alignment, Constraint, Margin, Rect};
 use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
@@ -7,6 +8,7 @@ use ratatui::widgets::{
     Block, BorderType, Borders, Cell, Clear, FrameExt, HighlightSpacing, Paragraph, Row, Scrollbar,
     ScrollbarOrientation, ScrollbarState, Table, TableState,
 };
+use ratatui::widgets::Widget;
 use ratatui::Frame;
 use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
@@ -127,11 +129,20 @@ fn queue_shelf_height(app: &App, main_height: u16, child_view: bool) -> u16 {
 /// Structured input-dock nodes expand inside the composer card. Generic
 /// summaries keep using the one-line cap, so Plan/Goal stay compact while a
 /// selector such as Queue can temporarily reveal its rows above the input.
+/// Measured at the width the dock will actually render at: card border (2)
+/// plus the pet inset (PET_PAD when the pet is perched in the composer) —
+/// measuring at the full card width under-reserved rows and truncated the
+/// content (M12).
 fn input_dock_body_height(app: &App, main_width: u16, main_height: u16, child_view: bool) -> u16 {
     if child_view || main_height < 14 {
         return 0;
     }
-    let lines = input_dock_body_lines(app, main_width.saturating_sub(2) as usize);
+    let pet_pad = if app.pet_visible && main_width >= 60 && main_height >= 10 {
+        PET_PAD
+    } else {
+        0
+    };
+    let lines = input_dock_body_lines(app, main_width.saturating_sub(2 + pet_pad) as usize);
     (lines.len() as u16).min(main_height.saturating_sub(12))
 }
 
@@ -638,7 +649,10 @@ fn draw_plugin_select(f: &mut Frame, app: &App, screen: Rect) {
         })
         .max()
         .unwrap_or(0) as u16;
-    let width = (needed + 2).min(screen.width.saturating_sub(4)).max(28);
+    // The 28-column floor must not beat the screen cap on narrow
+    // terminals (24-27 columns would render the popup past the right
+    // edge): apply the floor first, then the cap wins.
+    let width = (needed + 2).max(28).min(screen.width.saturating_sub(4));
     let inner = width.saturating_sub(2) as usize;
     let label_cells = inner.saturating_sub(4);
     let desc_cells = inner.saturating_sub(4);
@@ -1257,6 +1271,25 @@ fn draw_navigation_dock(f: &mut Frame, app: &mut App, area: Rect, embedded: bool
             break;
         };
         sections.remove(index);
+    }
+    // The loop above stops at two sections; two long ones can still
+    // overflow into the trailing action area. Trim the *last* drawn
+    // section only when the rail would actually overlap the trailing
+    // block (it starts one column past the budget) — earlier sections
+    // and their text stay intact.
+    if let Some(last_index) = sections.len().checked_sub(1) {
+        let used: usize = sections[..last_index]
+            .iter()
+            .map(|section| span_widths(&section.spans))
+            .sum::<usize>()
+            + last_index * 2;
+        let overlap_limit = left_budget + 1;
+        let last_width = span_widths(&sections[last_index].spans);
+        if used + last_width > overlap_limit {
+            let budget = overlap_limit.saturating_sub(used);
+            let last = &mut sections[last_index];
+            last.spans = truncate_spans(&last.spans, budget.saturating_sub(1));
+        }
     }
 
     let border_style = Style::default().fg(theme.border);
@@ -1929,6 +1962,38 @@ fn span_widths(spans: &[Span]) -> usize {
     spans.iter().map(|s| s.content.width()).sum()
 }
 
+/// Cut a span list to `budget` display columns, ending with an ellipsis
+/// when anything was dropped. Keeps each span's style.
+fn truncate_spans(spans: &[Span<'static>], budget: usize) -> Vec<Span<'static>> {
+    let mut out = Vec::new();
+    let mut used = 0usize;
+    for span in spans {
+        let width = span.content.width();
+        if used + width <= budget {
+            out.push(span.clone());
+            used += width;
+            continue;
+        }
+        let remaining = budget.saturating_sub(used);
+        let mut text = String::new();
+        let mut taken = 0usize;
+        for c in span.content.chars() {
+            let cw = unicode_width::UnicodeWidthChar::width(c).unwrap_or(0);
+            if taken + cw > remaining {
+                break;
+            }
+            text.push(c);
+            taken += cw;
+        }
+        if budget > 0 {
+            text.push('…');
+        }
+        out.push(Span::styled(text, span.style));
+        break;
+    }
+    out
+}
+
 fn slot_has_nodes(app: &App, name: &str) -> bool {
     app.slot_snapshots
         .get(name)
@@ -2244,18 +2309,20 @@ fn draw_chat(f: &mut Frame, app: &mut App, area: Rect) {
         app.chat_view.manual_top = Some(start);
         (start, end)
     };
-    let visible: Vec<Line> = lines[start..end].to_vec();
 
     // Layout snapshot for mouse selection: hit-testing and copy extraction
     // read exactly what this frame showed (grok-build's resolved selection
-    // model, scaled down to plain text per wrapped line).
+    // model, scaled down to plain text per wrapped line). Viewport-sized
+    // only (L25): the absolute→relative seam lives in
+    // `ChatView::line_text`/`line_owner`; `total` keeps scroll math whole.
     app.chat_view.area = inner;
     app.chat_view.top = start;
-    app.chat_view.lines = lines
+    app.chat_view.total = total;
+    app.chat_view.lines = lines[start..end]
         .iter()
         .map(|l| l.spans.iter().map(|s| s.content.as_ref()).collect())
         .collect();
-    app.chat_view.owners = owners;
+    app.chat_view.owners = owners[start..end].to_vec();
     // The ⌕ jump flash (issue #103): resolve the flashing transcript cell
     // to its current line span every frame — streaming can move the prompt
     // — and drop it once the 5 s window expired.
@@ -2290,7 +2357,10 @@ fn draw_chat(f: &mut Frame, app: &mut App, area: Rect) {
         })
         .collect();
 
-    f.render_widget(Paragraph::new(visible), inner);
+    // Zero-copy render (B): the widget borrows the frame's assembled
+    // window — no per-frame `to_vec` of the viewport on top of the
+    // snapshot above.
+    f.render_widget(LinesWindow { lines: &lines[start..end] }, inner);
     // The transient ⌕ jump wash paints under an active copy-selection so
     // the user's own highlight always wins.
     draw_prompt_flash(f, app, inner, start);
@@ -2298,6 +2368,27 @@ fn draw_chat(f: &mut Frame, app: &mut App, area: Rect) {
     // Last: the selection overlay above also writes these cells, so the
     // full-rewrite marker must run after it (issue #38).
     force_full_rewrite(f, inner);
+}
+
+/// Render the viewport's pre-wrapped lines, borrowing the frame's assembled
+/// `lines` — the zero-copy replacement for `Paragraph::new(window.to_vec())`,
+/// which had to clone the window because `Paragraph` consumes its text.
+/// Left-aligned truncation per line, exactly what an unwrapped `Paragraph`
+/// does: `Buffer::set_line` patches `line.style` over each span style and
+/// clips at the pane width.
+struct LinesWindow<'a> {
+    lines: &'a [Line<'static>],
+}
+
+impl Widget for LinesWindow<'_> {
+    fn render(self, area: Rect, buf: &mut Buffer) {
+        for (row, line) in self.lines.iter().enumerate() {
+            if row as u16 >= area.height {
+                break;
+            }
+            buf.set_line(area.x, area.y + row as u16, line, area.width);
+        }
+    }
 }
 
 /// The transient `⌕` jump highlight (issue #103): right after a jump the
@@ -2316,7 +2407,7 @@ fn draw_prompt_flash(f: &mut Frame, app: &App, inner: Rect, start: usize) {
         if li < s || li >= e {
             continue;
         }
-        let Some(text) = app.chat_view.lines.get(li) else {
+        let Some(text) = app.chat_view.line_text(li) else {
             continue;
         };
         let lw = text.trim_end().width();
@@ -2346,7 +2437,7 @@ fn draw_selection_overlay(f: &mut Frame, app: &App, inner: Rect, start: usize) {
         if li < s.line || li > e.line {
             continue;
         }
-        let Some(text) = app.chat_view.lines.get(li) else {
+        let Some(text) = app.chat_view.line_text(li) else {
             continue;
         };
         let lw = text.trim_end().width();

--- a/tests/unit/acp__tests.rs
+++ b/tests/unit/acp__tests.rs
@@ -155,6 +155,7 @@ fn prompt_response_usage_reaches_the_ui() {
         session_id: "s".into(),
         result: Ok(response),
         payload: ParkedPromptKind::Text("hello".into()),
+        gen: 1,
     };
     let (tx, rx) = std::sync::mpsc::channel();
     let mut parked = VecDeque::new();
@@ -189,6 +190,7 @@ fn prompt_error_ends_the_ui_turn_before_reporting_the_error() {
         session_id: "s".into(),
         result: Err(AcpError::new(-32603, "boom")),
         payload: ParkedPromptKind::Text("hello".into()),
+        gen: 1,
     };
     let (tx, rx) = std::sync::mpsc::channel();
     let mut parked = VecDeque::new();
@@ -3131,4 +3133,25 @@ async fn prompt_for_an_unbound_session_is_rejected_not_rerouted() {
 
     let _ = cmd_tx.send(Cmd::Shutdown);
     let _ = client.await;
+}
+
+#[test]
+fn file_uris_are_percent_encoded() {
+    use std::path::Path;
+
+    assert_eq!(
+        super::unix_file_uri(Path::new("/tmp/shot.png")),
+        "file:///tmp/shot.png",
+        "plain ASCII paths stay readable"
+    );
+    assert_eq!(
+        super::unix_file_uri(Path::new("/tmp/a b/c#d?e.png")),
+        "file:///tmp/a%20b/c%23d%3Fe.png",
+        "space, # and ? must not change URI semantics"
+    );
+    assert_eq!(
+        super::unix_file_uri(Path::new("/tmp/截图.png")),
+        "file:///tmp/%E6%88%AA%E5%9B%BE.png",
+        "non-ASCII is encoded byte-wise (RFC 3986)"
+    );
 }

--- a/tests/unit/acp_term__tests.rs
+++ b/tests/unit/acp_term__tests.rs
@@ -14,12 +14,12 @@ async fn piped_create_captures_output_and_exit() {
     let id = broker
         .create("/bin/echo", &["acp-term".into()], None, &[], None)
         .expect("spawn echo");
-    let status = broker.wait(&id).await;
+    let status = broker.wait(&id).await.expect("wait echo");
     assert_eq!(status.exit_code, Some(0));
-    let (output, truncated, _) = broker.output(&id);
+    let (output, truncated, _) = broker.output(&id).expect("output echo");
     assert!(output.contains("acp-term"), "output: {output:?}");
     assert!(!truncated);
-    broker.release(&id);
+    broker.release(&id).expect("release echo");
 }
 
 #[tokio::test]
@@ -28,12 +28,13 @@ async fn kill_then_wait_settles() {
     let id = broker
         .create("/bin/sleep", &["30".into()], None, &[], None)
         .expect("spawn sleep");
-    broker.kill(&id);
+    broker.kill(&id).expect("kill sleep");
     let status = tokio::time::timeout(Duration::from_secs(3), broker.wait(&id))
         .await
-        .expect("wait after kill");
+        .expect("wait after kill")
+        .expect("wait settles");
     assert!(status.exit_code.is_none() || status.exit_code != Some(0) || status.signal.is_some());
-    broker.release(&id);
+    broker.release(&id).expect("release sleep");
 }
 
 #[tokio::test]
@@ -50,9 +51,10 @@ async fn wait_after_the_exit_notification_already_fired_returns() {
     tokio::time::sleep(Duration::from_millis(300)).await;
     let status = tokio::time::timeout(Duration::from_secs(3), broker.wait(&id))
         .await
-        .expect("wait must not hang once exit was already recorded");
+        .expect("wait must not hang once exit was already recorded")
+        .expect("wait settles");
     assert_eq!(status.exit_code, Some(0));
-    broker.release(&id);
+    broker.release(&id).expect("release true");
 }
 
 #[tokio::test]
@@ -73,8 +75,69 @@ async fn concurrent_waiters_all_settle() {
         let status = tokio::time::timeout(Duration::from_secs(3), handle)
             .await
             .expect("waiter must settle")
-            .expect("join");
+            .expect("join")
+            .expect("wait settles");
         assert_eq!(status.exit_code, Some(0));
     }
-    broker.release(&id);
+    broker.release(&id).expect("release true");
+}
+
+/// Yields the buffer one byte per read, forcing every multi-byte
+/// character to be split across read boundaries.
+struct OneByteAtATime(Vec<u8>, usize);
+
+impl Read for OneByteAtATime {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        if self.1 >= self.0.len() {
+            return Ok(0);
+        }
+        buf[0] = self.0[self.1];
+        self.1 += 1;
+        Ok(1)
+    }
+}
+
+#[tokio::test]
+async fn multi_byte_characters_split_across_reads_stay_intact() {
+    // "你好 acp-term" — every byte arrives in its own read, so the
+    // reader must carry partial UTF-8 sequences across chunks instead
+    // of decoding each chunk in isolation.
+    let payload = "你好 acp-term".as_bytes().to_vec();
+    let rec = Arc::new(TerminalRec {
+        child: Mutex::new({
+            // A process that outlives the test is never spawned; the
+            // child handle only needs to satisfy the record shape.
+            let mut cmd = Command::new(true_command());
+            cmd.stdin(Stdio::null()).stdout(Stdio::null()).stderr(Stdio::null());
+            cmd.spawn().expect("spawn true")
+        }),
+        buf: Mutex::new(String::new()),
+        truncated: AtomicBool::new(false),
+        byte_limit: DEFAULT_BYTE_LIMIT,
+        exit: Mutex::new(None),
+        notify: Notify::new(),
+    });
+    spawn_reader(Arc::clone(&rec), OneByteAtATime(payload, 0));
+    let deadline = std::time::Instant::now() + Duration::from_secs(3);
+    loop {
+        let output = rec.buf.lock().unwrap_or_else(|e| e.into_inner()).clone();
+        if output.contains("acp-term") {
+            assert!(output.contains("你好"), "output: {output:?}");
+            break;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "output never settled: {output:?}"
+        );
+        std::thread::sleep(Duration::from_millis(10));
+    }
+}
+
+#[tokio::test]
+async fn unknown_terminal_ids_error_instead_of_default_success() {
+    let broker = TerminalBroker::new(std::env::temp_dir());
+    assert!(broker.output("term-missing").is_err());
+    assert!(broker.wait("term-missing").await.is_err());
+    assert!(broker.kill("term-missing").is_err());
+    assert!(broker.release("term-missing").is_err());
 }

--- a/tests/unit/app__mode_tests.rs
+++ b/tests/unit/app__mode_tests.rs
@@ -2493,6 +2493,7 @@ fn saving_a_selected_queue_edit_preserves_fifo_position() {
     app.handle(
         AppEvent::Ctl(CtlEvent::PromptQueued {
             message_id: "first".into(),
+            session_id: Some("dsh-test".into()),
         }),
         &ctl,
     );
@@ -3786,6 +3787,7 @@ fn direct_ui_turn_facts_update_client_lifecycle() {
     app.handle(
         AppEvent::Ctl(CtlEvent::PromptQueued {
             message_id: "dsh-test".into(),
+            session_id: Some("dsh-test".into()),
         }),
         &ctl,
     );
@@ -4053,6 +4055,7 @@ fn auth_retry_does_not_consume_the_followup_fifo_marker() {
     app.handle(
         AppEvent::Ctl(CtlEvent::PromptQueued {
             message_id: "dsh-test".into(),
+            session_id: Some("dsh-test".into()),
         }),
         &ctl,
     );

--- a/tests/unit/app__persistent_shell_tests.rs
+++ b/tests/unit/app__persistent_shell_tests.rs
@@ -28,6 +28,14 @@ fn wait_for_shell(rx: &Receiver<AppEvent>) -> (Option<i32>, String) {
     }
 }
 
+fn transcript_text(transcript: &mut crate::transcript::Transcript) -> String {
+    transcript
+        .lines(&Theme::dark(), 80, ' ')
+        .iter()
+        .flat_map(|l| l.spans.iter().map(|s| s.content.to_string()))
+        .collect()
+}
+
 #[test]
 fn local_shell_state_persists_between_invocations() {
     let workspace = std::env::temp_dir().join(format!("martty-shell-state-{}", std::process::id()));
@@ -73,6 +81,52 @@ fn shell_done_refreshes_the_cap_git_branch_label() {
     assert_eq!(
         app.git_branch, None,
         "a session shell command must re-check the workspace branch"
+    );
+
+    drop(app);
+    let _ = std::fs::remove_dir_all(workspace);
+}
+
+#[test]
+fn shell_result_after_a_clear_never_lands_in_a_new_cell() {
+    // Regression (review H-sweep): shell_pending holds a transcript cell
+    // index; after /clear a fresh cell can occupy the same index, and the
+    // old command's output must not be written into it.
+    let workspace = std::env::temp_dir().join(format!("martty-shell-clear-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&workspace);
+    std::fs::create_dir_all(&workspace).unwrap();
+    let (mut app, _rx) = test_app(&workspace);
+    let (ctl, _commands) = crate::controller::tests::test_controller();
+
+    let old_gen = app.transcript.gen();
+    let old_cell = app.transcript.push_shell("old-cmd".into());
+    app.shell_pending
+        .push((1, app.session_id.clone(), old_cell, old_gen));
+
+    // /clear empties the transcript (bumping the generation); the clear
+    // notice and a fresh `!` command then occupy new cells (the new one
+    // may even reuse a stale index).
+    app.run_slash("clear", "", &ctl);
+    assert_eq!(app.transcript.gen(), old_gen + 1, "clear bumps the gen");
+    let _ = app.transcript.push_shell("new-cmd".into());
+    let text_before = transcript_text(&mut app.transcript);
+
+    app.handle(
+        AppEvent::ShellDone {
+            id: 1,
+            code: Some(0),
+            output: "stale output".into(),
+        },
+        &ctl,
+    );
+    let text_after = transcript_text(&mut app.transcript);
+    assert_eq!(
+        text_before, text_after,
+        "the stale shell result must be dropped"
+    );
+    assert!(
+        !text_after.contains("stale output"),
+        "stale output leaked into a fresh cell"
     );
 
     drop(app);

--- a/tests/unit/app__scroll_tests.rs
+++ b/tests/unit/app__scroll_tests.rs
@@ -24,9 +24,12 @@ fn test_app() -> (App, Receiver<AppEvent>) {
 #[test]
 fn scroll_by_after_jump_top_resolves_the_sentinel_against_the_last_frame() {
     let (mut app, _rx) = test_app();
-    // Last rendered frame: 200 lines in a 20-row pane → max_scroll = 180.
+    // Last rendered frame: 200 layout lines in a 20-row pane → max_scroll =
+    // 180. The snapshot is viewport-sized; `total` carries the line count.
     app.chat_view.area = ratatui::layout::Rect::new(0, 0, 80, 20);
-    app.chat_view.lines = (0..200).map(|i| format!("line {i}")).collect();
+    app.chat_view.total = 200;
+    app.chat_view.top = 180;
+    app.chat_view.lines = (180..200).map(|i| format!("line {i}")).collect();
 
     // JumpTop leaves the usize::MAX sentinel until the next draw; a wheel
     // flick arriving in the same event burst must stay relative to the top

--- a/tests/unit/app__selection_tests.rs
+++ b/tests/unit/app__selection_tests.rs
@@ -21,6 +21,7 @@ fn view(lines: &[&str]) -> ChatView {
         manual_top: None,
         lines: lines.iter().map(|s| s.to_string()).collect(),
         owners: vec![None; lines.len()],
+        total: lines.len(),
         images: Vec::new(),
     }
 }
@@ -412,4 +413,42 @@ fn ctrl_shift_c_copies_a_mouse_drag_selection_and_keeps_the_highlight() {
 
     assert_eq!(app.input.buf(), "hello world", "copy leaves the draft");
     assert!(app.input_sel.is_some(), "copy keeps the highlight");
+}
+
+#[test]
+fn snapshot_lookups_translate_the_absolute_line_through_top() {
+    // The snapshot is viewport-sized: absolute layout lines resolve through
+    // `top` (L25). Frame: absolute lines 10..14, snapshot = 4 rows.
+    let mut app = test_app();
+    app.chat_view = view(&["ten", "eleven", "twelve", "thirteen"]);
+    app.chat_view.top = 10;
+    app.chat_view.total = 14;
+
+    assert_eq!(app.chat_view.line_text(11), Some("eleven"));
+    assert_eq!(app.chat_view.line_text(10), Some("ten"));
+    assert_eq!(app.chat_view.line_text(9), None, "above the viewport");
+    assert_eq!(app.chat_view.line_text(14), None, "below the viewport");
+
+    // chat_hit: screen row 1 → absolute line 11.
+    let p = app.chat_hit(3, 1).expect("inside pane");
+    assert_eq!(p.line, 11);
+    // Hit below the content but inside the pane clamps to the last line.
+    let p = app.chat_hit(3, 9).expect("inside pane");
+    assert_eq!(p.line, 13);
+}
+
+#[test]
+fn selection_text_extracts_the_visible_part_of_a_scrolled_selection() {
+    // Selection spans absolute lines 1..3 with the frame showing absolute
+    // 2..5: the copy covers only what the frame actually showed (viewport-
+    // sized snapshot) — absolute 2 ("two", whole line) and 3 ("three", cut
+    // at the selection's end column 4 inclusive); the part above the
+    // viewport is gone.
+    let mut app = test_app();
+    app.chat_view = view(&["two", "three", "four", "five"]);
+    app.chat_view.top = 2;
+    app.chat_view.total = 8;
+
+    let text = app.selection_text(sel((1, 2), (3, 4)));
+    assert_eq!(text, "two\nthree");
 }

--- a/tests/unit/app__session_tabs_tests.rs
+++ b/tests/unit/app__session_tabs_tests.rs
@@ -929,7 +929,7 @@ fn composer_draft_scroll_model_and_banner_are_bound_to_the_tab() {
 fn shell_output_lands_in_the_session_that_ran_it() {
     let (mut app, ctl, _rx) = test_app();
     app.run_local_shell("echo hello".into());
-    let (shell_id, session, _cell) = app.shell_pending[0].clone();
+    let (shell_id, session, _cell, _gen) = app.shell_pending[0].clone();
     assert_eq!(session, "dsh-test");
 
     // Switch away while the command is still running.
@@ -967,6 +967,7 @@ fn deferred_steer_settles_into_the_owning_parked_slot() {
             cells: Vec::new(),
             blocks: vec![StagedBlock::Text("steer me".into())],
             requeue_front: true,
+            gen: app.transcript.gen(),
         },
     );
     app.switch_to_session(1); // away again: entry parked with dsh-test
@@ -1003,6 +1004,7 @@ fn deferred_steer_settles_into_the_owning_parked_slot() {
         cells: Vec::new(),
         blocks: vec![StagedBlock::Text("ok".into())],
         requeue_front: true,
+        gen: app.transcript.gen(),
     });
     app.switch_to_session(1);
     app.handle(

--- a/tests/unit/input__composer__tests.rs
+++ b/tests/unit/input__composer__tests.rs
@@ -396,3 +396,40 @@ fn delete_forward_with_a_selection_deletes_the_selection() {
     assert_eq!(e.buf(), "lo world", "delete removes the active selection");
     assert_eq!(e.selection_text(), None);
 }
+
+#[test]
+fn explicit_range_kills_ignore_an_active_selection() {
+    // A shift-selection must not hijack explicit range kills: the
+    // requested range dies, the selection is cancelled. Regression for
+    // the delete_token_at bug (selection deleted instead of the token,
+    // while the image was dropped from the tray).
+    let mut e = ComposerEditor::new();
+    e.insert_str("[image 1] hello");
+    e.set_cursor_char(0);
+    e.select_right();
+    e.select_right();
+    e.select_right(); // selection "[im"
+    e.delete_char_range(0, 10); // want the whole "[image 1] " token
+    assert_eq!(e.buf(), "hello", "the requested range died, not the selection");
+    assert_eq!(e.selection_text(), None, "selection cancelled");
+
+    // kill_to_start / kill_to_end likewise: they kill to the *cursor*
+    // (which a shift-selection advances to the selection end), never the
+    // selection itself.
+    let mut e = ComposerEditor::new();
+    e.insert_str("hello world");
+    e.set_cursor_char(0);
+    e.select_right();
+    e.select_right();
+    e.select_right(); // selection "hel", cursor now at 3
+    e.kill_to_end(80);
+    assert_eq!(e.buf(), "hel", "kill_to_end killed to the cursor, not the selection");
+
+    let mut e = ComposerEditor::new();
+    e.insert_str("hello world");
+    e.set_cursor_char(6);
+    e.select_right();
+    e.select_right(); // selection "wo", cursor now at 8
+    e.kill_to_start(80);
+    assert_eq!(e.buf(), "rld", "kill_to_start killed from the row head to the cursor");
+}

--- a/tests/unit/input__editor__tests.rs
+++ b/tests/unit/input__editor__tests.rs
@@ -182,3 +182,29 @@ fn chars_between_slices_by_char_boundaries() {
     assert_eq!(i.chars_between(3, 3), "", "caret-only");
     assert_eq!(i.chars_between(2, 99), "b", "clamped to the buffer");
 }
+
+#[test]
+fn backspace_and_delete_forward_remove_whole_graphemes() {
+    // ZWJ family emoji: 7 chars, one grapheme. Deleting must never leave
+    // a dangling half of the sequence behind.
+    let mut input = Input::new();
+    input.insert_str("a\u{1f468}\u{200d}\u{1f469}\u{200d}\u{1f466}b");
+    let full = input.buf.clone();
+    assert!(full.chars().count() > 4, "sequence spans several chars");
+
+    input.backspace();
+    assert_eq!(input.buf, "a👨\u{200d}👩\u{200d}👦", "plain b died first");
+    // One more backspace removes the *whole* emoji cluster, not its
+    // last char — no dangling ZWJ or half a face left behind.
+    input.backspace();
+    assert_eq!(input.buf, "a");
+    input.backspace();
+    assert_eq!(input.buf, "");
+
+    // Forward delete from the start also takes the whole cluster.
+    let mut input = Input::new();
+    input.insert_str("e\u{301}x"); // e + combining acute = one grapheme
+    input.cursor = 0;
+    input.delete_forward();
+    assert_eq!(input.buf, "x", "combining mark went with its base");
+}

--- a/tests/unit/input__vim__tests.rs
+++ b/tests/unit/input__vim__tests.rs
@@ -145,6 +145,31 @@ fn unknown_keys_are_consumed_not_typed() {
 }
 
 #[test]
+#[allow(non_snake_case)]
+fn o_and_O_land_the_cursor_on_the_new_blank_line() {
+    let mut v = VimState::default();
+    v.set(true);
+    v.mode = VimMode::Normal;
+    let mut e = editor("hello");
+
+    // `o` opens below; typing must land on the new empty line.
+    assert!(v.handle_key(&char('o'), &mut e));
+    e.insert_char('X');
+    assert_eq!(e.buf(), "hello\nX", "o: typed text on the new line below");
+    assert!(v.handle_key(&key(KeyCode::Esc, KeyModifiers::NONE), &mut e));
+    assert_eq!(v.mode, VimMode::Normal);
+
+    // `O` opens above; typing must land on the new empty line too
+    // (previously the cursor stayed on the shifted original line).
+    let mut e2 = editor("hello");
+    e2.set_cursor_char(3);
+    assert!(v.handle_key(&char('O'), &mut e2));
+    e2.insert_char('X');
+    assert_eq!(e2.buf(), "X\nhello", "O: typed text on the new line above");
+    assert_eq!(e2.cursor_char(), 1);
+}
+
+#[test]
 fn ctrl_chords_fall_through_in_normal_mode() {
     let mut v = VimState::default();
     v.set(true);

--- a/tests/unit/markdown__tests.rs
+++ b/tests/unit/markdown__tests.rs
@@ -481,3 +481,32 @@ fn nested_blockquote_keeps_markers_together() {
         .flat_map(|l| l.spans.iter())
         .any(|s| { s.content == ">" && s.style.fg == Some(theme.fg_tertiary) }));
 }
+
+#[test]
+fn four_backtick_fences_survive_nested_backtick_content() {
+    // Regression: a ```` fence whose *content* contains ``` lines used to
+    // toggle the frame logic on the content lines, breaking the block into
+    // two frames with an unframed middle.
+    let text = "````\n```rust\nlet x = 1;\n```\nplain\n````\n";
+    let lines = render(text, &Theme::dark(), 40);
+    let texts: Vec<String> = lines
+        .iter()
+        .map(|l| l.spans.iter().map(|s| s.content.as_ref()).collect())
+        .collect();
+
+    let tops = texts.iter().filter(|t| t.starts_with('┌')).count();
+    let bottoms = texts.iter().filter(|t| t.starts_with('└')).count();
+    assert_eq!(tops, 1, "exactly one frame opens: {texts:?}");
+    assert_eq!(bottoms, 1, "exactly one frame closes: {texts:?}");
+    // The frame holds every content line, including the literal ``` line.
+    assert!(texts.iter().any(|t| t.contains("let x = 1;")), "{texts:?}");
+    assert!(
+        texts.iter().any(|t| t.contains("```rust")),
+        "the ``` content line must render inside the frame: {texts:?}"
+    );
+    assert!(texts.iter().any(|t| t.contains("plain")), "{texts:?}");
+    // Order: top edge first, bottom edge last.
+    let top = texts.iter().position(|t| t.starts_with('┌')).unwrap();
+    let bottom = texts.iter().position(|t| t.starts_with('└')).unwrap();
+    assert!(top < bottom);
+}


### PR DESCRIPTION
## Summary

Full sweep of the 2026-09-03 code review: all high/medium/low findings fixed, with regression tests added along the way.

### High
- **Terminal output integrity** — partial UTF-8 sequences are carried across 4096-byte reads instead of being decoded per chunk into U+FFFD; unknown terminal ids return protocol errors instead of fake success
- **Terminal Auth keystrokes** — the crossterm input reader parks during auth so the login subprocess keeps its keystrokes
- **Background tab errors** — image prompt failures report through the requesting session (a parked tab's running badge can no longer stick forever); `PromptQueued` carries the session id
- **Persistent shell** — `!` commands run with stdin from `/dev/null` and a 120s silence deadline (a wedged `!cat` can no longer brick the single shell worker)
- **vim `O`** lands the cursor on the new blank line above; explicit range kills ignore an active shift selection (no more literal `[image n]` with a removed attachment)

### Medium
- Cross-tab bind state: same-session `/resume` keeps a FIFO bind entry (no more bind stealing between `/new` tabs); resume releases plugin overlays with cancel events like a tab click; vim defers to every modal
- ACP turn lifecycle: prompt generation tags (stale finishes can't clear a new turn's inflight marker → no double `session/prompt`); cancel-vs-finish race trusts the agent's stop reason
- ACP robustness: 120s deadline on every request the command loop awaits; cordis negotiation guard for queue/agents snapshots; per-session mode catalog updates; percent-encoded `file://` URIs; permission ask before `terminal/create`
- Legacy transport: stdin writer taken out of the shared slot while blocking (no `kill()`/reader starvation deadlock)
- Rendering: `/clear` invalidates cell-index handles; 4+ backtick fences render as one frame (sentinel fence via stylesheet); input dock measured at its real width; shell collapse keeps the tail; nav rail trims instead of overlapping; width-based wrap budgets
- Form editor: grapheme-aware delete, zero-width combining marks

### Low / packaging
- `subagent.finished` no longer hardcoded success; interrupt failures not misreported; elicitation `ctrl+shift+c` no longer wipes the form
- npm: corrupt `settings.json` degrades instead of blocking boot + atomic theme writes; alias skips `node_modules` and asserts version parity; stale-alias release warning; signal exit codes; spawn-failure/env-fallback diagnostics
- scripts: `mktemp` for freeze diagnostics, `CARGO_TARGET_DIR` honored, `du`/`df` failure fallbacks, dist tgz cleanup, old-acp matrix case skips when the registry is unreachable
- Performance: chat selection snapshot is viewport-sized (no per-frame O(history) clones); render window borrows the assembled lines

## Test plan
- `cargo test --locked` — 697 passed (13 new regression tests)
- `npm test --prefix npm` — 226 passed
- `cargo check --locked --tests` — clean (2 pre-existing warnings)
- `martty -- --dump-frame` — renders byte-identical before/after (100x34 and 60x20)