### PR TITLE
fix: isolate session controls and correct Markdown rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ All notable changes to this project are documented here. The project follows
   same way: they open on the effective model/effort, ✓-mark it, and list
   the effective model even when it is not in the host catalog.
 
-- `⌕` user-prompt jump button on the composer cap row, between the project
+- `↥` user-prompt jump button on the composer cap row, between the project
   path and the `⛶` expand glyph (issue #103): hovering highlights it and
   clicking scrolls the chat to the newest user prompt; each further click
   walks one prompt back, and the oldest prompt wraps to the newest again.
@@ -89,6 +89,19 @@ All notable changes to this project are documented here. The project follows
   width are painted unchanged.
 
 ### Fixed
+
+- Preserve queue selection and edits across session tabs, including pausing
+  background delivery until an edit is saved or cancelled. Failed session
+  configuration operations no longer mark a running prompt idle.
+- Keep prompts and cancellations responsive while session creation, restore,
+  configuration or plugin requests are pending. Configuration changes retain
+  their order within a session; prompts and Send Now requests can run longer
+  than the 120-second control-request deadline.
+- Preserve replayed Plan and usage snapshots when session/load completes,
+  and keep concurrent Send Now responses from overwriting turn statistics.
+- Render code inside Markdown quotes with intact frames, newlines and
+  indentation; preserve grapheme clusters during wrapping; keep exact-width
+  table borders and deeply nested list content within the viewport.
 
 - Multi-session state is now isolated end to end: background ACP updates no
   longer replace the visible tab's config, plan, stats, status, model/skill/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -531,6 +531,7 @@ dependencies = [
  "futures",
  "image",
  "libc",
+ "pulldown-cmark",
  "ratatui",
  "ratatui-explorer",
  "ratatui-textarea",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,12 +23,16 @@ ruzstd = "0.8"
 unicode-segmentation = "1"
 unicode-width = "0.2"
 tui-markdown = { version = "0.3.9", default-features = false }
+pulldown-cmark = { version = "0.13.4", default-features = false }
 tui-tree-widget = "0.24"
 agent-client-protocol = { version = "2.0.0", features = ["unstable_auth_methods", "unstable_elicitation", "unstable_end_turn_token_usage"] }
 tokio = { version = "1.53.1", features = ["rt-multi-thread", "macros", "io-util", "fs", "net", "time", "sync"] }
 tokio-util = { version = "0.7.19", features = ["compat"] }
 futures = "0.3.34"
 image = { version = "0.25", default-features = false, features = ["png"] }
+
+[dev-dependencies]
+tokio = { version = "1.53.1", features = ["test-util"] }
 
 [profile.release]
 lto = true

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -54,6 +54,13 @@ Queue 标题位于 composer 顶沿，全部等待条目始终在同一个 compos
 `Send Now` 的并发 prompt 若被 agent 拒绝，ACP transport
 只向 Client 回报 deferred，由同一 Client FIFO 接管，不在 transport 内保留第二份重试队列。
 
+ACP 的 prompt 调度与慢控制请求分开执行：`src/acp.rs` 持有每个 session
+的轮次和发送队列，`src/acp/control.rs` 执行控制请求。创建/恢复共用一个串行队列，
+使绑定结果保持与 Rust tab 的等待 FIFO 同序；配置操作按 session 分别串行，
+该 session 的下一轮 prompt 等待先前配置完成，其他 session 的 prompt、完成事件、
+取消和关闭继续处理。短控制请求保留 120 秒 deadline，整轮 prompt 与 steer 不使用
+这个总时长限制。Queue 的选择和编辑状态随 session 保存，后台会话同样遵守暂停规则。
+
 原生 tab 是当前可见会话的唯一选择源。每次 bind 或 tab 切换，Rust 通过
 `_dsh/cordis/tui/session/active` request 把 session id（未绑定时为 `null`）投影到 Client tree；
 `acpSessionConfig`、`acpSessionPlan`、`acpSessionStats` 和 `acpSessionStatus` 只发布该会话的

--- a/npm/lib/acp-session-plan.js
+++ b/npm/lib/acp-session-plan.js
@@ -107,6 +107,7 @@ export function installAcpSessionPlan(ctx) {
         ? readString(message.params, 'sessionId', 'session_id')
         : undefined,
     })
+    if (message.method === 'session/load') reset(readString(message.params, 'sessionId', 'session_id'))
   }
 
   function observeAgent(message) {
@@ -117,7 +118,9 @@ export function installAcpSessionPlan(ctx) {
       if (message.error !== undefined || !isObject(message.result)) return
       const bound = readString(message.result, 'sessionId', 'session_id') ?? tracked.sessionId
       if (!selectionKnown) sessionId = bound
-      reset(bound)
+      // Replay notifications precede the setup response. Preserve their state.
+      if (!plansBySession.has(bound)) reset(bound)
+      else if (bound === sessionId) publish()
       return
     }
     if (message.method !== 'session/update' || !isObject(message.params)) return

--- a/npm/lib/acp-session-stats.js
+++ b/npm/lib/acp-session-stats.js
@@ -120,6 +120,7 @@ export function installAcpSessionStats(ctx, options = {}) {
           ? readString(message.params, 'sessionId', 'session_id')
           : undefined,
       })
+      if (message.method === 'session/load') reset(readString(message.params, 'sessionId', 'session_id'))
       return
     }
     if (message.method !== 'session/prompt') return
@@ -128,13 +129,16 @@ export function installAcpSessionStats(ctx, options = {}) {
     if (!selectionKnown && sessionId === undefined) sessionId = promptSessionId
     const prompt = {
       sessionId: promptSessionId,
+      primary: !activePrompts.has(promptSessionId),
       started: now(),
       firstToken: undefined,
       toolMillis: 0,
     }
     pendingPrompts.set(message.id, prompt)
-    activePrompts.set(promptSessionId, prompt)
-    stateFor(promptSessionId).stats.turns += 1
+    if (prompt.primary) {
+      activePrompts.set(promptSessionId, prompt)
+      stateFor(promptSessionId).stats.turns += 1
+    }
     publishIf(promptSessionId)
   }
 
@@ -146,19 +150,21 @@ export function installAcpSessionStats(ctx, options = {}) {
       if (message.error !== undefined || !object(message.result)) return
       const bound = readString(message.result, 'sessionId', 'session_id') ?? tracked.sessionId
       if (!selectionKnown) sessionId = bound
-      reset(bound)
+      // Replay notifications precede the setup response. Preserve their state.
+      if (!values.has(bound)) reset(bound)
+      else if (bound === sessionId) publish()
       return
     }
     if (message.id !== undefined && pendingPrompts.has(message.id)) {
       const prompt = pendingPrompts.get(message.id)
       pendingPrompts.delete(message.id)
-      activePrompts.delete(prompt.sessionId)
+      if (activePrompts.get(prompt.sessionId) === prompt) activePrompts.delete(prompt.sessionId)
       const value = stateFor(prompt.sessionId)
       if (message.error === undefined && object(message.result)) {
         addUsage(value, message.result.usage)
       }
       const elapsed = Math.max(0, now() - prompt.started)
-      value.stats.llmMillis += Math.max(0, elapsed - prompt.toolMillis)
+      if (prompt.primary) value.stats.llmMillis += Math.max(0, elapsed - prompt.toolMillis)
       publishIf(prompt.sessionId)
       return
     }

--- a/scripts/acp-session-plan.test.mjs
+++ b/scripts/acp-session-plan.test.mjs
@@ -88,3 +88,24 @@ test('plan snapshots follow explicit native tab selection', () => {
   plan.selectSession('s-2')
   assert.equal(plan.current().content, 'two')
 })
+
+test('load replay survives its response and resume preserves the cached plan', () => {
+  const plan = planModule.installAcpSessionPlan(makeCtx())
+  const update = (sessionId, content) => plan.observeAgent({
+    method: 'session/update', params: {
+      sessionId, update: { sessionUpdate: 'plan', entries: [{ content, status: 'pending' }] },
+    },
+  })
+  update('background', 'background plan')
+  plan.selectSession('restored')
+  update('restored', 'stale plan')
+  plan.observeClient({ id: 1, method: 'session/load', params: { sessionId: 'restored' } })
+  update('restored', 'replayed plan')
+  plan.observeAgent({ id: 1, result: {} })
+  assert.equal(plan.current().entries[0].content, 'replayed plan')
+  plan.observeClient({ id: 2, method: 'session/resume', params: { sessionId: 'restored' } })
+  plan.observeAgent({ id: 2, result: {} })
+  assert.equal(plan.current().entries[0].content, 'replayed plan')
+  plan.selectSession('background')
+  assert.equal(plan.current().entries[0].content, 'background plan')
+})

--- a/scripts/acp-session-stats.test.mjs
+++ b/scripts/acp-session-stats.test.mjs
@@ -148,3 +148,70 @@ test('concurrent Session statistics remain isolated across native tab switches',
   stats.selectSession('s-1')
   assert.equal(stats.current().usage.input, 0)
 })
+
+test('usage replay before the load response survives with background stats isolated', () => {
+  const stats = statsModule.installAcpSessionStats(makeCtx())
+  const context = (sessionId, used) => stats.observeAgent({
+    method: 'session/update', params: { sessionId,
+      update: { sessionUpdate: 'usage_update', used, size: 1000 } },
+  })
+  context('background', 90)
+  stats.selectSession('restored')
+  context('restored', 999)
+  stats.observeClient({ id: 'load', method: 'session/load', params: { sessionId: 'restored' } })
+  context('restored', 400)
+  stats.observeAgent({ method: 'session/update', params: { sessionId: 'restored', update: {
+    sessionUpdate: 'session_info_update', _meta: { dsh: { event: 'prompt/usage', usage: { inputTokens: 7 } } },
+  } } })
+  stats.observeAgent({ id: 'load', result: {} })
+  assert.equal(stats.current().context.used, 400)
+  assert.equal(stats.current().usage.input, 7)
+  stats.selectSession('background')
+  assert.equal(stats.current().context.used, 90)
+})
+
+test('a rejected steer cannot steal first-token and tool timing from the main prompt', () => {
+  let now = 0
+  const stats = statsModule.installAcpSessionStats(makeCtx(), { now: () => now })
+  stats.selectSession('s')
+  stats.observeClient({ id: 1, method: 'session/prompt', params: { sessionId: 's' } })
+  now = 10
+  stats.observeClient({ id: 2, method: 'session/prompt', params: { sessionId: 's' } })
+  now = 20
+  stats.observeAgent({ id: 2, error: { code: -1, message: 'busy' } })
+  const update = (value) => stats.observeAgent({ method: 'session/update', params: { sessionId: 's', update: value } })
+  now = 30
+  update({ sessionUpdate: 'agent_message_chunk', content: { type: 'text', text: 'hello' } })
+  now = 40
+  update({ sessionUpdate: 'tool_call', toolCallId: 't' })
+  now = 60
+  update({ sessionUpdate: 'tool_call_update', toolCallId: 't', status: 'completed' })
+  now = 100
+  stats.observeAgent({ id: 1, result: {} })
+  assert.deepEqual(stats.current().stats, {
+    turns: 1, steps: 0, llmMillis: 80, toolMillis: 20, ttftTotalMillis: 30, ttftCount: 1,
+  })
+})
+
+test('late steer completion cannot clear the next main prompt timing', () => {
+  let now = 0
+  const stats = statsModule.installAcpSessionStats(makeCtx(), { now: () => now })
+  stats.selectSession('s')
+  for (const id of [1, 2]) stats.observeClient({ id, method: 'session/prompt', params: { sessionId: 's' } })
+  now = 10
+  stats.observeAgent({ id: 1, result: {} })
+  now = 20
+  stats.observeClient({ id: 3, method: 'session/prompt', params: { sessionId: 's' } })
+  now = 30
+  stats.observeAgent({ id: 2, result: {} })
+  now = 40
+  stats.observeAgent({ method: 'session/update', params: { sessionId: 's', update: {
+    sessionUpdate: 'agent_message_chunk', content: { type: 'text', text: 'next turn' },
+  } } })
+  now = 50
+  stats.observeAgent({ id: 3, result: {} })
+  assert.equal(stats.current().stats.turns, 2)
+  assert.equal(stats.current().stats.ttftCount, 1)
+  assert.equal(stats.current().stats.ttftTotalMillis, 20)
+  assert.equal(stats.current().stats.llmMillis, 40)
+})

--- a/src/acp.rs
+++ b/src/acp.rs
@@ -53,6 +53,9 @@ use crate::events::{
 };
 use crate::runtime::RuntimeConfig;
 
+mod control;
+use control::{ControlFinish, ControlWorkers};
+
 pub enum AcpEndpoint {
     Spawn(Vec<String>),
     AttachStdio {
@@ -398,7 +401,7 @@ fn spawn_session_prompt(
         }));
         let result = cx
             .send_request(PromptRequest::new(sid.clone(), content))
-            .block_task_deadline()
+            .block_task()
             .await;
         let _ = done.send(PromptFinish {
             session_id: sid.to_string(),
@@ -422,7 +425,7 @@ fn spawn_steer_prompt(
     tokio::spawn(async move {
         let result = cx
             .send_request(PromptRequest::new(sid, content))
-            .block_task_deadline()
+            .block_task()
             .await;
         let _ = done.send(SteerFinish { message_id, result });
     });
@@ -592,6 +595,7 @@ fn begin_prompt(
 /// in-flight `session/prompt`; a busy session simply keeps its FIFO.
 #[allow(clippy::too_many_arguments)]
 fn drain_ready_sessions(
+    controls: &ControlWorkers,
     sessions: &mut HashMap<String, SessionHandle>,
     cx: &ConnectionTo<Agent>,
     bus: &Sender<AppEvent>,
@@ -614,7 +618,7 @@ fn drain_ready_sessions(
         let Some(handle) = sessions.get_mut(&key) else {
             continue;
         };
-        if handle.inflight.is_some() {
+        if handle.inflight.is_some() || controls.busy(&key) {
             continue;
         }
         let Some(next) = handle.queue.pop_front() else {
@@ -1937,6 +1941,8 @@ where
                 // tagged, finishes carry the tag back, and a stale finish
                 // can never clear a newer turn's occupancy marker.
                 let mut prompt_gen: u64 = 0;
+                let mut controls = ControlWorkers::default();
+                let (control_done_tx, mut control_done_rx) = tokio::sync::mpsc::unbounded_channel();
                 loop {
                     tokio::select! {
                         cmd = fwd_rx.recv() => {
@@ -1996,7 +2002,7 @@ where
                             match resolve_cmd_session(&sessions, &current, &cmd_session, "prompt") {
                                 Ok(Some(sid)) => {
                                     let handle = sessions.entry(sid.to_string()).or_default();
-                                    if handle.inflight.is_some() || !parked.is_empty() {
+                                    if handle.inflight.is_some() || controls.busy(&sid.0) || !parked.is_empty() {
                                         handle.queue.push_back(next);
                                     } else {
                                         prompt_gen += 1;
@@ -2093,7 +2099,7 @@ where
                             match resolve_cmd_session(&sessions, &current, &cmd_session, "prompt_images") {
                                 Ok(Some(sid)) => {
                                     let handle = sessions.entry(sid.to_string()).or_default();
-                                    if handle.inflight.is_some() || !parked.is_empty() {
+                                    if handle.inflight.is_some() || controls.busy(&sid.0) || !parked.is_empty() {
                                         handle.queue.push_back(next);
                                     } else {
                                         prompt_gen += 1;
@@ -2216,78 +2222,11 @@ where
                                 }
                                 Ok(None) => {}
                                 Err(err) => {
-                                    let _ = bus.send(AppEvent::Ctl(CtlEvent::SessionError {
+                                    let _ = bus.send(AppEvent::Ctl(CtlEvent::SessionOpFailed {
                                     session_id: cmd_session.clone(),
                                     message: err,
                                 }));
                                 }
-                            }
-                        }
-                        Cmd::SelectModel { session_id: cmd_session, model, effort, .. } => {
-                            let sid = match resolve_cmd_session(&sessions, &current, &cmd_session, "select_model") {
-                                Ok(Some(sid)) => sid,
-                                Ok(None) => continue,
-                                Err(err) => {
-                                    let _ = bus.send(AppEvent::Ctl(CtlEvent::SessionError {
-                                    session_id: cmd_session.clone(),
-                                    message: err,
-                                }));
-                                    continue;
-                                }
-                            };
-                            if let Some(model) = model {
-                                let value = {
-                                    let surface = surface.lock().unwrap_or_else(|e| e.into_inner());
-                                    match surface
-                                        .session(&sid.0)
-                                        .models
-                                        .iter()
-                                        .find(|m| m.id == model)
-                                    {
-                                        Some(m) if !m.provider.is_empty() => {
-                                            format!("{}/{}", m.provider, model)
-                                        }
-                                        _ => model.clone(),
-                                    }
-                                };
-                                let _ = cx
-                                    .send_request(SetSessionConfigOptionRequest::new(
-                                        sid.clone(),
-                                        "model",
-                                        SessionConfigOptionValue::value_id(value),
-                                    ))
-                                    .block_task_deadline()
-                                    .await
-                                    .map_err(|err| {
-                                        if is_auth_required_error(&err) {
-                                            emit_needs_auth_open(
-                                                &bus,
-                                                methods.clone(),
-                                                selected.as_ref(),
-                                                Some(acp_error_message(&err)),
-                                            );
-                                        }
-                                    });
-                            }
-                            if let Some(effort) = effort {
-                                let _ = cx
-                                    .send_request(SetSessionConfigOptionRequest::new(
-                                        sid,
-                                        "effort",
-                                        SessionConfigOptionValue::value_id(effort),
-                                    ))
-                                    .block_task_deadline()
-                                    .await
-                                    .map_err(|err| {
-                                        if is_auth_required_error(&err) {
-                                            emit_needs_auth_open(
-                                                &bus,
-                                                methods.clone(),
-                                                selected.as_ref(),
-                                                Some(acp_error_message(&err)),
-                                            );
-                                        }
-                                    });
                             }
                         }
                         Cmd::FetchCatalog { session_id } => {
@@ -2314,189 +2253,6 @@ where
                                 skills,
                             }));
                         }
-                        Cmd::FetchStaticPlugins => match fetch_static_plugins(&cx).await {
-                            Ok(plugins) => {
-                                let _ = bus.send(AppEvent::Ctl(CtlEvent::StaticPlugins { plugins }));
-                            }
-                            Err(error) => {
-                                let _ = bus.send(AppEvent::Ctl(CtlEvent::TuiOpFailed(format!(
-                                    "static plugins unavailable: {error}"
-                                ))));
-                            }
-                        },
-                        Cmd::FetchCordisPlugins { agent_id } => {
-                            if !ensure_agent_cordis(&surface, &bus) {
-                                continue;
-                            }
-                            match fetch_dynamic_plugins(&cx, &agent_id).await {
-                                Ok(plugins) => {
-                                    let _ = bus.send(AppEvent::Ctl(CtlEvent::CordisPlugins { plugins }));
-                                }
-                                Err(error) => {
-                                    let _ = bus.send(AppEvent::Ctl(CtlEvent::TuiOpFailed(format!(
-                                        "dynamic plugins unavailable: {error}"
-                                    ))));
-                                }
-                            }
-                        }
-                        Cmd::SetCordisPluginEnabled {
-                            agent_id,
-                            plugin_id,
-                            enabled,
-                        } => {
-                            if !ensure_agent_cordis(&surface, &bus) {
-                                continue;
-                            }
-                            let method = if enabled {
-                                crate::cordis::PLUGIN_START
-                            } else {
-                                crate::cordis::PLUGIN_STOP
-                            };
-                            let action = call_tui_extension(
-                                &cx,
-                                method,
-                                serde_json::json!({
-                                    "agentId": &agent_id,
-                                    "pluginId": &plugin_id,
-                                }),
-                            )
-                            .await;
-                            match action {
-                                Ok(value) if value.get("ok").and_then(Value::as_bool) == Some(false) => {
-                                    let message = value
-                                        .get("message")
-                                        .and_then(Value::as_str)
-                                        .unwrap_or("the Host rejected the lifecycle change");
-                                    let _ = bus.send(AppEvent::Ctl(CtlEvent::TuiOpFailed(
-                                        message.to_string(),
-                                    )));
-                                }
-                                Ok(_) => match fetch_dynamic_plugins(&cx, &agent_id).await {
-                                    Ok(plugins) => {
-                                        let _ = bus.send(AppEvent::Ctl(CtlEvent::CordisPlugins { plugins }));
-                                    }
-                                    Err(error) => {
-                                        let _ = bus.send(AppEvent::Ctl(CtlEvent::TuiOpFailed(format!(
-                                            "plugin changed, but inventory refresh failed: {error}"
-                                        ))));
-                                    }
-                                },
-                                Err(error) => {
-                                    let action = if enabled { "restore" } else { "stop" };
-                                    let _ = bus.send(AppEvent::Ctl(CtlEvent::TuiOpFailed(format!(
-                                        "plugin {action} failed: {error}"
-                                    ))));
-                                }
-                            }
-                        }
-                        Cmd::RespondCordisApproval { request_id, decision } => {
-                            if !ensure_agent_cordis(&surface, &bus) {
-                                continue;
-                            }
-                            if let Err(error) = call_tui_extension(
-                                &cx,
-                                crate::cordis::APPROVAL_RESPOND,
-                                serde_json::json!({
-                                    "protocol": crate::cordis::PROTOCOL,
-                                    "requestId": request_id,
-                                    "decision": decision,
-                                }),
-                            )
-                            .await
-                            {
-                                let _ = bus.send(AppEvent::Ctl(CtlEvent::TuiOpFailed(format!(
-                                    "plugin approval failed: {error}"
-                                ))));
-                            }
-                        }
-                        Cmd::InvokePluginCommand { name, args } => {
-                            if !ensure_agent_cordis(&surface, &bus) {
-                                continue;
-                            }
-                            if let Err(error) = call_tui_extension(
-                                &cx,
-                                crate::cordis::COMMAND_INVOKE,
-                                serde_json::json!({
-                                    "protocol": 0,
-                                    "name": name,
-                                    "args": args,
-                                }),
-                            )
-                            .await
-                            {
-                                let _ = bus.send(AppEvent::Ctl(CtlEvent::TuiOpFailed(format!(
-                                    "plugin command failed: {error}"
-                                ))));
-                            }
-                        }
-                        Cmd::PluginThemeSelected { agent_id, id } => {
-                            if !ensure_agent_cordis(&surface, &bus) {
-                                continue;
-                            }
-                            let result = call_tui_extension(
-                                &cx,
-                                crate::cordis::THEME_SELECTED,
-                                serde_json::json!({
-                                    "protocol": 0,
-                                    "agentId": agent_id,
-                                    "id": id,
-                                }),
-                            )
-                            .await;
-                            if let Err(error) = result {
-                                let _ = bus.send(AppEvent::Ctl(CtlEvent::TuiOpFailed(format!(
-                                    "theme Plugin selection failed: {error}"
-                                ))));
-                            }
-                        }
-                        Cmd::PluginUiSelected { agent_id, id } => {
-                            if !ensure_agent_cordis(&surface, &bus) {
-                                continue;
-                            }
-                            match call_tui_extension(
-                                &cx,
-                                crate::cordis::UI_SELECTED,
-                                serde_json::json!({
-                                    "protocol": crate::cordis::PROTOCOL,
-                                    "agentId": agent_id,
-                                    "id": id,
-                                }),
-                            )
-                            .await
-                            {
-                                Ok(_) => {}
-                                Err(error) => {
-                                    let _ = bus.send(AppEvent::Ctl(CtlEvent::TuiOpFailed(format!(
-                                        "UI Plugin selection failed: {error}"
-                                    ))));
-                                }
-                            }
-                        }
-                        Cmd::PluginOverlayEvent { id, event, value } => {
-                            if !ensure_agent_cordis(&surface, &bus) {
-                                continue;
-                            }
-                            let mut params = serde_json::json!({
-                                "protocol": 0,
-                                "id": id,
-                                "event": event,
-                            });
-                            if let Some(value) = value {
-                                params["value"] = value;
-                            }
-                            let result = if event == "change" {
-                                UntypedMessage::new(crate::cordis::OVERLAY_EVENT, params)
-                                    .and_then(|notification| cx.send_notification(notification))
-                                    .map(|_| Value::Null)
-                            } else {
-                                call_tui_extension(&cx, crate::cordis::OVERLAY_EVENT, params).await
-                            };
-                            if let Err(error) = result {
-                                let _ = bus.send(AppEvent::Ctl(CtlEvent::TuiOpFailed(format!(
-                                    "plugin overlay event failed: {error}"
-                                ))));
-                            }
-                        }
                         Cmd::FetchEfforts { session_id, .. } => {
                             let surface = surface.lock().unwrap_or_else(|e| e.into_inner());
                             let efforts = surface.session(&session_id).efforts.clone();
@@ -2509,567 +2265,6 @@ where
                                 },
                                 default: efforts.first().cloned(),
                             }));
-                        }
-                        Cmd::SetPermission { session_id: cmd_session, preset } => {
-                            let sid = match resolve_cmd_session(&sessions, &current, &cmd_session, "set_permission") {
-                                Ok(Some(sid)) => sid,
-                                Ok(None) => continue,
-                                Err(err) => {
-                                    let _ = bus.send(AppEvent::Ctl(CtlEvent::SessionError {
-                                    session_id: cmd_session.clone(),
-                                    message: err,
-                                }));
-                                    continue;
-                                }
-                            };
-                            match cx
-                                .send_request(SetSessionModeRequest::new(sid.clone(), preset.clone()))
-                                .block_task_deadline()
-                                .await
-                            {
-                                Ok(_) => {
-                                    let _ = bus.send(AppEvent::Ctl(CtlEvent::TuiOpDone(format!(
-                                        "permission → {preset}"
-                                    ))));
-                                }
-                                Err(err) if is_auth_required_error(&err) => {
-                                    emit_needs_auth_open(
-                                        &bus,
-                                        methods.clone(),
-                                        selected.as_ref(),
-                                        Some(acp_error_message(&err)),
-                                    );
-                                }
-                                Err(err) => {
-                                    let _ = cx
-                                        .send_request(SetSessionConfigOptionRequest::new(
-                                            sid,
-                                            "mode",
-                                            SessionConfigOptionValue::value_id(preset.clone()),
-                                        ))
-                                        .block_task_deadline()
-                                        .await;
-                                    let _ = bus.send(AppEvent::Ctl(CtlEvent::TuiOpDone(format!(
-                                        "permission → {preset} ({err})"
-                                    ))));
-                                }
-                            }
-                        }
-                        Cmd::SetPreset { session_id: cmd_session, preset } => {
-                            let sid = match resolve_cmd_session(&sessions, &current, &cmd_session, "set_preset") {
-                                Ok(Some(sid)) => sid,
-                                Ok(None) => continue,
-                                Err(err) => {
-                                    let _ = bus.send(AppEvent::Ctl(CtlEvent::SessionError {
-                                    session_id: cmd_session.clone(),
-                                    message: err,
-                                }));
-                                    continue;
-                                }
-                            };
-                            let config_id = surface
-                                .lock()
-                                .unwrap_or_else(|e| e.into_inner())
-                                .session(&sid.0)
-                                .composition_id
-                                .clone()
-                                .unwrap_or_else(|| "agent".into());
-                            match cx
-                                .send_request(SetSessionConfigOptionRequest::new(
-                                    sid.clone(),
-                                    config_id,
-                                    SessionConfigOptionValue::value_id(preset.clone()),
-                                ))
-                                .block_task_deadline()
-                                .await
-                            {
-                                Ok(response) => {
-                                     if let Ok(value) = serde_json::to_value(&response) {
-                                        if let Some(options) = value
-                                            .get("configOptions")
-                                            .or_else(|| value.get("config_options"))
-                                        {
-                                            if let Ok(mut surface) = surface.lock() {
-                                                surface.apply_config_options(
-                                                    options,
-                                                    &bus,
-                                                    Some(&sid.0),
-                                                );
-                                            }
-                                        }
-                                    }
-                                    let _ = bus.send(AppEvent::Ctl(CtlEvent::PresetSet {
-                                        session_id: sid.to_string(),
-                                        preset,
-                                    }));
-                                }
-                                Err(err) if is_auth_required_error(&err) => {
-                                    emit_needs_auth_open(
-                                        &bus,
-                                        methods.clone(),
-                                        selected.as_ref(),
-                                        Some(acp_error_message(&err)),
-                                    );
-                                }
-                                Err(err) => {
-                                    let _ = bus.send(AppEvent::Ctl(CtlEvent::TuiOpFailed(
-                                        format!("composition switch failed: {err}"),
-                                    )));
-                                }
-                            }
-                        }
-                        Cmd::SetConfigOption {
-                            session_id: cmd_session,
-                            config_id,
-                            value,
-                        } => {
-                            let sid = match resolve_cmd_session(
-                                &sessions,
-                                &current,
-                                &cmd_session,
-                                "config_option",
-                            ) {
-                                Ok(Some(sid)) => sid,
-                                Ok(None) => continue,
-                                Err(err) => {
-                                    let _ = bus.send(AppEvent::Ctl(CtlEvent::SessionError {
-                                        session_id: cmd_session.clone(),
-                                        message: err,
-                                    }));
-                                    continue;
-                                }
-                            };
-                            match cx
-                                .send_request(SetSessionConfigOptionRequest::new(
-                                    sid.clone(),
-                                    config_id,
-                                    SessionConfigOptionValue::value_id(value),
-                                ))
-                                .block_task_deadline()
-                                .await
-                            {
-                                Ok(response) => {
-                                    if let Ok(value) = serde_json::to_value(&response) {
-                                        let _ = apply_config_response(
-                                            &value,
-                                            &sid,
-                                            &surface,
-                                            &bus,
-                                        );
-                                    }
-                                }
-                                Err(err) if is_auth_required_error(&err) => {
-                                    emit_needs_auth_open(
-                                        &bus,
-                                        methods.clone(),
-                                        selected.as_ref(),
-                                        Some(acp_error_message(&err)),
-                                    );
-                                }
-                                Err(err) => {
-                                    let _ = bus.send(AppEvent::Ctl(CtlEvent::SessionError {
-                                        session_id: sid.to_string(),
-                                        message: format!("config option switch failed: {err}"),
-                                    }));
-                                }
-                            }
-                        }
-                        Cmd::Authenticate { method_id, values } => {
-                            let method = select_auth_method(&methods, Some(&method_id))
-                                .or_else(|| select_auth_method(&methods, None))
-                                .cloned();
-                            let Some(method) = method else {
-                                let _ = bus.send(AppEvent::Ctl(CtlEvent::TuiOpFailed(
-                                    if method_id.is_empty() {
-                                        "no supported ACP auth method is available".into()
-                                    } else {
-                                        format!(
-                                            "ACP auth method is unavailable or not supported: {method_id}"
-                                        )
-                                    },
-                                )));
-                                continue;
-                            };
-                            if method.is_env_prompt() {
-                                let vars = method
-                                    .vars
-                                    .iter()
-                                    .map(|v| v.name.as_str())
-                                    .collect::<Vec<_>>()
-                                    .join(", ");
-                                let _ = bus.send(AppEvent::Ctl(CtlEvent::TuiOpFailed(
-                                    if vars.is_empty() {
-                                        format!(
-                                            "ACP auth method {} requires credential variables and cannot be started as a sign-in flow.",
-                                            method.id
-                                        )
-                                    } else {
-                                        format!(
-                                            "ACP auth method {} requires credential variables ({vars}) and cannot be started as a sign-in flow.",
-                                            method.id
-                                        )
-                                    },
-                                )));
-                                continue;
-                            }
-                            if method.form && authenticate_meta_from_method(&method, &values).is_none()
-                            {
-                                let _ = bus.send(AppEvent::Ctl(CtlEvent::TuiOpFailed(
-                                    "sign-in needs values — /auth <api-key> (gateway: /auth <base-url> <api-key>)"
-                                        .into(),
-                                )));
-                                continue;
-                            }
-                            let mut req = AuthenticateRequest::new(method.id.clone());
-                            if let Some(meta) = authenticate_meta_from_method(&method, &values) {
-                                req = req.meta(meta);
-                            }
-                            match cx.send_request(req).block_task_deadline().await {
-                                Ok(_) => {
-                                    if current.is_none() {
-                                        match create_prompt_session(
-                                            &cx,
-                                            &cwd,
-                                            &surface,
-                                            &bus,
-                                            &methods,
-                                            Some(&method),
-                                        )
-                                        .await
-                                        {
-                                            Ok(Some(sid)) => {
-                                                bind_session(
-                                                    &mut sessions,
-                                                    &mut current,
-                                                    &mut pending,
-                                                    sid,
-                                                );
-                                                session_auth_pending = false;
-                                            }
-                                            Ok(None) => {
-                                                session_auth_pending = true;
-                                                continue;
-                                            }
-                                            Err(err) => {
-                                                let _ = bus.send(AppEvent::Ctl(CtlEvent::Error(
-                                                    format!("session/new after authenticate: {err}"),
-                                                )));
-                                                continue;
-                                            }
-                                        }
-                                    }
-                                    emit_auth(
-                                        &bus,
-                                        configured_snapshot(methods.clone(), Some(&method)),
-                                    );
-                                    // Release every stalled prompt into its
-                                    // own session's queue (entries whose
-                                    // session was closed meanwhile are
-                                    // dropped by the helper).
-                                    let retried = requeue_parked_prompts(
-                                        &mut sessions,
-                                        &current,
-                                        &mut parked,
-                                    );
-                                    let _ = bus.send(AppEvent::Ctl(CtlEvent::TuiOpDone(if retried
-                                        > 0
-                                    {
-                                        format!("signed in — retried {retried} parked prompt{s}", s = if retried == 1 { "" } else { "s" })
-                                    } else {
-                                        "signed in".into()
-                                    })));
-                                }
-                                Err(err) if is_auth_required_error(&err) => {
-                                    emit_auth(
-                                        &bus,
-                                        needs_auth_snapshot(
-                                            methods.clone(),
-                                            Some(&method),
-                                            Some(acp_error_message(&err)),
-                                        ),
-                                    );
-                                }
-                                Err(err) => {
-                                    let _ = bus.send(AppEvent::Ctl(CtlEvent::Error(format!(
-                                        "authenticate: {err}"
-                                    ))));
-                                }
-                            }
-                        }
-                        Cmd::NewSession => {
-                            match cx
-                                .send_request(NewSessionRequest::new(cwd.clone()))
-                                .block_task_deadline()
-                                .await
-                            {
-                                Ok(created) => {
-                                    bind_session(
-                                        &mut sessions,
-                                        &mut current,
-                                        &mut pending,
-                                        created.session_id.clone(),
-                                    );
-                                    session_auth_pending = false;
-                                    apply_created(
-                                        &created,
-                                        &surface,
-                                        &bus,
-                                        Some(format!(
-                                            "new session · {} — /agent picks its agent preset",
-                                            created.session_id
-                                        )),
-                                    );
-                                }
-                                Err(err) if is_auth_required_error(&err) => {
-                                    // The bind request is dead for now: pop
-                                    // its awaiting entry so a later bind can
-                                    // never land on it. The tab stays open
-                                    // (BindFailed notice) — /new again after
-                                    // signing in.
-                                    let _ = bus.send(AppEvent::Ctl(CtlEvent::BindFailed {
-                                        message: acp_error_message(&err),
-                                    }));
-                                    emit_needs_auth_open(
-                                        &bus,
-                                        methods.clone(),
-                                        selected.as_ref(),
-                                        Some(acp_error_message(&err)),
-                                    );
-                                }
-                                Err(err) => {
-                                    // The request the UI is awaiting died;
-                                    // the tab that asked stays open but the
-                                    // bind is never coming.
-                                    let _ = bus.send(AppEvent::Ctl(CtlEvent::BindFailed {
-                                        message: acp_error_message(&err),
-                                    }));
-                                }
-                            }
-                        }
-                        Cmd::ListSessions { requester_session_id, prefix, limit } => {
-                            if !list_session {
-                                let _ = bus.send(AppEvent::Ctl(CtlEvent::SessionListUnavailable {
-                                    requester_session_id,
-                                    prefix,
-                                    limit,
-                                    error: "agent did not advertise sessionCapabilities.list"
-                                        .into(),
-                                }));
-                                continue;
-                            }
-                            match cx
-                                .send_request(ListSessionsRequest::new().cwd(cwd.clone()))
-                                .block_task_deadline()
-                                .await
-                            {
-                                Ok(listed) => {
-                                    let sessions: Vec<SessionListItem> = listed
-                                        .sessions
-                                        .into_iter()
-                                        .map(|s| SessionListItem {
-                                            id: s.session_id.to_string(),
-                                            title: s.title,
-                                            updated_at: s.updated_at,
-                                        })
-                                        .collect();
-                                    // `/resume n`: the limit is applied on the
-                                    // App side, after the current session is
-                                    // filtered out of the list.
-                                    let _ = bus.send(AppEvent::Ctl(CtlEvent::SessionList {
-                                        requester_session_id,
-                                        sessions,
-                                        prefix,
-                                        limit,
-                                    }));
-                                }
-                                Err(err) if is_auth_required_error(&err) => {
-                                    emit_needs_auth_open(
-                                        &bus,
-                                        methods.clone(),
-                                        selected.as_ref(),
-                                        Some(acp_error_message(&err)),
-                                    );
-                                }
-                                Err(err) => {
-                                    let _ = bus.send(AppEvent::Ctl(CtlEvent::SessionListUnavailable {
-                                        requester_session_id,
-                                        prefix,
-                                        limit,
-                                        error: err.to_string(),
-                                    }));
-                                }
-                            }
-                        }
-                        Cmd::ResumeSession { session_id: id } => {
-                            let sid = SessionId::new(id.clone());
-                            let restored = if resume_session {
-                                match cx
-                                    .send_request(ResumeSessionRequest::new(
-                                        sid.clone(),
-                                        cwd.clone(),
-                                    ))
-                                    .block_task_deadline()
-                                    .await
-                                {
-                                    Ok(resumed) => Ok((
-                                        serde_json::to_value(resumed).unwrap_or(Value::Null),
-                                        true,
-                                    )),
-                                    Err(err)
-                                        if load_session && !is_auth_required_error(&err) =>
-                                    {
-                                        cx.send_request(LoadSessionRequest::new(
-                                            sid.clone(),
-                                            cwd.clone(),
-                                        ))
-                                        .block_task_deadline()
-                                        .await
-                                        .map(|loaded| {
-                                            (
-                                                serde_json::to_value(loaded)
-                                                    .unwrap_or(Value::Null),
-                                                false,
-                                            )
-                                        })
-                                    }
-                                    Err(err) => Err(err),
-                                }
-                            } else {
-                                cx.send_request(LoadSessionRequest::new(sid.clone(), cwd.clone()))
-                                    .block_task_deadline()
-                                    .await
-                                    .map(|loaded| {
-                                        (
-                                            serde_json::to_value(loaded).unwrap_or(Value::Null),
-                                            false,
-                                        )
-                                    })
-                            };
-                            match restored {
-                                Ok((setup, resumed)) => {
-                                    bind_session(
-                                        &mut sessions,
-                                        &mut current,
-                                        &mut pending,
-                                        sid.clone(),
-                                    );
-                                    let notice = if resumed {
-                                        format!(
-                                            "⟲ resumed {id} — previous transcript was not replayed"
-                                        )
-                                    } else {
-                                        format!(
-                                            "⟲ loaded {id} — transcript from session/update"
-                                        )
-                                    };
-                                    emit_session_bound(
-                                        &bus,
-                                        &sid,
-                                        Some(notice),
-                                    );
-                                    let session = sid.to_string();
-                                    apply_setup(&setup, Some(&session), &surface, &bus);
-                                }
-                                Err(err) if is_auth_required_error(&err) => {
-                                    // Same dead-request rule as /new: the
-                                    // awaiting entry pops now; retry /resume
-                                    // after signing in.
-                                    let _ = bus.send(AppEvent::Ctl(CtlEvent::BindFailed {
-                                        message: acp_error_message(&err),
-                                    }));
-                                    emit_needs_auth_open(
-                                        &bus,
-                                        methods.clone(),
-                                        selected.as_ref(),
-                                        Some(acp_error_message(&err)),
-                                    );
-                                }
-                                Err(err) => {
-                                    // session/resume failed outright: the
-                                    // awaiting tab's bind is never coming.
-                                    let _ = bus.send(AppEvent::Ctl(CtlEvent::BindFailed {
-                                        message: acp_error_message(&err),
-                                    }));
-                                }
-                            }
-                        }
-                        Cmd::QueueSnapshot { snapshot } => {
-                            let items = snapshot
-                                .items
-                                .into_iter()
-                                .map(|item| {
-                                    serde_json::json!({
-                                        "id": item.id,
-                                        "ordinal": item.ordinal,
-                                        "summary": item.summary,
-                                    })
-                                })
-                                .collect::<Vec<_>>();
-                            // This method belongs to the local Client compositor.
-                            // Direct native launches may not have one, so absence is
-                            // intentionally silent and never affects prompt flow.
-                            // Guarded by the initialize negotiation: an
-                            // un-negotiated agent gets no `_dsh/cordis`
-                            // traffic at all (protocol 0 rule).
-                            if agent_cordis_negotiated(&surface) {
-                                let _ = call_tui_extension(
-                                &cx,
-                                crate::cordis::QUEUE_UPDATE,
-                                serde_json::json!({
-                                    "protocol": crate::cordis::PROTOCOL,
-                                    "count": snapshot.count,
-                                    "items": items,
-                                    "selectedId": snapshot.selected_id,
-                                    "editingId": snapshot.editing_id,
-                                    "deleteConfirm": snapshot.delete_confirm,
-                                }),
-                                )
-                                .await;
-                            }
-                        }
-                        Cmd::AgentsSnapshot { snapshot } => {
-                            let items = snapshot
-                                .items
-                                .into_iter()
-                                .map(|item| {
-                                    serde_json::json!({
-                                        "id": item.id,
-                                        "label": item.label,
-                                        "kind": item.kind,
-                                        "status": item.status,
-                                        "current": item.current,
-                                    })
-                                })
-                                .collect::<Vec<_>>();
-                            // Agent transcript navigation is Client chrome;
-                            // it never becomes an ACP prompt or timeline cell.
-                            // Same negotiation guard as the queue snapshot.
-                            if agent_cordis_negotiated(&surface) {
-                                let _ = call_tui_extension(
-                                &cx,
-                                crate::cordis::AGENTS_UPDATE,
-                                serde_json::json!({
-                                    "protocol": crate::cordis::PROTOCOL,
-                                    "activeId": snapshot.active_id,
-                                    "selectedId": snapshot.selected_id,
-                                    "items": items,
-                                }),
-                                )
-                                .await;
-                            }
-                        }
-                        Cmd::ActiveSession { session_id } => {
-                            if agent_cordis_negotiated(&surface) {
-                                let _ = call_tui_extension(
-                                    &cx,
-                                    crate::cordis::SESSION_ACTIVE,
-                                    serde_json::json!({
-                                        "protocol": crate::cordis::PROTOCOL,
-                                        "sessionId": session_id,
-                                    }),
-                                )
-                                .await;
-                            }
                         }
                         Cmd::ForgetSession { session_id } => {
                             // `/close`: this client stopped viewing the
@@ -3095,8 +2290,33 @@ where
                             }
                         }
                         Cmd::Shutdown => break,
+                        control => {
+                            let mut control = control;
+                            let target = match &mut control {
+                                Cmd::SelectModel { session_id, .. }
+                                | Cmd::SetPermission { session_id, .. }
+                                | Cmd::SetPreset { session_id, .. }
+                                | Cmd::SetConfigOption { session_id, .. } => Some(session_id),
+                                _ => None,
+                            };
+                            if let Some(target) = target {
+                                match resolve_cmd_session(&sessions, &current, target, "session operation") {
+                                    Ok(Some(sid)) => *target = sid.to_string(),
+                                    Ok(None) => continue,
+                                    Err(message) => {
+                                        let _ = bus.send(AppEvent::Ctl(CtlEvent::SessionOpFailed {
+                                            session_id: target.clone(), message,
+                                        }));
+                                        continue;
+                                    }
+                                }
+                            }
+                            controls.enqueue(control, &cx, &bus, &surface, &methods, &selected,
+                                &cwd, load_session, resume_session, list_session, &control_done_tx);
+                        }
                     }
                             drain_ready_sessions(
+                                &controls,
                                 &mut sessions,
                                 &cx,
                                 &bus,
@@ -3109,6 +2329,53 @@ where
                                 &prompt_done_tx,
                             );
                         }
+                        completion = control_done_rx.recv() => {
+                            match completion {
+                                Some(ControlFinish::SessionOperationDone { session_id }) => controls.settled(&session_id),
+                                Some(ControlFinish::Setup { result }) => match result {
+                                    Ok((sid, setup, notice)) => {
+                                        bind_session(&mut sessions, &mut current, &mut pending, sid.clone());
+                                        session_auth_pending = false;
+                                        emit_session_bound(&bus, &sid, notice);
+                                        apply_setup(&setup, Some(&sid.0), &surface, &bus);
+                                    }
+                                    Err(err) => {
+                                        let _ = bus.send(AppEvent::Ctl(CtlEvent::BindFailed { message: acp_error_message(&err) }));
+                                        if is_auth_required_error(&err) {
+                                            emit_needs_auth_open(&bus, methods.clone(), selected.as_ref(), Some(acp_error_message(&err)));
+                                        }
+                                    }
+                                },
+                                Some(ControlFinish::Authenticated { method, result }) => match result {
+                                    Ok(()) => {
+                                        if current.is_none() {
+                                            match create_prompt_session(&cx, &cwd, &surface, &bus, &methods, Some(&method)).await {
+                                                Ok(Some(sid)) => {
+                                                    bind_session(&mut sessions, &mut current, &mut pending, sid);
+                                                    session_auth_pending = false;
+                                                }
+                                                Ok(None) => { session_auth_pending = true; continue; }
+                                                Err(err) => {
+                                                    let _ = bus.send(AppEvent::Ctl(CtlEvent::Error(format!("session/new after authenticate: {err}"))));
+                                                    continue;
+                                                }
+                                            }
+                                        }
+                                        emit_auth(&bus, configured_snapshot(methods.clone(), Some(&method)));
+                                        let retried = requeue_parked_prompts(&mut sessions, &current, &mut parked);
+                                        let _ = bus.send(AppEvent::Ctl(CtlEvent::TuiOpDone(if retried > 0 {
+                                            format!("signed in — retried {retried} parked prompt{s}", s = if retried == 1 { "" } else { "s" })
+                                        } else { "signed in".into() })));
+                                    }
+                                    Err(err) if is_auth_required_error(&err) => emit_auth(&bus,
+                                        needs_auth_snapshot(methods.clone(), Some(&method), Some(acp_error_message(&err)))),
+                                    Err(err) => { let _ = bus.send(AppEvent::Ctl(CtlEvent::TuiOpFailed(format!("authenticate: {err}")))); }
+                                },
+                                None => {}
+                            }
+                            drain_ready_sessions(&controls, &mut sessions, &cx, &bus, &mut parked, &methods,
+                                selected.as_ref(), &surface, &cfg.workspace, &mut prompt_gen, &prompt_done_tx);
+                        }
                         steer = steer_done_rx.recv() => {
                             if let Some(SteerFinish { message_id, result }) = steer {
                                 let deferred = result.is_err();
@@ -3118,6 +2385,7 @@ where
                                 }));
                             }
                             drain_ready_sessions(
+                                &controls,
                                 &mut sessions,
                                 &cx,
                                 &bus,
@@ -3198,6 +2466,7 @@ where
                                     .is_some_and(|handle| !handle.queue.is_empty());
                             if queued {
                                 drain_ready_sessions(
+                                    &controls,
                                     &mut sessions,
                                     &cx,
                                     &bus,

--- a/src/acp/control.rs
+++ b/src/acp/control.rs
@@ -1,0 +1,741 @@
+//! Slow ACP control requests, serialized within their owning lane.
+
+use super::*;
+
+pub(super) type SetupResult = Result<(SessionId, Value, Option<String>), AcpError>;
+
+pub(super) enum ControlFinish {
+    SessionOperationDone {
+        session_id: String,
+    },
+    Setup {
+        result: SetupResult,
+    },
+    Authenticated {
+        method: AuthMethodInfo,
+        result: Result<(), AcpError>,
+    },
+}
+
+type ControlJob = std::pin::Pin<Box<dyn Future<Output = ()> + Send>>;
+
+#[derive(Default)]
+pub(super) struct ControlWorkers {
+    pending: HashMap<String, usize>,
+    lanes: HashMap<String, tokio::sync::mpsc::UnboundedSender<ControlJob>>,
+    tasks: Vec<tokio::task::JoinHandle<()>>,
+}
+
+impl Drop for ControlWorkers {
+    fn drop(&mut self) {
+        for task in &self.tasks {
+            task.abort();
+        }
+    }
+}
+
+impl ControlWorkers {
+    pub(super) fn busy(&self, session: &str) -> bool {
+        self.pending.get(session).copied().unwrap_or(0) > 0
+    }
+
+    pub(super) fn settled(&mut self, session: &str) {
+        if let Some(count) = self.pending.get_mut(session) {
+            *count = count.saturating_sub(1);
+            if *count == 0 {
+                self.pending.remove(session);
+            }
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(super) fn enqueue(
+        &mut self,
+        cmd: Cmd,
+        cx: &ConnectionTo<Agent>,
+        bus: &Sender<AppEvent>,
+        surface: &Arc<Mutex<Surface>>,
+        methods: &[AuthMethodInfo],
+        selected: &Option<AuthMethodInfo>,
+        cwd: &std::path::Path,
+        load_session: bool,
+        resume_session: bool,
+        list_session: bool,
+        done: &tokio::sync::mpsc::UnboundedSender<ControlFinish>,
+    ) {
+        // Preserve setup FIFO and per-session mutation order without blocking
+        // prompts, cancellations, or other sessions' control requests.
+        let lane = match &cmd {
+            Cmd::NewSession | Cmd::ResumeSession { .. } => "setup".to_string(),
+            Cmd::SelectModel { session_id, .. }
+            | Cmd::SetPermission { session_id, .. }
+            | Cmd::SetPreset { session_id, .. }
+            | Cmd::SetConfigOption { session_id, .. } => format!("config:{session_id}"),
+            Cmd::Authenticate { .. } => "auth".to_string(),
+            _ => "client".to_string(),
+        };
+        let session = lane.strip_prefix("config:").map(str::to_string);
+        if let Some(session) = &session {
+            *self.pending.entry(session.clone()).or_default() += 1;
+        }
+        let sender = self.lanes.entry(lane).or_insert_with(|| {
+            let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<ControlJob>();
+            self.tasks.push(tokio::spawn(async move {
+                while let Some(job) = rx.recv().await {
+                    job.await;
+                }
+            }));
+            tx
+        });
+        let job = run_control(
+            cmd,
+            cx.clone(),
+            bus.clone(),
+            Arc::clone(surface),
+            methods.to_vec(),
+            selected.clone(),
+            cwd.to_path_buf(),
+            load_session,
+            resume_session,
+            list_session,
+            done.clone(),
+        );
+        let done = done.clone();
+        let _ = sender.send(Box::pin(async move {
+            job.await;
+            if let Some(session_id) = session {
+                let _ = done.send(ControlFinish::SessionOperationDone { session_id });
+            }
+        }));
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn run_control(
+    cmd: Cmd,
+    cx: ConnectionTo<Agent>,
+    bus: Sender<AppEvent>,
+    surface: Arc<Mutex<Surface>>,
+    methods: Vec<AuthMethodInfo>,
+    selected: Option<AuthMethodInfo>,
+    cwd: std::path::PathBuf,
+    load_session: bool,
+    resume_session: bool,
+    list_session: bool,
+    done: tokio::sync::mpsc::UnboundedSender<ControlFinish>,
+) {
+    match cmd {
+        Cmd::SelectModel {
+            session_id: cmd_session,
+            model,
+            effort,
+            ..
+        } => {
+            let sid = SessionId::new(cmd_session);
+            if let Some(model) = model {
+                let value = {
+                    let surface = surface.lock().unwrap_or_else(|e| e.into_inner());
+                    match surface
+                        .session(&sid.0)
+                        .models
+                        .iter()
+                        .find(|m| m.id == model)
+                    {
+                        Some(m) if !m.provider.is_empty() => {
+                            format!("{}/{}", m.provider, model)
+                        }
+                        _ => model.clone(),
+                    }
+                };
+                let _ = cx
+                    .send_request(SetSessionConfigOptionRequest::new(
+                        sid.clone(),
+                        "model",
+                        SessionConfigOptionValue::value_id(value),
+                    ))
+                    .block_task_deadline()
+                    .await
+                    .map_err(|err| {
+                        if is_auth_required_error(&err) {
+                            emit_needs_auth_open(
+                                &bus,
+                                methods.clone(),
+                                selected.as_ref(),
+                                Some(acp_error_message(&err)),
+                            );
+                        }
+                    });
+            }
+            if let Some(effort) = effort {
+                let _ = cx
+                    .send_request(SetSessionConfigOptionRequest::new(
+                        sid,
+                        "effort",
+                        SessionConfigOptionValue::value_id(effort),
+                    ))
+                    .block_task_deadline()
+                    .await
+                    .map_err(|err| {
+                        if is_auth_required_error(&err) {
+                            emit_needs_auth_open(
+                                &bus,
+                                methods.clone(),
+                                selected.as_ref(),
+                                Some(acp_error_message(&err)),
+                            );
+                        }
+                    });
+            }
+        }
+        Cmd::FetchStaticPlugins => match fetch_static_plugins(&cx).await {
+            Ok(plugins) => {
+                let _ = bus.send(AppEvent::Ctl(CtlEvent::StaticPlugins { plugins }));
+            }
+            Err(error) => {
+                let _ = bus.send(AppEvent::Ctl(CtlEvent::TuiOpFailed(format!(
+                    "static plugins unavailable: {error}"
+                ))));
+            }
+        },
+        Cmd::FetchCordisPlugins { agent_id } => {
+            if !ensure_agent_cordis(&surface, &bus) {
+                return;
+            }
+            match fetch_dynamic_plugins(&cx, &agent_id).await {
+                Ok(plugins) => {
+                    let _ = bus.send(AppEvent::Ctl(CtlEvent::CordisPlugins { plugins }));
+                }
+                Err(error) => {
+                    let _ = bus.send(AppEvent::Ctl(CtlEvent::TuiOpFailed(format!(
+                        "dynamic plugins unavailable: {error}"
+                    ))));
+                }
+            }
+        }
+        Cmd::SetCordisPluginEnabled {
+            agent_id,
+            plugin_id,
+            enabled,
+        } => {
+            if !ensure_agent_cordis(&surface, &bus) {
+                return;
+            }
+            let method = if enabled {
+                crate::cordis::PLUGIN_START
+            } else {
+                crate::cordis::PLUGIN_STOP
+            };
+            let action = call_tui_extension(
+                &cx,
+                method,
+                serde_json::json!({
+                    "agentId": &agent_id,
+                    "pluginId": &plugin_id,
+                }),
+            )
+            .await;
+            match action {
+                Ok(value) if value.get("ok").and_then(Value::as_bool) == Some(false) => {
+                    let message = value
+                        .get("message")
+                        .and_then(Value::as_str)
+                        .unwrap_or("the Host rejected the lifecycle change");
+                    let _ = bus.send(AppEvent::Ctl(CtlEvent::TuiOpFailed(message.to_string())));
+                }
+                Ok(_) => match fetch_dynamic_plugins(&cx, &agent_id).await {
+                    Ok(plugins) => {
+                        let _ = bus.send(AppEvent::Ctl(CtlEvent::CordisPlugins { plugins }));
+                    }
+                    Err(error) => {
+                        let _ = bus.send(AppEvent::Ctl(CtlEvent::TuiOpFailed(format!(
+                            "plugin changed, but inventory refresh failed: {error}"
+                        ))));
+                    }
+                },
+                Err(error) => {
+                    let action = if enabled { "restore" } else { "stop" };
+                    let _ = bus.send(AppEvent::Ctl(CtlEvent::TuiOpFailed(format!(
+                        "plugin {action} failed: {error}"
+                    ))));
+                }
+            }
+        }
+        Cmd::RespondCordisApproval {
+            request_id,
+            decision,
+        } => {
+            if !ensure_agent_cordis(&surface, &bus) {
+                return;
+            }
+            if let Err(error) = call_tui_extension(
+                &cx,
+                crate::cordis::APPROVAL_RESPOND,
+                serde_json::json!({
+                    "protocol": crate::cordis::PROTOCOL,
+                    "requestId": request_id,
+                    "decision": decision,
+                }),
+            )
+            .await
+            {
+                let _ = bus.send(AppEvent::Ctl(CtlEvent::TuiOpFailed(format!(
+                    "plugin approval failed: {error}"
+                ))));
+            }
+        }
+        Cmd::InvokePluginCommand { name, args } => {
+            if !ensure_agent_cordis(&surface, &bus) {
+                return;
+            }
+            if let Err(error) = call_tui_extension(
+                &cx,
+                crate::cordis::COMMAND_INVOKE,
+                serde_json::json!({
+                    "protocol": 0,
+                    "name": name,
+                    "args": args,
+                }),
+            )
+            .await
+            {
+                let _ = bus.send(AppEvent::Ctl(CtlEvent::TuiOpFailed(format!(
+                    "plugin command failed: {error}"
+                ))));
+            }
+        }
+        Cmd::PluginThemeSelected { agent_id, id } => {
+            if !ensure_agent_cordis(&surface, &bus) {
+                return;
+            }
+            let result = call_tui_extension(
+                &cx,
+                crate::cordis::THEME_SELECTED,
+                serde_json::json!({
+                    "protocol": 0,
+                    "agentId": agent_id,
+                    "id": id,
+                }),
+            )
+            .await;
+            if let Err(error) = result {
+                let _ = bus.send(AppEvent::Ctl(CtlEvent::TuiOpFailed(format!(
+                    "theme Plugin selection failed: {error}"
+                ))));
+            }
+        }
+        Cmd::PluginUiSelected { agent_id, id } => {
+            if !ensure_agent_cordis(&surface, &bus) {
+                return;
+            }
+            match call_tui_extension(
+                &cx,
+                crate::cordis::UI_SELECTED,
+                serde_json::json!({
+                    "protocol": crate::cordis::PROTOCOL,
+                    "agentId": agent_id,
+                    "id": id,
+                }),
+            )
+            .await
+            {
+                Ok(_) => {}
+                Err(error) => {
+                    let _ = bus.send(AppEvent::Ctl(CtlEvent::TuiOpFailed(format!(
+                        "UI Plugin selection failed: {error}"
+                    ))));
+                }
+            }
+        }
+        Cmd::PluginOverlayEvent { id, event, value } => {
+            if !ensure_agent_cordis(&surface, &bus) {
+                return;
+            }
+            let mut params = serde_json::json!({
+                "protocol": 0,
+                "id": id,
+                "event": event,
+            });
+            if let Some(value) = value {
+                params["value"] = value;
+            }
+            let result = if event == "change" {
+                UntypedMessage::new(crate::cordis::OVERLAY_EVENT, params)
+                    .and_then(|notification| cx.send_notification(notification))
+                    .map(|_| Value::Null)
+            } else {
+                call_tui_extension(&cx, crate::cordis::OVERLAY_EVENT, params).await
+            };
+            if let Err(error) = result {
+                let _ = bus.send(AppEvent::Ctl(CtlEvent::TuiOpFailed(format!(
+                    "plugin overlay event failed: {error}"
+                ))));
+            }
+        }
+        Cmd::SetPermission {
+            session_id: cmd_session,
+            preset,
+        } => {
+            let sid = SessionId::new(cmd_session);
+            match cx
+                .send_request(SetSessionModeRequest::new(sid.clone(), preset.clone()))
+                .block_task_deadline()
+                .await
+            {
+                Ok(_) => {
+                    let _ = bus.send(AppEvent::Ctl(CtlEvent::TuiOpDone(format!(
+                        "permission → {preset}"
+                    ))));
+                }
+                Err(err) if is_auth_required_error(&err) => {
+                    emit_needs_auth_open(
+                        &bus,
+                        methods.clone(),
+                        selected.as_ref(),
+                        Some(acp_error_message(&err)),
+                    );
+                }
+                Err(err) => {
+                    let _ = cx
+                        .send_request(SetSessionConfigOptionRequest::new(
+                            sid,
+                            "mode",
+                            SessionConfigOptionValue::value_id(preset.clone()),
+                        ))
+                        .block_task_deadline()
+                        .await;
+                    let _ = bus.send(AppEvent::Ctl(CtlEvent::TuiOpDone(format!(
+                        "permission → {preset} ({err})"
+                    ))));
+                }
+            }
+        }
+        Cmd::SetPreset {
+            session_id: cmd_session,
+            preset,
+        } => {
+            let sid = SessionId::new(cmd_session);
+            let config_id = surface
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .session(&sid.0)
+                .composition_id
+                .clone()
+                .unwrap_or_else(|| "agent".into());
+            match cx
+                .send_request(SetSessionConfigOptionRequest::new(
+                    sid.clone(),
+                    config_id,
+                    SessionConfigOptionValue::value_id(preset.clone()),
+                ))
+                .block_task_deadline()
+                .await
+            {
+                Ok(response) => {
+                    if let Ok(value) = serde_json::to_value(&response) {
+                        if let Some(options) = value
+                            .get("configOptions")
+                            .or_else(|| value.get("config_options"))
+                        {
+                            if let Ok(mut surface) = surface.lock() {
+                                surface.apply_config_options(options, &bus, Some(&sid.0));
+                            }
+                        }
+                    }
+                    let _ = bus.send(AppEvent::Ctl(CtlEvent::PresetSet {
+                        session_id: sid.to_string(),
+                        preset,
+                    }));
+                }
+                Err(err) if is_auth_required_error(&err) => {
+                    emit_needs_auth_open(
+                        &bus,
+                        methods.clone(),
+                        selected.as_ref(),
+                        Some(acp_error_message(&err)),
+                    );
+                }
+                Err(err) => {
+                    let _ = bus.send(AppEvent::Ctl(CtlEvent::TuiOpFailed(format!(
+                        "composition switch failed: {err}"
+                    ))));
+                }
+            }
+        }
+        Cmd::SetConfigOption {
+            session_id: cmd_session,
+            config_id,
+            value,
+        } => {
+            let sid = SessionId::new(cmd_session);
+            match cx
+                .send_request(SetSessionConfigOptionRequest::new(
+                    sid.clone(),
+                    config_id,
+                    SessionConfigOptionValue::value_id(value),
+                ))
+                .block_task_deadline()
+                .await
+            {
+                Ok(response) => {
+                    if let Ok(value) = serde_json::to_value(&response) {
+                        let _ = apply_config_response(&value, &sid, &surface, &bus);
+                    }
+                }
+                Err(err) if is_auth_required_error(&err) => {
+                    emit_needs_auth_open(
+                        &bus,
+                        methods.clone(),
+                        selected.as_ref(),
+                        Some(acp_error_message(&err)),
+                    );
+                }
+                Err(err) => {
+                    let _ = bus.send(AppEvent::Ctl(CtlEvent::SessionOpFailed {
+                        session_id: sid.to_string(),
+                        message: format!("config option switch failed: {err}"),
+                    }));
+                }
+            }
+        }
+        Cmd::Authenticate { method_id, values } => {
+            let method = select_auth_method(&methods, Some(&method_id))
+                .or_else(|| select_auth_method(&methods, None))
+                .cloned();
+            let Some(method) = method else {
+                let _ = bus.send(AppEvent::Ctl(CtlEvent::TuiOpFailed(
+                    if method_id.is_empty() {
+                        "no supported ACP auth method is available".into()
+                    } else {
+                        format!("ACP auth method is unavailable or not supported: {method_id}")
+                    },
+                )));
+                return;
+            };
+            if method.is_env_prompt() {
+                let vars = method
+                    .vars
+                    .iter()
+                    .map(|v| v.name.as_str())
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                let _ = bus.send(AppEvent::Ctl(CtlEvent::TuiOpFailed(
+                                    if vars.is_empty() {
+                                        format!(
+                                            "ACP auth method {} requires credential variables and cannot be started as a sign-in flow.",
+                                            method.id
+                                        )
+                                    } else {
+                                        format!(
+                                            "ACP auth method {} requires credential variables ({vars}) and cannot be started as a sign-in flow.",
+                                            method.id
+                                        )
+                                    },
+                                )));
+                return;
+            }
+            if method.form && authenticate_meta_from_method(&method, &values).is_none() {
+                let _ = bus.send(AppEvent::Ctl(CtlEvent::TuiOpFailed(
+                    "sign-in needs values — /auth <api-key> (gateway: /auth <base-url> <api-key>)"
+                        .into(),
+                )));
+                return;
+            }
+            let mut req = AuthenticateRequest::new(method.id.clone());
+            if let Some(meta) = authenticate_meta_from_method(&method, &values) {
+                req = req.meta(meta);
+            }
+            let result = cx.send_request(req).block_task_deadline().await.map(|_| ());
+            let _ = done.send(ControlFinish::Authenticated { method, result });
+        }
+        Cmd::NewSession => {
+            let result = cx
+                .send_request(NewSessionRequest::new(cwd.clone()))
+                .block_task_deadline()
+                .await
+                .map(|created| {
+                    let sid = created.session_id.clone();
+                    let notice = Some(format!(
+                        "new session · {sid} — /agent picks its agent preset"
+                    ));
+                    (
+                        sid,
+                        serde_json::to_value(created).unwrap_or(Value::Null),
+                        notice,
+                    )
+                });
+            let _ = done.send(ControlFinish::Setup { result });
+        }
+        Cmd::ListSessions {
+            requester_session_id,
+            prefix,
+            limit,
+        } => {
+            if !list_session {
+                let _ = bus.send(AppEvent::Ctl(CtlEvent::SessionListUnavailable {
+                    requester_session_id,
+                    prefix,
+                    limit,
+                    error: "agent did not advertise sessionCapabilities.list".into(),
+                }));
+                return;
+            }
+            match cx
+                .send_request(ListSessionsRequest::new().cwd(cwd.clone()))
+                .block_task_deadline()
+                .await
+            {
+                Ok(listed) => {
+                    let sessions: Vec<SessionListItem> = listed
+                        .sessions
+                        .into_iter()
+                        .map(|s| SessionListItem {
+                            id: s.session_id.to_string(),
+                            title: s.title,
+                            updated_at: s.updated_at,
+                        })
+                        .collect();
+                    // `/resume n`: the limit is applied on the
+                    // App side, after the current session is
+                    // filtered out of the list.
+                    let _ = bus.send(AppEvent::Ctl(CtlEvent::SessionList {
+                        requester_session_id,
+                        sessions,
+                        prefix,
+                        limit,
+                    }));
+                }
+                Err(err) if is_auth_required_error(&err) => {
+                    emit_needs_auth_open(
+                        &bus,
+                        methods.clone(),
+                        selected.as_ref(),
+                        Some(acp_error_message(&err)),
+                    );
+                }
+                Err(err) => {
+                    let _ = bus.send(AppEvent::Ctl(CtlEvent::SessionListUnavailable {
+                        requester_session_id,
+                        prefix,
+                        limit,
+                        error: err.to_string(),
+                    }));
+                }
+            }
+        }
+        Cmd::ResumeSession { session_id: id } => {
+            let sid = SessionId::new(id.clone());
+            let restored = if resume_session {
+                match cx
+                    .send_request(ResumeSessionRequest::new(sid.clone(), cwd.clone()))
+                    .block_task_deadline()
+                    .await
+                {
+                    Ok(resumed) => Ok((serde_json::to_value(resumed).unwrap_or(Value::Null), true)),
+                    Err(err) if load_session && !is_auth_required_error(&err) => cx
+                        .send_request(LoadSessionRequest::new(sid.clone(), cwd.clone()))
+                        .block_task_deadline()
+                        .await
+                        .map(|loaded| (serde_json::to_value(loaded).unwrap_or(Value::Null), false)),
+                    Err(err) => Err(err),
+                }
+            } else {
+                cx.send_request(LoadSessionRequest::new(sid.clone(), cwd.clone()))
+                    .block_task_deadline()
+                    .await
+                    .map(|loaded| (serde_json::to_value(loaded).unwrap_or(Value::Null), false))
+            };
+            let result = restored.map(|(setup, resumed)| {
+                let notice = if resumed {
+                    format!("⟲ resumed {id} — previous transcript was not replayed")
+                } else {
+                    format!("⟲ loaded {id} — transcript from session/update")
+                };
+                (sid, setup, Some(notice))
+            });
+            let _ = done.send(ControlFinish::Setup { result });
+        }
+        Cmd::QueueSnapshot { snapshot } => {
+            let items = snapshot
+                .items
+                .into_iter()
+                .map(|item| {
+                    serde_json::json!({
+                        "id": item.id,
+                        "ordinal": item.ordinal,
+                        "summary": item.summary,
+                    })
+                })
+                .collect::<Vec<_>>();
+            // This method belongs to the local Client compositor.
+            // Direct native launches may not have one, so absence is
+            // intentionally silent and never affects prompt flow.
+            // Guarded by the initialize negotiation: an
+            // un-negotiated agent gets no `_dsh/cordis`
+            // traffic at all (protocol 0 rule).
+            if agent_cordis_negotiated(&surface) {
+                let _ = call_tui_extension(
+                    &cx,
+                    crate::cordis::QUEUE_UPDATE,
+                    serde_json::json!({
+                        "protocol": crate::cordis::PROTOCOL,
+                        "count": snapshot.count,
+                        "items": items,
+                        "selectedId": snapshot.selected_id,
+                        "editingId": snapshot.editing_id,
+                        "deleteConfirm": snapshot.delete_confirm,
+                    }),
+                )
+                .await;
+            }
+        }
+        Cmd::AgentsSnapshot { snapshot } => {
+            let items = snapshot
+                .items
+                .into_iter()
+                .map(|item| {
+                    serde_json::json!({
+                        "id": item.id,
+                        "label": item.label,
+                        "kind": item.kind,
+                        "status": item.status,
+                        "current": item.current,
+                    })
+                })
+                .collect::<Vec<_>>();
+            // Agent transcript navigation is Client chrome;
+            // it never becomes an ACP prompt or timeline cell.
+            // Same negotiation guard as the queue snapshot.
+            if agent_cordis_negotiated(&surface) {
+                let _ = call_tui_extension(
+                    &cx,
+                    crate::cordis::AGENTS_UPDATE,
+                    serde_json::json!({
+                        "protocol": crate::cordis::PROTOCOL,
+                        "activeId": snapshot.active_id,
+                        "selectedId": snapshot.selected_id,
+                        "items": items,
+                    }),
+                )
+                .await;
+            }
+        }
+        Cmd::ActiveSession { session_id } => {
+            if agent_cordis_negotiated(&surface) {
+                let _ = call_tui_extension(
+                    &cx,
+                    crate::cordis::SESSION_ACTIVE,
+                    serde_json::json!({
+                        "protocol": crate::cordis::PROTOCOL,
+                        "sessionId": session_id,
+                    }),
+                )
+                .await;
+            }
+        }
+        _ => {}
+    }
+}
+
+#[cfg(test)]
+#[path = "../../tests/unit/acp__control_tests.rs"]
+mod tests;

--- a/src/app.rs
+++ b/src/app.rs
@@ -42,7 +42,7 @@ struct CtrlCQuitChord {
     required: u8,
 }
 const TIP_TTL: Duration = Duration::from_secs(4);
-/// How long the `⌕` jump flash keeps the jumped user prompt background-
+/// How long the `↥` jump flash keeps the jumped user prompt background-
 /// washed before it restores to normal (issue #103).
 pub(crate) const PROMPT_FLASH_TTL: Duration = Duration::from_secs(5);
 /// How often the composer cap re-checks the workspace git branch (tick
@@ -817,6 +817,8 @@ pub struct SessionSlot {
     /// Finished while parked → tab badge until the user views the tab.
     pub completed_unseen: bool,
     pub prompt_queue: VecDeque<ClientQueuedPrompt>,
+    queue_selection: Option<usize>,
+    queue_edit: Option<QueueEditState>,
     pub prompt_pending: bool,
     pub modes: Modes,
     pub skills: Vec<crate::bus::SkillInfo>,
@@ -872,6 +874,8 @@ impl SessionSlot {
             running: false,
             completed_unseen: false,
             prompt_queue: VecDeque::new(),
+            queue_selection: None,
+            queue_edit: None,
             prompt_pending: false,
             modes: Modes::default(),
             skills: Vec::new(),
@@ -1281,18 +1285,18 @@ pub struct App {
     /// True while the pointer rests on the expand button; only then does
     /// the frame painter show it (`needs_redraw` on change).
     pub(crate) hover_expand_btn: bool,
-    /// Screen rect of the mouse-only `⌕` user-prompt jump button (issue
+    /// Screen rect of the mouse-only `↥` user-prompt jump button (issue
     /// #103) from the latest frame — one cell left of the expand glyph on
     /// the composer card's top-right.
     pub(crate) prompt_jump_btn: Option<ratatui::layout::Rect>,
-    /// True while the pointer rests on the `⌕` button (`needs_redraw` on
+    /// True while the pointer rests on the `↥` button (`needs_redraw` on
     /// change, same hover policy as the expand button).
     pub(crate) hover_prompt_jump_btn: bool,
-    /// Transcript cell of the user prompt the last `⌕` click jumped to
+    /// Transcript cell of the user prompt the last `↥` click jumped to
     /// (issue #103). The next click walks one prompt back; the oldest
     /// wraps to the newest. In-memory only — never persisted.
     pub(crate) prompt_jump_cell: Option<usize>,
-    /// The `⌕` jump flash (issue #103): the transcript cell of the prompt
+    /// The `↥` jump flash (issue #103): the transcript cell of the prompt
     /// that was just jumped to, with the instant the highlight (chip
     /// background wash + brand text) expires, 5 s after the click.
     /// `App::tick` clears it on expiry; the painter resolves the cell to
@@ -1928,6 +1932,8 @@ impl App {
             running: self.state != RunState::Idle || self.prompt_pending,
             completed_unseen: false,
             prompt_queue: std::mem::take(&mut self.prompt_queue),
+            queue_selection: self.queue_selection.take(),
+            queue_edit: self.queue_edit.take(),
             prompt_pending: std::mem::take(&mut self.prompt_pending),
             modes: std::mem::take(&mut self.modes),
             skills: std::mem::take(&mut self.skills),
@@ -1963,6 +1969,8 @@ impl App {
         self.transcript = slot.transcript;
         self.queued = slot.prompt_queue.len();
         self.prompt_queue = slot.prompt_queue;
+        self.queue_selection = slot.queue_selection;
+        self.queue_edit = slot.queue_edit;
         self.prompt_pending = slot.prompt_pending;
         self.modes = slot.modes;
         self.skills = slot.skills;
@@ -2024,10 +2032,8 @@ impl App {
         self.input_sel = None;
         self.input_selecting = false;
         self.picker = None;
-        self.queue_selection = None;
-        self.queue_edit = None;
         self.vim.reset_pending();
-        // The ⌕ jump cursor indexes this session's transcript cells, and
+        // The ↥ jump cursor indexes this session's transcript cells, and
         // the flash must not carry over to another session's view.
         self.prompt_jump_cell = None;
         self.prompt_flash = None;
@@ -2239,6 +2245,9 @@ impl App {
         let Some(slot) = self.parked.iter_mut().find(|slot| slot.id == session) else {
             return;
         };
+        if slot.queue_selection.is_some() || slot.queue_edit.is_some() {
+            return;
+        }
         if !slot.session_bound {
             // Mirror of the live path's guard (dispatch_next_queued): an
             // unbound placeholder must never burn its queue — the prompts
@@ -2361,7 +2370,7 @@ impl App {
                 self.needs_redraw = true;
             }
         }
-        // The ⌕ jump flash restores the prompt to normal after its 5 s.
+        // The ↥ jump flash restores the prompt to normal after its 5 s.
         if let Some((_, until)) = &self.prompt_flash {
             if Instant::now() >= *until {
                 self.prompt_flash = None;
@@ -3498,6 +3507,8 @@ impl App {
                     slot.running = false;
                     slot.prompt_pending = false;
                     slot.prompt_queue.clear();
+                    slot.queue_selection = None;
+                    slot.queue_edit = None;
                     slot.pending_steer_cells.clear();
                 }
                 if self.state != RunState::Idle {
@@ -3576,6 +3587,15 @@ impl App {
                         self.run_started = None;
                         self.transcript.push_notice(NoticeLevel::Error, err);
                         self.dispatch_next_queued(ctl);
+                    }
+                    CtlEvent::SessionOpFailed { session_id, message } => {
+                        if session_id == self.session_id {
+                            self.transcript.push_notice(NoticeLevel::Error, message);
+                        } else if let Some(slot) = self.parked.iter_mut()
+                            .find(|slot| slot.id == session_id)
+                        {
+                            slot.transcript.push_notice(NoticeLevel::Error, message);
+                        }
                     }
                     CtlEvent::SessionError {
                         session_id,
@@ -4533,7 +4553,7 @@ impl App {
                     self.toggle_tool(ci);
                     return;
                 }
-                // The ⌕ prompt-jump button (issue #103) wins over caret
+                // The ↥ prompt-jump button (issue #103) wins over caret
                 // placement: each click walks the chat view to the previous
                 // user prompt (newest first, wrapping at the oldest).
                 if self.elicitation_ask.is_none()
@@ -4743,7 +4763,7 @@ impl App {
         })
     }
 
-    /// Hit-test the mouse-only `⌕` user-prompt jump button (issue #103).
+    /// Hit-test the mouse-only `↥` user-prompt jump button (issue #103).
     fn prompt_jump_btn_hit(&self, col: u16, row: u16) -> bool {
         self.prompt_jump_btn.is_some_and(|r| {
             col >= r.x
@@ -4753,7 +4773,7 @@ impl App {
         })
     }
 
-    /// `⌕` click (issue #103): jump the chat view to a user prompt. The
+    /// `↥` click (issue #103): jump the chat view to a user prompt. The
     /// first click goes to the newest prompt, each further click walks one
     /// prompt back, and the oldest wraps to the newest again. The last
     /// target is remembered in memory only (never persisted) and rides
@@ -4770,8 +4790,8 @@ impl App {
             .layout(&theme, area.width, spinner, crate::pet::kitty_supported());
         if layout.users.is_empty() {
             self.show_tip(self.locale.tr(
-                "no user prompts yet — ⌕ finds them once you send one",
-                "还没有用户输入 —— 发送后 ⌕ 即可跳转",
+                "no user prompts yet — ↥ finds them once you send one",
+                "还没有用户输入 —— 发送后 ↥ 即可跳转",
             ));
             return;
         }
@@ -4810,8 +4830,8 @@ impl App {
         self.prompt_flash = Some((target.cell, Instant::now() + PROMPT_FLASH_TTL));
         self.needs_redraw = true;
         self.show_tip(self.locale.trf(
-            "⌕ user prompt {k}/{n} · newest first",
-            "⌕ 用户输入 {k}/{n} · 从最新往前",
+            "↥ user prompt {k}/{n} · newest first",
+            "↥ 用户输入 {k}/{n} · 从最新往前",
             &[from_newest.to_string(), layout.users.len().to_string()],
         ));
     }

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -133,10 +133,12 @@ pub enum CtlEvent {
         efforts: Vec<String>,
         default: Option<String>,
     },
-    /// A command failed for one specific session (prompt, steer, config
-    /// select, …). The UI routes the notice into that session's own
-    /// transcript — parked sessions no longer spill their errors onto the
-    /// viewed tab.
+    /// A failed session operation that does not finish the active prompt.
+    SessionOpFailed {
+        session_id: String,
+        message: String,
+    },
+    /// A failed prompt: settle this session's delivery state and report the error.
     SessionError {
         session_id: String,
         message: String,

--- a/src/markdown.rs
+++ b/src/markdown.rs
@@ -25,7 +25,8 @@
 use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
 use tui_markdown::{AlertKind, ImageFallback, Options, StyleSheet};
-use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
+use unicode_segmentation::UnicodeSegmentation;
+use unicode_width::UnicodeWidthStr;
 
 use crate::theme::{
     Theme, DEEPSEEK_200, DEEPSEEK_300, DEEPSEEK_400, DEEPSEEK_450, DEEPSEEK_500, DEEPSEEK_600,
@@ -42,6 +43,8 @@ pub fn render(text: &str, theme: &Theme, width: usize) -> Vec<Line<'static>> {
     let mut out: Vec<Line<'static>> = Vec::new();
     let mut in_code = false;
     let mut table: Option<TableBuffer> = None;
+    let mut code_prefix: Vec<Seg> = Vec::new();
+    let mut code_blocks = None;
     for line in parsed.lines {
         // Flatten the line-level base style (blockquote, code block, …) into
         // each span so wrapping can move spans freely without losing it.
@@ -56,60 +59,43 @@ pub fn render(text: &str, theme: &Theme, width: usize) -> Vec<Line<'static>> {
             })
             .collect();
 
-        // Code blocks become framed boxes: fence delimiter lines turn into
-        // the top/bottom edges (the top one carries the language label),
-        // content rows get `│` side borders and a padded panel background.
-        // Content hard-wraps without collapsing whitespace so indentation and
-        // ASCII art survive; empty lines inside a block still carry the code
-        // line style, so they join the box instead of punching a hole in it.
-        // Checked before the rule/table heuristics — a fenced `---` or a line
-        // starting with a box-drawing char is code, not a rule or table.
-        let is_code = if segs.is_empty() {
-            line.style.bg == Some(theme.panel)
-        } else {
-            segs.iter().all(|s| s.style.bg == Some(theme.panel))
-        };
-        if is_code {
+        // Fence sentinels are structural spans, even when a quote prefix
+        // precedes them. Track that prefix separately from code content;
+        // colors alone cannot distinguish nested blocks from inline code.
+        if let Some(fence) = segs.iter().position(|s| s.text.starts_with(CODE_FENCE_SENTINEL)) {
             flush_table(&mut table, &mut out, theme, width);
-            let text: String = segs.iter().map(|s| s.text.as_str()).collect();
-            // Delimiters are sentinel-prefixed (see `code_block_fence`);
-            // literal ```` ``` ```` content lines — including inside longer
-            // fences — never toggle the frame anymore.
-            if !segs.is_empty() && text.starts_with(CODE_FENCE_SENTINEL) {
-                if in_code {
-                    out.push(code_frame_bottom(width, theme));
-                    in_code = false;
-                } else {
-                    out.push(code_frame_top(
-                        text.strip_prefix(CODE_FENCE_SENTINEL)
-                            .unwrap_or("")
-                            .trim(),
-                        width,
-                        theme,
-                    ));
-                    in_code = true;
-                }
-                continue;
-            }
             if in_code {
-                let inner = width.saturating_sub(4).max(1);
-                let rows = if segs.is_empty() {
-                    vec![Line::default()]
-                } else {
-                    wrap_pre(segs, inner)
-                };
-                for row in rows {
-                    out.push(code_frame_row(row, inner, theme));
-                }
+                let frame_width = width - segments_width(&code_prefix);
+                out.push(with_prefix(&code_prefix, code_frame_bottom(frame_width, theme)));
+                in_code = false;
             } else {
-                // A code-styled line outside any fence (e.g. a paragraph that
-                // is one inline-code span): preformatted, but no frame.
-                if segs.is_empty() {
-                    out.push(Line::default());
-                } else {
-                    out.extend(wrap_pre(segs, width));
+                let lang = segs[fence].text[CODE_FENCE_SENTINEL.len()..].trim();
+                code_prefix = fit_prefix(segs[..fence].to_vec(), width.saturating_sub(8), theme);
+                let frame_width = width - segments_width(&code_prefix);
+                out.push(with_prefix(&code_prefix, code_frame_top(lang, frame_width, theme)));
+                // tui-markdown joins separate Text events in quoted code.
+                // Preserve their exact newlines from the parser instead.
+                let content = code_blocks.get_or_insert_with(|| code_block_texts(text))
+                    .pop_front().unwrap_or_default();
+                let inner = frame_width - 4;
+                for raw in content.lines() {
+                    let mut rows = wrap_pre(vec![Seg {
+                        text: raw.to_string(), style: DeepSeekStyleSheet(*theme).code(),
+                    }], inner);
+                    if rows.is_empty() { rows.push(Line::default()); }
+                    for row in rows {
+                        out.push(with_prefix(&code_prefix, code_frame_row(row, inner, theme)));
+                    }
                 }
+                in_code = true;
             }
+            continue;
+        }
+        if in_code { continue; }
+        // A standalone inline-code paragraph remains preformatted.
+        if !segs.is_empty() && segs.iter().all(|s| s.style.bg == Some(theme.panel)) {
+            flush_table(&mut table, &mut out, theme, width);
+            out.extend(wrap_pre(segs, width));
             continue;
         }
         if segs.is_empty() {
@@ -163,7 +149,7 @@ pub fn render(text: &str, theme: &Theme, width: usize) -> Vec<Line<'static>> {
         // Task-list checkboxes render as status glyphs instead of literal
         // `[x]` / `[ ]` markers, so lists read as rendered UI rather than
         // raw markdown source.
-        let prefix = task_list_glyphs(prefix, theme);
+        let prefix = fit_prefix(task_list_glyphs(prefix, theme), width.saturating_sub(4), theme);
         let body = two_tone(body, theme);
         let indent = prefix_width(&prefix);
         let mut wrapped = wrap_segments(body, width.saturating_sub(indent).max(4));
@@ -305,6 +291,56 @@ struct Seg {
     style: Style,
 }
 
+/// Match tui-markdown's parser extensions so code-block order agrees even
+/// inside footnotes, metadata, alerts, lists, and incomplete streamed fences.
+fn code_block_texts(text: &str) -> std::collections::VecDeque<String> {
+    use pulldown_cmark::{Event, Options as ParseOptions, Parser, Tag, TagEnd};
+    let options = ParseOptions::ENABLE_STRIKETHROUGH | ParseOptions::ENABLE_TASKLISTS
+        | ParseOptions::ENABLE_HEADING_ATTRIBUTES | ParseOptions::ENABLE_YAML_STYLE_METADATA_BLOCKS
+        | ParseOptions::ENABLE_SUPERSCRIPT | ParseOptions::ENABLE_SUBSCRIPT
+        | ParseOptions::ENABLE_MATH | ParseOptions::ENABLE_FOOTNOTES
+        | ParseOptions::ENABLE_DEFINITION_LIST | ParseOptions::ENABLE_GFM | ParseOptions::ENABLE_TABLES;
+    let mut blocks = std::collections::VecDeque::new();
+    let mut code = None;
+    for event in Parser::new_ext(text, options) {
+        match event {
+            Event::Start(Tag::CodeBlock(_)) => code = Some(String::new()),
+            Event::Text(text) => if let Some(code) = &mut code { code.push_str(&text); },
+            Event::End(TagEnd::CodeBlock) => if let Some(code) = code.take() { blocks.push_back(code); },
+            _ => {}
+        }
+    }
+    blocks
+}
+
+fn segments_width(segs: &[Seg]) -> usize {
+    segs.iter().map(|s| s.text.width()).sum()
+}
+
+fn with_prefix(prefix: &[Seg], mut line: Line<'static>) -> Line<'static> {
+    let mut spans: Vec<_> = prefix.iter().map(|s| Span::styled(s.text.clone(), s.style)).collect();
+    spans.append(&mut line.spans);
+    Line::from(spans)
+}
+
+/// Compress excessive nesting before clipping a marker. Always leave room
+/// for the body so a narrow view cannot place all content off screen.
+fn fit_prefix(mut prefix: Vec<Seg>, budget: usize, theme: &Theme) -> Vec<Seg> {
+    if budget == 0 { return Vec::new(); }
+    let mut excess = segments_width(&prefix).saturating_sub(budget);
+    for seg in &mut prefix {
+        let leading = seg.text.len() - seg.text.trim_start_matches(' ').len();
+        let only_spaces = leading == seg.text.len();
+        let remove = excess.min(leading);
+        seg.text.drain(..remove);
+        excess -= remove;
+        if !only_spaces || excess == 0 { break; }
+    }
+    truncate_line(prefix, budget, theme).spans.into_iter().map(|s| Seg {
+        text: s.content.into_owned(), style: s.style,
+    }).collect()
+}
+
 /// A lone `---` line with no styling is a horizontal rule (metadata-block
 /// delimiters carry the metadata style, so they are excluded).
 fn is_plain_rule(segs: &[Seg]) -> bool {
@@ -429,7 +465,9 @@ fn render_table(buf: TableBuffer, theme: &Theme, width: usize) -> Vec<Line<'stat
     // (cols+1) border columns plus the fixed one-space padding on both
     // sides of every cell.
     let overhead = 3 * cols + 1;
-    if overhead + natural.iter().sum::<usize>() <= avail {
+    // If even one content column per cell cannot fit, retain the clipped
+    // fallback rather than drawing a frame wider than the viewport.
+    if overhead + cols > avail || overhead + natural.iter().sum::<usize>() <= avail {
         return paint_fit(&buf, theme, width);
     }
 
@@ -678,7 +716,8 @@ fn paint_fit(buf: &TableBuffer, theme: &Theme, width: usize) -> Vec<Line<'static
     let mut out = Vec::new();
     let mut prev_row = false;
     for line in &buf.lines {
-        let row = truncate_line(two_tone(line.segs.clone(), theme), width, theme);
+        let available = width.saturating_sub(line.prefix.iter().map(Span::width).sum::<usize>());
+        let row = truncate_line(two_tone(line.segs.clone(), theme), available, theme);
         let is_row = row.spans.first().and_then(|s| s.content.chars().next()) == Some('│');
         if is_row && prev_row {
             let sep = table_row_separator(&row, theme);
@@ -698,11 +737,11 @@ fn table_row_separator(row: &Line, theme: &Theme) -> Line<'static> {
     let mut bars: Vec<usize> = Vec::new();
     let mut w = 0usize;
     for s in &row.spans {
-        for c in s.content.chars() {
-            if c == '│' {
+        for c in s.content.graphemes(true) {
+            if c == "│" {
                 bars.push(w);
             }
-            w += UnicodeWidthChar::width(c).unwrap_or(0);
+            w += UnicodeWidthStr::width(c);
         }
     }
     let mut sep = String::with_capacity(w);
@@ -899,13 +938,13 @@ fn code_frame_top(lang: &str, width: usize, theme: &Theme) -> Line<'static> {
         let max = width.saturating_sub(8);
         let mut cut = 0usize;
         let mut used = 0usize;
-        for c in lang.chars() {
-            let cw = UnicodeWidthChar::width(c).unwrap_or(0);
+        for c in lang.graphemes(true) {
+            let cw = UnicodeWidthStr::width(c);
             if used + cw > max {
                 break;
             }
             used += cw;
-            cut += c.len_utf8();
+            cut += c.len();
         }
         format!("─ {} ", &lang[..cut])
     };
@@ -956,8 +995,8 @@ fn wrap_pre(segs: Vec<Seg>, width: usize) -> Vec<Line<'static>> {
     let mut style = segs.first().map(|s| s.style).unwrap_or_default();
     let mut w = 0usize;
     for seg in segs {
-        for c in seg.text.chars() {
-            let cw = UnicodeWidthChar::width(c).unwrap_or(0);
+        for c in seg.text.graphemes(true) {
+            let cw = UnicodeWidthStr::width(c);
             if w + cw > width && w > 0 {
                 if !buf.is_empty() {
                     spans.push(Span::styled(std::mem::take(&mut buf), style));
@@ -974,7 +1013,7 @@ fn wrap_pre(segs: Vec<Seg>, width: usize) -> Vec<Line<'static>> {
                 }
                 style = seg.style;
             }
-            buf.push(c);
+            buf.push_str(c);
             w += cw;
         }
     }
@@ -1011,20 +1050,21 @@ fn collapse_autolinks(mut segs: Vec<Seg>) -> Vec<Seg> {
 /// Truncate a line to `width` columns, appending an ellipsis when content was
 /// dropped. Used for table lines, where wrapping would break the box.
 fn truncate_line(segs: Vec<Seg>, width: usize, theme: &Theme) -> Line<'static> {
-    let budget = width.saturating_sub(1);
+    let fits = segments_width(&segs) <= width;
+    let budget = if fits { width } else { width.saturating_sub(1) };
     let mut spans: Vec<Span<'static>> = Vec::new();
     let mut w = 0usize;
     let mut stopped = false;
     for seg in segs {
         let mut buf = String::new();
-        for c in seg.text.chars() {
-            let cw = UnicodeWidthChar::width(c).unwrap_or(0);
+        for c in seg.text.graphemes(true) {
+            let cw = UnicodeWidthStr::width(c);
             if w + cw > budget {
                 stopped = true;
                 break;
             }
             w += cw;
-            buf.push(c);
+            buf.push_str(c);
         }
         if !buf.is_empty() {
             spans.push(Span::styled(buf, seg.style));
@@ -1200,8 +1240,8 @@ fn chunk_str(s: &str, width: usize) -> Vec<&str> {
     let mut out = Vec::new();
     let mut start = 0usize;
     let mut w = 0usize;
-    for (i, ch) in s.char_indices() {
-        let cw = UnicodeWidthChar::width(ch).unwrap_or(0);
+    for (i, ch) in s.grapheme_indices(true) {
+        let cw = UnicodeWidthStr::width(ch);
         if w + cw > width && w > 0 {
             out.push(&s[start..i]);
             start = i;

--- a/src/transcript.rs
+++ b/src/transcript.rs
@@ -360,7 +360,7 @@ pub struct ImageShot {
 /// One user prompt in a rendered transcript: the transcript cell index and
 /// the half-open line span `[line, end)` its bubble occupies (the leading
 /// blank separator row is not counted; `end` covers wrapped text lines and,
-/// for image prompts, the thumbnail rows). The ⌕ composer button walks
+/// for image prompts, the thumbnail rows). The ↥ composer button walks
 /// these from the newest one back and flashes the jumped span (issue #103).
 #[derive(Clone, Copy, Debug)]
 pub struct UserPromptLine {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -174,7 +174,7 @@ pub fn draw(f: &mut Frame, app: &mut App) {
     app.caret_cell = None;
     // The mouse-only expand button's frame rect is rebuilt by
     // `layout_expand_btn`; clear it first so a child view (or a frame where
-    // the card vanished) cannot keep a stale hit-test rect alive. The ⌕
+    // the card vanished) cannot keep a stale hit-test rect alive. The ↥
     // prompt-jump button rect rides the same layout pass.
     app.expand_btn = None;
     app.prompt_jump_btn = None;
@@ -1625,7 +1625,7 @@ fn draw_composer(f: &mut Frame, app: &mut App, area: Rect, pet_pad: u16, navigat
     );
     // The mouse-only composer buttons sit on the card's top row, outside
     // the well; painted last so no text render can paint over them (issue
-    // #92 / ⌕ of issue #103).
+    // #92 / ↥ of issue #103).
     paint_composer_buttons(f, app);
 }
 
@@ -2320,7 +2320,7 @@ fn draw_chat(f: &mut Frame, app: &mut App, area: Rect) {
         .map(|l| l.spans.iter().map(|s| s.content.as_ref()).collect())
         .collect();
     app.chat_view.owners = owners[start..end].to_vec();
-    // The ⌕ jump flash (issue #103): resolve the flashing transcript cell
+    // The ↥ jump flash (issue #103): resolve the flashing transcript cell
     // to its current line span every frame — streaming can move the prompt
     // — and drop it once the 5 s window expired.
     app.prompt_flash_lines = app
@@ -2358,7 +2358,7 @@ fn draw_chat(f: &mut Frame, app: &mut App, area: Rect) {
     // window — no per-frame `to_vec` of the viewport on top of the
     // snapshot above.
     f.render_widget(LinesWindow { lines: &lines[start..end] }, inner);
-    // The transient ⌕ jump wash paints under an active copy-selection so
+    // The transient ↥ jump wash paints under an active copy-selection so
     // the user's own highlight always wins.
     draw_prompt_flash(f, app, inner, start);
     draw_selection_overlay(f, app, inner, start);
@@ -2388,7 +2388,7 @@ impl Widget for LinesWindow<'_> {
     }
 }
 
-/// The transient `⌕` jump highlight (issue #103): right after a jump the
+/// The transient `↥` jump highlight (issue #103): right after a jump the
 /// jumped prompt's rows are highlighted exactly like a picker's selected
 /// row — chip background wash plus the text brightened to the brand tone —
 /// for ~5 seconds, then the ordinary bubble look returns (the expiry lives
@@ -2608,7 +2608,7 @@ fn draw_composer_box(
     let theme = app.theme;
     let has_input_dock = slot_has_nodes(app, "conversation.input.dock");
     // Leave the cap row's top-right corner to the mouse-only composer
-    // buttons: the workspace title ends four cells early, so the `⌕`
+    // buttons: the workspace title ends four cells early, so the `↥`
     // prompt-jump glyph (issue #103) and the `⛶` expand glyph (issue #92)
     // — with a space between them — never cover title text.
     let mut workspace = workspace_cap_title(app, area.width as usize);
@@ -2701,7 +2701,7 @@ fn draw_composer_box(
     draw_input(f, app, input);
     // The mouse-only composer buttons sit on the card's top border (the cap
     // row), outside the well — a full draft never hides them. Painted last
-    // so nothing can paint over them (issue #92 / ⌕ of issue #103).
+    // so nothing can paint over them (issue #92 / ↥ of issue #103).
     paint_composer_buttons(f, app);
 }
 
@@ -2811,22 +2811,22 @@ fn paint_caret(f: &mut Frame, x: u16, y: u16) {
 }
 
 /// Mouse-only composer buttons on the cap row's top-right (issue #92 / the
-/// ⌕ prompt jump of issue #103): the `⛶` expand/collapse glyph and, one
-/// cell left of it, the `⌕` user-prompt jump glyph — both on the card's top
+/// ↥ prompt jump of issue #103): the `⛶` expand/collapse glyph and, one
+/// cell left of it, the `↥` user-prompt jump glyph — both on the card's top
 /// border, outside the text well. Always visible; hovering (no key binding)
 /// highlights them; clicking pins/restores the well height or walks the
 /// user prompts.
 const EXPAND_BTN_W: u16 = 3;
 const EXPAND_BTN_H: u16 = 1;
 const EXPAND_BTN_MARGIN: u16 = 1;
-/// The ⌕ prompt-jump button is 2 cells wide (glyph + one margin), tucked
+/// The ↥ prompt-jump button is 2 cells wide (glyph + one margin), tucked
 /// directly left of the expand button's hit rect.
 const JUMP_BTN_W: u16 = 2;
 
 /// Record the expand button's screen rect for hit-testing. `cap` is the
 /// composer's top row: the rounded card's cap line (boxed layout) or the
 /// well's first row (short-terminal fallback). Runs every frame, so the
-/// pointer can discover the glyph before hovering it. The ⌕ jump button
+/// pointer can discover the glyph before hovering it. The ↥ jump button
 /// rect (issue #103) is recorded in the same pass, one cell left of the
 /// expand glyph.
 fn layout_expand_btn(app: &mut App, cap: Rect) {
@@ -2849,7 +2849,7 @@ fn layout_expand_btn(app: &mut App, cap: Rect) {
     };
 }
 
-/// Paint the composer cap-row glyphs — `⌕` (prompt jump, issue #103) left
+/// Paint the composer cap-row glyphs — `↥` (prompt jump, issue #103) left
 /// of `⛶` (expand/collapse, issue #92). Idle: quiet caption tone. Hovered:
 /// the glyph brightens to the strongest foreground — no BOLD, which
 /// terminals synthesize by widening the glyph and clip at the cell edge
@@ -2870,7 +2870,7 @@ fn paint_composer_buttons(f: &mut Frame, app: &mut App) {
             b.set_string(
                 rect.x.saturating_add(rect.width).saturating_sub(1),
                 rect.y,
-                "⌕",
+                "↥",
                 Style::default().fg(tone),
             );
         }

--- a/tests/unit/acp__control_tests.rs
+++ b/tests/unit/acp__control_tests.rs
@@ -1,0 +1,265 @@
+use super::*;
+use agent_client_protocol::schema::v1::{
+    AgentCapabilities, InitializeRequest, InitializeResponse, NewSessionResponse, PromptResponse,
+    SetSessionConfigOptionResponse, StopReason,
+};
+
+async fn wait_event(rx: &Receiver<AppEvent>, predicate: impl Fn(&AppEvent) -> bool) {
+    tokio::time::timeout(Duration::from_secs(3), async {
+        loop {
+            while let Ok(event) = rx.try_recv() {
+                if predicate(&event) {
+                    return;
+                }
+            }
+            tokio::time::sleep(Duration::from_millis(1)).await;
+        }
+    })
+    .await
+    .expect("expected scheduler event");
+}
+
+/// Stall one control request while another session prompts, finishes, and
+/// cancels. For config, also check same-session prompts cannot overtake it.
+async fn check_slow_control(config: bool) {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    let count = Arc::new(AtomicUsize::new(0));
+    let (blocked_tx, mut blocked_rx) = tokio::sync::mpsc::unbounded_channel();
+    let (release_tx, release_rx) = tokio::sync::watch::channel(false);
+    let (cancel_tx, mut cancel_rx) = tokio::sync::mpsc::unbounded_channel();
+    let (prompt_tx, mut prompt_rx) = tokio::sync::mpsc::unbounded_channel();
+    let (prompt_release_tx, prompt_release_rx) = tokio::sync::watch::channel(false);
+    let agent = Agent
+        .builder()
+        .on_receive_request(
+            async move |req: InitializeRequest, responder, _cx| {
+                responder.respond(
+                    InitializeResponse::new(req.protocol_version)
+                        .agent_capabilities(AgentCapabilities::new()),
+                )
+            },
+            on_receive_request!(),
+        )
+        .on_receive_request(
+            {
+                let blocked = blocked_tx.clone();
+                let release = release_rx.clone();
+                async move |_req: NewSessionRequest, responder, cx| {
+                    let index = count.fetch_add(1, Ordering::SeqCst) + 1;
+                    let mut release = release.clone();
+                    if index > 2 {
+                        let _ = blocked.send(());
+                        cx.spawn(async move {
+                            release.wait_for(|ready| *ready).await.unwrap();
+                            responder.respond(NewSessionResponse::new(SessionId::new(format!(
+                                "s{index}"
+                            ))))
+                        })?;
+                        Ok(())
+                    } else {
+                        responder
+                            .respond(NewSessionResponse::new(SessionId::new(format!("s{index}"))))
+                    }
+                }
+            },
+            on_receive_request!(),
+        )
+        .on_receive_request(
+            {
+                let blocked = blocked_tx;
+                let release = release_rx;
+                async move |_req: SetSessionConfigOptionRequest, responder, cx| {
+                    let _ = blocked.send(());
+                    let mut release = release.clone();
+                    cx.spawn(async move {
+                        release.wait_for(|ready| *ready).await.unwrap();
+                        responder.respond(SetSessionConfigOptionResponse::new(vec![]))
+                    })?;
+                    Ok(())
+                }
+            },
+            on_receive_request!(),
+        )
+        .on_receive_request(
+            async move |req: PromptRequest, responder, cx| {
+                let _ = prompt_tx.send(req.session_id.to_string());
+                let mut release = prompt_release_rx.clone();
+                cx.spawn(async move {
+                    release.wait_for(|ready| *ready).await.unwrap();
+                    responder.respond(PromptResponse::new(StopReason::EndTurn))
+                })?;
+                Ok(())
+            },
+            on_receive_request!(),
+        )
+        .on_receive_notification(
+            async move |req: CancelNotification, _cx| {
+                let _ = cancel_tx.send(req.session_id.to_string());
+                Ok(())
+            },
+            on_receive_notification!(),
+        );
+    let cfg = RuntimeConfig {
+        bin: "demo".into(),
+        cordis: "demo".into(),
+        workspace: "/tmp".into(),
+        session_root: "/tmp".into(),
+        provider: "test".into(),
+        model: "test".into(),
+        max_tokens: None,
+        base_url: None,
+        api_key: None,
+    };
+    let (bus, events) = std::sync::mpsc::channel();
+    let (cmds, commands) = std::sync::mpsc::channel();
+    let task = tokio::spawn(connect(agent, cfg, bus, commands));
+    wait_event(&events, |event| matches!(event, AppEvent::Ctl(CtlEvent::SessionBound { session_id, .. }) if session_id == "s1")).await;
+    cmds.send(Cmd::NewSession).unwrap();
+    wait_event(&events, |event| matches!(event, AppEvent::Ctl(CtlEvent::SessionBound { session_id, .. }) if session_id == "s2")).await;
+    cmds.send(if config {
+        Cmd::SetConfigOption {
+            session_id: "s2".into(),
+            config_id: "model".into(),
+            value: "next".into(),
+        }
+    } else {
+        Cmd::NewSession
+    })
+    .unwrap();
+    tokio::time::timeout(Duration::from_secs(3), blocked_rx.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    if config {
+        cmds.send(Cmd::Prompt {
+            session_id: "s2".into(),
+            text: "after config".into(),
+        })
+        .unwrap();
+    }
+    cmds.send(Cmd::Prompt {
+        session_id: "s1".into(),
+        text: "other session".into(),
+    })
+    .unwrap();
+    let started = tokio::time::timeout(Duration::from_secs(3), prompt_rx.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        started, "s1",
+        "other sessions progress, same-session prompts wait for config"
+    );
+    cmds.send(Cmd::Interrupt {
+        session_id: "s1".into(),
+    })
+    .unwrap();
+    assert_eq!(
+        tokio::time::timeout(Duration::from_secs(3), cancel_rx.recv())
+            .await
+            .unwrap()
+            .unwrap(),
+        "s1"
+    );
+    prompt_release_tx.send(true).unwrap();
+    wait_event(&events, |event| matches!(event, AppEvent::Ui(crate::events::UiEvent::TurnEnd { session, .. }) if session == "s1")).await;
+    if config {
+        assert!(
+            prompt_rx.try_recv().is_err(),
+            "s2 still waits for its config response"
+        );
+        release_tx.send(true).unwrap();
+        assert_eq!(
+            tokio::time::timeout(Duration::from_secs(3), prompt_rx.recv())
+                .await
+                .unwrap()
+                .unwrap(),
+            "s2"
+        );
+    }
+    // Shutdown must also work with the setup request still stalled.
+    cmds.send(Cmd::Shutdown).unwrap();
+    tokio::time::timeout(Duration::from_secs(3), task)
+        .await
+        .unwrap()
+        .unwrap()
+        .unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn slow_session_creation_does_not_block_other_session_prompts_or_cancel() {
+    check_slow_control(false).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn slow_config_only_blocks_following_prompts_on_its_own_session() {
+    check_slow_control(true).await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn prompts_and_steers_outlive_the_control_request_deadline() {
+    let (release, release_rx) = tokio::sync::watch::channel(false);
+    let (started, mut started_rx) = tokio::sync::mpsc::unbounded_channel();
+    let agent = Agent.builder().on_receive_request(
+        async move |_req: PromptRequest, responder, cx| {
+            let _ = started.send(());
+            let mut release_rx = release_rx.clone();
+            cx.spawn(async move {
+                release_rx.wait_for(|ready| *ready).await.unwrap();
+                responder.respond(PromptResponse::new(StopReason::EndTurn))
+            })?;
+            Ok(())
+        },
+        on_receive_request!(),
+    );
+    Client
+        .builder()
+        .connect_with(agent, move |cx: ConnectionTo<Agent>| async move {
+            let (bus, _) = std::sync::mpsc::channel();
+            let (done, mut done_rx) = tokio::sync::mpsc::unbounded_channel();
+            let (steer_done, mut steer_rx) = tokio::sync::mpsc::unbounded_channel();
+            let task = spawn_session_prompt(
+                cx.clone(),
+                bus,
+                SessionId::new("s"),
+                vec!["work".into()],
+                ParkedPromptKind::Text("work".into()),
+                1,
+                done,
+            );
+            spawn_steer_prompt(
+                cx,
+                SessionId::new("s"),
+                vec!["follow up".into()],
+                2,
+                steer_done,
+            );
+            started_rx.recv().await.unwrap();
+            started_rx.recv().await.unwrap();
+            tokio::time::advance(REQUEST_DEADLINE + Duration::from_secs(1)).await;
+            for _ in 0..5 {
+                tokio::task::yield_now().await;
+            }
+            assert!(
+                matches!(
+                    done_rx.try_recv(),
+                    Err(tokio::sync::mpsc::error::TryRecvError::Empty)
+                ),
+                "healthy prompt timed out"
+            );
+            assert!(
+                matches!(
+                    steer_rx.try_recv(),
+                    Err(tokio::sync::mpsc::error::TryRecvError::Empty)
+                ),
+                "healthy steer timed out"
+            );
+            release.send(true).unwrap();
+            assert!(done_rx.recv().await.unwrap().result.is_ok());
+            assert!(steer_rx.recv().await.unwrap().result.is_ok());
+            task.await.unwrap();
+            Ok(())
+        })
+        .await
+        .unwrap();
+}

--- a/tests/unit/app__mode_tests.rs
+++ b/tests/unit/app__mode_tests.rs
@@ -1317,7 +1317,7 @@ fn seed_prompt_history(app: &mut App, n: usize) -> Vec<usize> {
         .collect()
 }
 
-/// The first line the `⌕` jump anchors for `cell`, mirroring
+/// The first line the `↥` jump anchors for `cell`, mirroring
 /// `App::jump_to_user_prompt` (layout at the recorded chat width).
 fn prompt_jump_anchor(app: &mut App, cell: usize) -> usize {
     let area = app.chat_view.area;
@@ -1338,9 +1338,9 @@ fn prompt_jump_anchor(app: &mut App, cell: usize) -> usize {
     line.min(layout.lines.len().saturating_sub(area.height as usize))
 }
 
-/// Left-click the `⌕` button recorded by the last frame.
+/// Left-click the `↥` button recorded by the last frame.
 fn click_prompt_jump(app: &mut App, ctl: &Controller) {
-    let jump = app.prompt_jump_btn.expect("⌕ button rect recorded");
+    let jump = app.prompt_jump_btn.expect("↥ button rect recorded");
     app.handle_mouse(
         crossterm::event::MouseEvent {
             kind: crossterm::event::MouseEventKind::Down(
@@ -1410,7 +1410,7 @@ fn prompt_jump_without_user_prompts_tips_instead_of_jumping() {
     click_prompt_jump(&mut app, &ctl);
 
     assert!(app.prompt_jump_cell.is_none());
-    assert!(app.tip.is_some(), "no prompts → a tip explains ⌕");
+    assert!(app.tip.is_some(), "no prompts → a tip explains ↥");
     assert_eq!(app.chat_view.top, 0, "no jump happened");
 }
 

--- a/tests/unit/app__session_tabs_tests.rs
+++ b/tests/unit/app__session_tabs_tests.rs
@@ -1466,3 +1466,48 @@ fn strip_offset_snaps_to_the_head_once_everything_fits_again() {
     assert_eq!(strip_window(&mut app), vec![0, 1]);
     assert_eq!(app.tab_strip_offset, 0, "no scroll state when nothing overflows");
 }
+
+#[test]
+fn queue_edit_survives_tab_switch_and_keeps_background_queue_paused() {
+    let (mut app, _demo, _) = test_app();
+    let (ctl, commands) = crate::controller::tests::test_controller();
+    app.state = RunState::Running;
+    app.prompt_queue.push_back(ClientQueuedPrompt {
+        id: 991,
+        blocks: vec![StagedBlock::Text("original".into())],
+    });
+    app.begin_queue_edit_at(0);
+    app.input.set("edited".into());
+    app.open_new_session("second".into(), true);
+    app.handle(AppEvent::Ui(crate::events::UiEvent::SessionStatus {
+        session: "dsh-test".into(), running: false,
+    }), &ctl);
+    assert!(!commands.try_iter().any(|cmd| matches!(cmd, Cmd::Prompt { .. })),
+        "the background queue stays paused until the edit is saved or cancelled");
+    app.switch_view_to_tab(0, &ctl);
+    assert_eq!(app.input.buf(), "edited");
+    assert!(app.queue_editing());
+    app.save_queue_edit(&ctl);
+    let prompts: Vec<_> = commands.try_iter().filter_map(|cmd| match cmd {
+        Cmd::Prompt { session_id, text } => Some((session_id, text)),
+        _ => None,
+    }).collect();
+    assert_eq!(prompts, vec![("dsh-test".into(), "edited".into())]);
+}
+
+#[test]
+fn operation_failure_does_not_finish_live_or_parked_prompts() {
+    let (mut app, ctl, _) = test_app();
+    app.state = RunState::Running;
+    app.open_new_session("second".into(), true);
+    app.state = RunState::Running;
+    for session in ["dsh-test", "second"] {
+        app.handle(AppEvent::Ctl(CtlEvent::SessionOpFailed {
+            session_id: session.into(), message: "unsupported config option".into(),
+        }), &ctl);
+    }
+    assert_eq!(app.state, RunState::Running);
+    assert!(app.parked[0].running);
+    assert!(transcript_text(&mut app.parked[0].transcript).contains("unsupported config option"));
+    assert!(transcript_text(&mut app.transcript).contains("unsupported config option"));
+}

--- a/tests/unit/markdown__tests.rs
+++ b/tests/unit/markdown__tests.rs
@@ -580,3 +580,70 @@ fn four_backtick_fences_survive_nested_backtick_content() {
     let bottom = texts.iter().position(|t| t.starts_with('└')).unwrap();
     assert!(top < bottom);
 }
+
+#[test]
+fn quoted_code_preserves_frames_indentation_and_literal_markers() {
+    let md = "> > ```python\n> > if yes:\n> >     run()\n> > >\n> > \n> > ```";
+    let lines = render_dark(md, 24);
+    let text = plain(&lines);
+    assert!(!text.contains('\0'), "internal fence sentinel escaped: {text:?}");
+    assert!(text.contains("┌─ python"), "{text}");
+    assert!(text.contains("│     run()"), "indentation survives: {text}");
+    assert!(text.contains("│ >"), "literal code marker survives: {text}");
+    assert!(text.contains('└'));
+    for line in &lines { assert!(line.width() <= 24, "{line:?}"); }
+}
+
+#[test]
+fn exact_width_table_keeps_its_right_border() {
+    let md = "| a | b |\n|---|---|\n| c | d |";
+    let lines = render_dark(md, 9);
+    assert!(!plain(&lines).contains('…'));
+    assert!(plain(&lines).contains("│ c │ d │"));
+    assert!(render_dark(md, 8).iter().any(|line| plain(std::slice::from_ref(line)).contains('…')));
+}
+
+#[test]
+fn table_followed_by_quoted_code_keeps_order_and_frames() {
+    let md = "| title |\n|---|\n| table text wraps here |\n\n> ```rust\n> let x = 1;\n> ```";
+    let lines = render_dark(md, 14);
+    let text = plain(&lines);
+    assert!(text.find("table").unwrap() < text.find("rust").unwrap(), "{text}");
+    assert_eq!(text.matches('┌').count(), 2, "{text}");
+    assert_eq!(text.matches('└').count(), 2, "{text}");
+    assert!(!text.contains('\0'));
+    assert!(lines.iter().all(|line| line.width() <= 14), "{text}");
+}
+
+#[test]
+fn grapheme_clusters_survive_code_prose_and_table_wrapping() {
+    let family = "👨‍👩‍👧‍👦";
+    let flag = "🇨🇳";
+    for md in [format!("```\n12345{family}{flag}end\n```"),
+        format!("abcdefghijkl{family}{flag}abcdefghijkl"),
+        format!("| x |\n|---|\n| 123{family}{flag}end |")]
+    {
+        let lines = render_dark(&md, 12);
+        for line in &lines {
+            let text = plain(std::slice::from_ref(line));
+            if text.contains('👨') || text.contains('👩') || text.contains('👧') || text.contains('👦') {
+                assert!(text.contains(family), "split grapheme: {text:?}");
+            }
+            if text.contains('🇨') || text.contains('🇳') {
+                assert!(text.contains(flag), "split flag: {text:?}");
+            }
+            assert!(line.width() <= 12, "{line:?}");
+        }
+    }
+}
+
+#[test]
+fn deeply_nested_lists_keep_the_body_inside_the_viewport() {
+    let md = "- a\n  - b\n    - c\n      - longwordlongword";
+    for width in [8, 10, 12, 16, 40] {
+        let lines = render_dark(md, width);
+        for line in &lines { assert!(line.width() <= width, "width={width}: {line:?}"); }
+        assert!(plain(&lines).contains('c'));
+        assert!(plain(&lines).contains("long"));
+    }
+}

--- a/tests/unit/ui__tests.rs
+++ b/tests/unit/ui__tests.rs
@@ -2070,7 +2070,7 @@ fn model_picker_marks_only_the_current_provider_model_pair() {
     );
 }
 
-/// The ⌕ jump flash (issue #103): for ~5 s after a jump the jumped
+/// The ↥ jump flash (issue #103): for ~5 s after a jump the jumped
 /// prompt's bubble rows are highlighted like a picker's selected row —
 /// chip background wash and the text in the brand tone; after the window
 /// the next tick clears it and the next frame restores the normal bubble.
@@ -3325,7 +3325,7 @@ fn expand_button_survives_a_full_draft() {
     assert_ne!(buf[(btn.x + 2, app.input_area.y)].symbol(), "⛶");
 }
 
-/// The ⌕ user-prompt jump button (issue #103) renders between the project
+/// The ↥ user-prompt jump button (issue #103) renders between the project
 /// path and the ⛶ expand glyph — spaces on both sides — and hovers the
 /// same way: quiet caption tone idle, brightest foreground on hover.
 #[test]
@@ -3343,17 +3343,17 @@ fn prompt_jump_button_sits_between_path_and_expand_and_hovers() {
     let expand = app.expand_btn.expect("expand rect");
     let jump = app.prompt_jump_btn.expect("jump rect");
 
-    // Geometry: ⌕ (space) ⛶ (space) ╮ — the jump glyph one cell left of
+    // Geometry: ↥ (space) ⛶ (space) ╮ — the jump glyph one cell left of
     // the expand glyph with a space in between, and a space before it.
     assert_eq!(jump.y, expand.y, "both buttons share the cap row");
     assert_eq!(jump.x + jump.width, expand.x, "jump rect tucked left of expand");
-    assert_eq!(buf[(jump.x + 1, jump.y)].symbol(), "⌕");
-    assert_eq!(buf[(expand.x - 2, expand.y)].symbol(), " ", "space before ⌕");
-    assert_eq!(buf[(expand.x, expand.y)].symbol(), " ", "space between ⌕ and ⛶");
+    assert_eq!(buf[(jump.x + 1, jump.y)].symbol(), "↥");
+    assert_eq!(buf[(expand.x - 2, expand.y)].symbol(), " ", "space before ↥");
+    assert_eq!(buf[(expand.x, expand.y)].symbol(), " ", "space between ↥ and ⛶");
     assert_eq!(buf[(expand.x + 1, expand.y)].symbol(), "⛶");
     assert_eq!(buf[(jump.x + 1, jump.y)].fg, theme.caption, "idle tone");
 
-    // Hover brightens the ⌕ glyph.
+    // Hover brightens the ↥ glyph.
     app.handle_mouse(mouse(MouseEventKind::Moved, jump.x + 1, jump.y), &ctl);
     assert!(app.hover_prompt_jump_btn);
     terminal.draw(|f| draw(f, &mut app)).expect("draw frame");
@@ -3361,7 +3361,7 @@ fn prompt_jump_button_sits_between_path_and_expand_and_hovers() {
     assert_eq!(
         buf[(jump.x + 1, jump.y)].fg,
         theme.fg,
-        "hover brightens the ⌕ glyph"
+        "hover brightens the ↥ glyph"
     );
     // Leaving restores the quiet glyph.
     app.handle_mouse(mouse(MouseEventKind::Moved, 5, 5), &ctl);


### PR DESCRIPTION
Switching session tabs while editing a queued prompt could lose the edit or send it in the background. Slow ACP control requests could also stall unrelated sessions, and configuration failures could incorrectly mark an active prompt idle. Quoted Markdown code blocks lost framing/newlines, while wrapping could split Unicode graphemes or clip content that should fit.

- Preserve queue selection/edit state per session and distinguish operation failures from prompt completion. Move slow ACP controls into ordered workers, keep setup binding order and per-session configuration order, and remove the overall 120-second deadline from prompts and Send Now requests.
- Preserve Plan/usage replay received before session/load completes and prevent concurrent Send Now responses from replacing the active turn's statistics.
- Preserve quoted code, grapheme clusters, exact-width table borders and deeply nested list content. Integrate the table soft-wrap changes from #108, retaining clipping when the minimum table frame cannot fit, and add coverage for tables followed by quoted code.
- Change the prompt-jump glyph to `↥`, including its English/Chinese hints, and document the changes and scheduler structure.

Validation:
- `RUSTFLAGS="-C link-arg=-fuse-ld=mold" CARGO_BUILD_JOBS=2 cargo test --locked`
- `cargo check --locked --tests`
- `npm test --prefix npm` (4 pretest checks and 239 suite tests)
- `DSH_TUI_ACP_ROOT="$PWD/npm/node_modules/@openma/deepseek-harness-acp" DSH_TUI_LOCAL_DEPS=1 npm run test:profile-install-matrix --prefix npm` (6 tests, using the installed ACP runtime dependency)
- `target/debug/martty --dump-frame 100x34`
- `git diff --check`
