### PR TITLE
feat(tui): default markdown body to a single tone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,15 @@ All notable changes to this project are documented here. The project follows
 
 ### Changed
 
+- Markdown body text is now single-tone by default: CJK and Latin/digit
+  runs share one foreground color (`fg`) instead of the previous always-on
+  CJK/Latin split. The two-tone look (Chinese on the muted body gray,
+  English brighter) remains available as a deliberately quiet preference —
+  no command or picker surface for now: set `markdownTone` to `"two"` in
+  the UI settings file (settings.json, next to `themeMode`) to opt in. The
+  choice applies everywhere markdown paints — assistant messages, tables,
+  plugin slot content, and overlay/plan descriptions.
+
 - Markdown tables wider than the chat width no longer truncate cells with
   an ellipsis. The transcript buffers each table block whole and re-lays
   it out: columns shrink proportionally (narrow columns keep their

--- a/src/app.rs
+++ b/src/app.rs
@@ -26,6 +26,7 @@ use crate::controller::Controller;
 use crate::events::parse_notification;
 use crate::input::{Action, VimMode};
 use crate::locale::{Locale, UiSettings};
+use crate::markdown::ToneMode;
 use crate::runtime::{legacy_settings_path, settings_path, RuntimeConfig};
 use crate::theme::Theme;
 use crate::transcript::{clamp_str, NoticeLevel, Transcript};
@@ -1234,6 +1235,10 @@ fn shell_output(bytes: Vec<u8>) -> String {
 pub struct App {
     pub theme: Theme,
     pub locale: Locale,
+    /// Markdown body-color scheme: single (default, one color for CJK and
+    /// Latin) or two-tone. A deliberately quiet preference — no command or
+    /// picker surface; set `markdownTone` in settings.json (`two`) to opt in.
+    pub tone_mode: ToneMode,
     pub palettes: Vec<crate::theme::PalettePack>,
     pub active_palette_id: String,
     /// Persisted UI Preset id. The Client compositor owns activation; Rust
@@ -1765,9 +1770,16 @@ impl App {
             .unwrap_or(crate::theme::Mode::Dark);
         let theme = palettes[0].theme(mode);
         let locale = settings.language;
+        // Persisted markdown body tone (`single` | `two`); absent → single.
+        let tone_mode = settings
+            .markdown_tone
+            .as_deref()
+            .and_then(ToneMode::parse)
+            .unwrap_or_default();
         let mut app = App {
             theme,
             locale,
+            tone_mode,
             palettes,
             active_palette_id: "default".into(),
             ui_preset: settings.ui_preset,
@@ -4785,9 +4797,13 @@ impl App {
         }
         let theme = self.theme;
         let spinner = self.spinner();
-        let layout = self
-            .transcript
-            .layout(&theme, area.width, spinner, crate::pet::kitty_supported());
+        let layout = self.transcript.layout(
+            &theme,
+            self.tone_mode,
+            area.width,
+            spinner,
+            crate::pet::kitty_supported(),
+        );
         if layout.users.is_empty() {
             self.show_tip(self.locale.tr(
                 "no user prompts yet — ↥ finds them once you send one",
@@ -5182,6 +5198,7 @@ impl App {
             .unwrap_or_else(|| serde_json::json!({}));
         current["language"] = serde_json::json!(self.locale);
         current["themeMode"] = serde_json::json!(self.theme.mode.as_str());
+        current["markdownTone"] = serde_json::json!(self.tone_mode.as_str());
         if let Ok(text) = serde_json::to_string_pretty(&current) {
             let _ = std::fs::write(path, text);
         }

--- a/src/locale.rs
+++ b/src/locale.rs
@@ -154,6 +154,10 @@ pub struct UiSettings {
     /// `tuiTheme` service.
     #[serde(rename = "themeMode")]
     pub theme_mode: Option<String>,
+    /// Persisted markdown body tone (`single` | `two`). Absent → the
+    /// builtin default (`single`: CJK and Latin share the main `fg`).
+    #[serde(rename = "markdownTone")]
+    pub markdown_tone: Option<String>,
 }
 
 impl Default for UiSettings {
@@ -162,6 +166,7 @@ impl Default for UiSettings {
             language: Locale::default(),
             ui_preset: default_ui_preset(),
             theme_mode: None,
+            markdown_tone: None,
         }
     }
 }

--- a/src/markdown.rs
+++ b/src/markdown.rs
@@ -4,8 +4,10 @@
 //! structure; this module maps its output onto the DeepSeek palette through a
 //! custom `StyleSheet`, then post-processes the rendered lines:
 //!
-//! - body runs are split into CJK vs Latin/digit runs so Chinese and English
-//!   take two different foreground colors (the transcript's two-tone body);
+//! - body runs follow the caller's [`ToneMode`]: the default single tone
+//!   paints CJK and Latin/digit runs alike with the main `fg`, while the
+//!   optional two-tone split gives Chinese a muted gray and English a
+//!   brighter foreground;
 //! - lines wrap to the chat width, keeping hanging indents under list markers
 //!   and blockquote prefixes;
 //! - `---` rules are redrawn as full-width `─` lines;
@@ -20,7 +22,9 @@
 //!   rows, so long cells stay readable instead of truncating with an ellipsis.
 //!
 //! Colors stay inside the DeepSeek palette: grayscale body text, brand-blue
-//! accents for links and headings, red still reserved for errors.
+//! accents for links and headings, red reserved for errors. The two-tone
+//! body pass is an opt-in [`ToneMode::Two`]; the default single tone
+//! renders every body run in the main `fg`.
 
 use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
@@ -33,8 +37,38 @@ use crate::theme::{
     DEEPSEEK_800, DEEPSEEK_900,
 };
 
+/// Body-color scheme for rendered markdown: whether CJK and Latin/digit
+/// runs take different foreground colors.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum ToneMode {
+    /// Whole body in one color — CJK and Latin/digits both use `fg`.
+    #[default]
+    Single,
+    /// Two-tone: CJK keeps the muted body gray, Latin/digits take `fg`.
+    Two,
+}
+
+impl ToneMode {
+    pub fn parse(value: &str) -> Option<Self> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "single" | "one" | "1" => Some(Self::Single),
+            "two" | "2" => Some(Self::Two),
+            _ => None,
+        }
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Single => "single",
+            Self::Two => "two",
+        }
+    }
+
+}
+
 /// Render markdown `text` to wrapped, styled lines for `width` columns.
-pub fn render(text: &str, theme: &Theme, width: usize) -> Vec<Line<'static>> {
+/// `tone` picks the body-color scheme (see [`ToneMode`]).
+pub fn render(text: &str, theme: &Theme, tone: ToneMode, width: usize) -> Vec<Line<'static>> {
     let width = width.max(8);
     let options =
         Options::new(DeepSeekStyleSheet(*theme)).image_fallback(ImageFallback::AltTextAndUrl);
@@ -63,7 +97,7 @@ pub fn render(text: &str, theme: &Theme, width: usize) -> Vec<Line<'static>> {
         // precedes them. Track that prefix separately from code content;
         // colors alone cannot distinguish nested blocks from inline code.
         if let Some(fence) = segs.iter().position(|s| s.text.starts_with(CODE_FENCE_SENTINEL)) {
-            flush_table(&mut table, &mut out, theme, width);
+            flush_table(&mut table, &mut out, theme, tone, width);
             if in_code {
                 let frame_width = width - segments_width(&code_prefix);
                 out.push(with_prefix(&code_prefix, code_frame_bottom(frame_width, theme)));
@@ -94,17 +128,17 @@ pub fn render(text: &str, theme: &Theme, width: usize) -> Vec<Line<'static>> {
         if in_code { continue; }
         // A standalone inline-code paragraph remains preformatted.
         if !segs.is_empty() && segs.iter().all(|s| s.style.bg == Some(theme.panel)) {
-            flush_table(&mut table, &mut out, theme, width);
+            flush_table(&mut table, &mut out, theme, tone, width);
             out.extend(wrap_pre(segs, width));
             continue;
         }
         if segs.is_empty() {
-            flush_table(&mut table, &mut out, theme, width);
+            flush_table(&mut table, &mut out, theme, tone, width);
             out.push(Line::default());
             continue;
         }
         if is_plain_rule(&segs) {
-            flush_table(&mut table, &mut out, theme, width);
+            flush_table(&mut table, &mut out, theme, tone, width);
             out.push(Line::from(Span::styled(
                 "─".repeat(width.min(120)),
                 Style::default().fg(theme.border),
@@ -114,8 +148,8 @@ pub fn render(text: &str, theme: &Theme, width: usize) -> Vec<Line<'static>> {
 
         // Hanging indent: quote (`>`) and list (`- ` / `1. `) prefixes stay on
         // the first wrapped line; continuations align under the body text.
-        // Prefixes keep their block style — the two-tone split applies to the
-        // body only, so markers don't turn into bright Latin runs.
+        // Prefixes keep their block style — the tone pass applies to the
+        // body only, so markers don't turn into bright runs.
         let segs = collapse_autolinks(segs);
         let (prefix, body) = split_prefix(segs);
         // Table frames are buffered whole: tui-markdown sizes every column
@@ -134,7 +168,7 @@ pub fn render(text: &str, theme: &Theme, width: usize) -> Vec<Line<'static>> {
             }
             let line = TableLine { prefix: prefix_spans, segs: strip_lead_spaces(body) };
             if first == '┌' {
-                flush_table(&mut table, &mut out, theme, width);
+                flush_table(&mut table, &mut out, theme, tone, width);
                 table = Some(TableBuffer { indent: Some(indent), lines: vec![line] });
             } else {
                 let buf = table
@@ -144,13 +178,13 @@ pub fn render(text: &str, theme: &Theme, width: usize) -> Vec<Line<'static>> {
             }
             continue;
         }
-        flush_table(&mut table, &mut out, theme, width);
+        flush_table(&mut table, &mut out, theme, tone, width);
 
         // Task-list checkboxes render as status glyphs instead of literal
         // `[x]` / `[ ]` markers, so lists read as rendered UI rather than
         // raw markdown source.
         let prefix = fit_prefix(task_list_glyphs(prefix, theme), width.saturating_sub(4), theme);
-        let body = two_tone(body, theme);
+        let body = body_tone(body, theme, tone);
         let indent = prefix_width(&prefix);
         let mut wrapped = wrap_segments(body, width.saturating_sub(indent).max(4));
         if wrapped.is_empty() && !prefix.is_empty() {
@@ -167,7 +201,7 @@ pub fn render(text: &str, theme: &Theme, width: usize) -> Vec<Line<'static>> {
             out.push(Line::from(spans));
         }
     }
-    flush_table(&mut table, &mut out, theme, width);
+    flush_table(&mut table, &mut out, theme, tone, width);
     out
 }
 
@@ -394,10 +428,11 @@ fn flush_table(
     table: &mut Option<TableBuffer>,
     out: &mut Vec<Line<'static>>,
     theme: &Theme,
+    tone: ToneMode,
     width: usize,
 ) {
     if let Some(buf) = table.take() {
-        out.extend(render_table(buf, theme, width));
+        out.extend(render_table(buf, theme, tone, width));
     }
 }
 
@@ -446,13 +481,18 @@ fn prefix_width(prefix: &[Seg]) -> usize {
 }
 
 /// Lay out one buffered table block. When the block fits the available
-/// width it is repainted as tui-markdown drew it (two-tone cells, `├─┼─┤`
-/// junctions between body rows); otherwise the columns shrink and each
-/// cell's text soft-wraps across box rows, so long cells read in full
+/// width it is repainted as tui-markdown drew it (tone-colored cells,
+/// `├─┼─┤` junctions between body rows); otherwise the columns shrink and
+/// each cell's text soft-wraps across box rows, so long cells read in full
 /// instead of truncating with an ellipsis.
-fn render_table(buf: TableBuffer, theme: &Theme, width: usize) -> Vec<Line<'static>> {
+fn render_table(
+    buf: TableBuffer,
+    theme: &Theme,
+    tone: ToneMode,
+    width: usize,
+) -> Vec<Line<'static>> {
     let Some((header, body)) = parse_table(&buf.lines) else {
-        return paint_fit(&buf, theme, width);
+        return paint_fit(&buf, theme, tone, width);
     };
     let cols = header.iter().chain(&body).map(|r| r.cells.len()).max().unwrap_or(0);
     let mut natural = vec![1usize; cols];
@@ -468,7 +508,7 @@ fn render_table(buf: TableBuffer, theme: &Theme, width: usize) -> Vec<Line<'stat
     // If even one content column per cell cannot fit, retain the clipped
     // fallback rather than drawing a frame wider than the viewport.
     if overhead + cols > avail || overhead + natural.iter().sum::<usize>() <= avail {
-        return paint_fit(&buf, theme, width);
+        return paint_fit(&buf, theme, tone, width);
     }
 
     // Column alignment is recovered from the original padding spans: the
@@ -502,14 +542,14 @@ fn render_table(buf: TableBuffer, theme: &Theme, width: usize) -> Vec<Line<'stat
         &buf.lines.first().map(|l| &l.prefix).unwrap_or(&empty),
     ));
     for row in &header {
-        lines.extend(paint_row(row, &widths, &aligns, theme, false));
+        lines.extend(paint_row(row, &widths, &aligns, theme, tone, false));
     }
     lines.push(prefix_line(frame_edge('├', '┼', '┤', &widths, border), cont_prefix));
     for (i, row) in body.iter().enumerate() {
         if i > 0 {
             lines.push(prefix_line(frame_edge('├', '┼', '┤', &widths, border), cont_prefix));
         }
-        lines.extend(paint_row(row, &widths, &aligns, theme, true));
+        lines.extend(paint_row(row, &widths, &aligns, theme, tone, true));
     }
     lines.push(prefix_line(frame_edge('└', '┴', '┘', &widths, border), cont_prefix));
     lines
@@ -647,14 +687,16 @@ fn frame_edge(left: char, cross: char, right: char, widths: &[usize], border: St
 }
 
 /// Paint one logical row as one or more `│ … │` lines: each cell's styled
-/// runs are two-toned and soft-wrapped to its column width; cells that fit
-/// on one line keep the column's alignment, wrapped ones left-align. Every
-/// physical line re-applies the row's quote/list prefix.
+/// runs are tone-colored (see [`ToneMode`]) and soft-wrapped to its column
+/// width; cells that fit on one line keep the column's alignment, wrapped
+/// ones left-align. Every physical line re-applies the row's quote/list
+/// prefix.
 fn paint_row(
     row: &TableRow,
     widths: &[usize],
     aligns: &[TAlign],
     theme: &Theme,
+    tone: ToneMode,
     body: bool,
 ) -> Vec<Line<'static>> {
     let border = Style::default().fg(theme.border);
@@ -670,7 +712,7 @@ fn paint_row(
         .map(|(i, w)| {
             let segs = cells
                 .get(i)
-                .map(|c| two_tone(c.segs.clone(), theme))
+                .map(|c| body_tone(c.segs.clone(), theme, tone))
                 .unwrap_or_default();
             wrap_segments(segs, *w)
         })
@@ -708,16 +750,16 @@ fn pad_split(align: TAlign, free: usize) -> (usize, usize) {
     }
 }
 
-/// Repaint the buffered block as tui-markdown drew it: two-tone body,
+/// Repaint the buffered block as tui-markdown drew it: tone-colored body,
 /// `├─┼─┤` junctions between consecutive body rows, and — when the block is
 /// not a well-formed frame (degenerate fallback) — ellipsis truncation.
 /// Each line re-applies its own quote/list prefix.
-fn paint_fit(buf: &TableBuffer, theme: &Theme, width: usize) -> Vec<Line<'static>> {
+fn paint_fit(buf: &TableBuffer, theme: &Theme, tone: ToneMode, width: usize) -> Vec<Line<'static>> {
     let mut out = Vec::new();
     let mut prev_row = false;
     for line in &buf.lines {
         let available = width.saturating_sub(line.prefix.iter().map(Span::width).sum::<usize>());
-        let row = truncate_line(two_tone(line.segs.clone(), theme), available, theme);
+        let row = truncate_line(body_tone(line.segs.clone(), theme, tone), available, theme);
         let is_row = row.spans.first().and_then(|s| s.content.chars().next()) == Some('│');
         if is_row && prev_row {
             let sep = table_row_separator(&row, theme);
@@ -867,11 +909,39 @@ fn task_list_glyphs(prefix: Vec<Seg>, theme: &Theme) -> Vec<Seg> {
     out
 }
 
+/// Tint plain body runs according to the chosen [`ToneMode`] — the body is
+/// paragraph/list/table-cell text, including blockquote italic. Spans that
+/// already carry an accent (headings, links, code, captions) are left
+/// untouched.
+fn body_tone(segs: Vec<Seg>, theme: &Theme, mode: ToneMode) -> Vec<Seg> {
+    match mode {
+        ToneMode::Single => single_tone(segs, theme),
+        ToneMode::Two => two_tone(segs, theme),
+    }
+}
+
+/// Single-tone body coloring: every plain body run is repainted with the
+/// main `fg` — CJK and Latin/digits share one color, no script split.
+fn single_tone(segs: Vec<Seg>, theme: &Theme) -> Vec<Seg> {
+    segs.into_iter()
+        .map(|seg| {
+            // Box-drawing characters are structural borders, never body text:
+            // keep their own style (see the note in `two_tone`).
+            if is_body_style(seg.style, theme) && !is_box_drawing(&seg.text) {
+                Seg {
+                    text: seg.text,
+                    style: seg.style.fg(theme.fg),
+                }
+            } else {
+                seg
+            }
+        })
+        .collect()
+}
+
 /// Two-tone body coloring: plain body runs (paragraph/list/table-cell text,
 /// including blockquote italic) are split into CJK vs Latin/digit runs, CJK
 /// keeping the muted body gray and Latin/digits taking the brighter `fg`.
-/// Spans that already carry an accent (headings, links, code, captions) are
-/// left untouched.
 fn two_tone(segs: Vec<Seg>, theme: &Theme) -> Vec<Seg> {
     let mut out = Vec::new();
     for seg in segs {

--- a/src/slots.rs
+++ b/src/slots.rs
@@ -8,6 +8,7 @@ use serde::Deserialize;
 use serde_json::Value;
 use unicode_width::UnicodeWidthStr;
 
+use crate::markdown::ToneMode;
 use crate::theme::Theme;
 use crate::transcript::wrap;
 
@@ -337,7 +338,7 @@ fn indent(lines: Vec<Line<'static>>, prefix: &str, color: Color) -> Vec<Line<'st
         .collect()
 }
 
-fn render_node(node: &TuiNode, theme: &Theme, width: usize) -> Vec<Line<'static>> {
+fn render_node(node: &TuiNode, theme: &Theme, tone: ToneMode, width: usize) -> Vec<Line<'static>> {
     match node {
         TuiNode::Ascii { lines, tone, .. } => styled_wrapped(
             &lines.join("\n"),
@@ -364,11 +365,11 @@ fn render_node(node: &TuiNode, theme: &Theme, width: usize) -> Vec<Line<'static>
         ),
         TuiNode::Group {
             title,
-            tone,
+            tone: accent_tone,
             children,
             ..
         } => {
-            let accent = tone
+            let accent = accent_tone
                 .as_deref()
                 .map(|name| token_color(theme, name))
                 .unwrap_or(theme.brand);
@@ -384,7 +385,7 @@ fn render_node(node: &TuiNode, theme: &Theme, width: usize) -> Vec<Line<'static>
             }
             for child in children {
                 lines.extend(indent(
-                    render_node(child, theme, width.saturating_sub(2)),
+                    render_node(child, theme, tone, width.saturating_sub(2)),
                     "  ",
                     theme.border,
                 ));
@@ -394,7 +395,7 @@ fn render_node(node: &TuiNode, theme: &Theme, width: usize) -> Vec<Line<'static>
         TuiNode::Markdown {
             text, streaming, ..
         } => {
-            let mut lines = crate::markdown::render(text, theme, width);
+            let mut lines = crate::markdown::render(text, theme, tone, width);
             if *streaming {
                 lines.push(Line::from(Span::styled(
                     "…",
@@ -610,19 +611,24 @@ fn render_node(node: &TuiNode, theme: &Theme, width: usize) -> Vec<Line<'static>
     }
 }
 
-pub fn render_nodes(nodes: &[TuiNode], theme: &Theme, width: usize) -> Vec<Line<'static>> {
+pub fn render_nodes(
+    nodes: &[TuiNode],
+    theme: &Theme,
+    tone: ToneMode,
+    width: usize,
+) -> Vec<Line<'static>> {
     let mut lines = Vec::new();
     for (index, node) in nodes.iter().enumerate() {
         if index > 0 {
             lines.push(Line::default());
         }
-        lines.extend(render_node(node, theme, width));
+        lines.extend(render_node(node, theme, tone, width));
     }
     lines
 }
 
-pub fn render(snapshot: &SlotSnapshot, theme: &Theme, width: usize) -> Vec<Line<'static>> {
-    render_nodes(&snapshot.nodes, theme, width)
+pub fn render(snapshot: &SlotSnapshot, theme: &Theme, tone: ToneMode, width: usize) -> Vec<Line<'static>> {
+    render_nodes(&snapshot.nodes, theme, tone, width)
 }
 
 fn centered(width: usize, mut line: Line<'static>) -> Line<'static> {
@@ -644,15 +650,16 @@ fn centered(width: usize, mut line: Line<'static>) -> Line<'static> {
 pub fn render_welcome_hero(
     snapshot: &SlotSnapshot,
     theme: &Theme,
+    tone: ToneMode,
     width: usize,
 ) -> Vec<Line<'static>> {
     let [logo, hint] = snapshot.nodes.as_slice() else {
         return Vec::new();
     };
-    let mut lines = render_node(logo, theme, width);
+    let mut lines = render_node(logo, theme, tone, width);
     lines.push(Line::default());
     lines.extend(
-        render_node(hint, theme, width)
+        render_node(hint, theme, tone, width)
             .into_iter()
             .map(|line| centered(width, line)),
     );

--- a/src/transcript.rs
+++ b/src/transcript.rs
@@ -15,6 +15,7 @@ use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
 use crate::events::UiEvent;
 use crate::locale::Locale;
+use crate::markdown::ToneMode;
 use crate::theme::Theme;
 
 /// Collapsed tool preview height; click toggles full expansion. Mouse wheel
@@ -109,6 +110,7 @@ struct CellRender {
     version: u64,
     width: u16,
     theme: Theme,
+    tone: ToneMode,
     expanded: bool,
     thumbs: bool,
     locale: Locale,
@@ -136,12 +138,13 @@ impl Cell {
     }
 
     /// Return the cached body render, rebuilding it when the cell content
-    /// version or any layout input (width/theme/expanded/thumbs/locale)
+    /// version or any layout input (width/theme/tone/expanded/thumbs/locale)
     /// drifted. `expanded` is the *effective* value including the
     /// transcript-wide `expand_all`; it decides Tool/Shell/Reasoning layout.
     fn ensure_render(
         &mut self,
         theme: &Theme,
+        tone: ToneMode,
         width: u16,
         expanded: bool,
         thumbs: bool,
@@ -152,6 +155,7 @@ impl Cell {
                 r.version != self.version
                     || r.width != width
                     || r.theme != *theme
+                    || r.tone != tone
                     || r.expanded != expanded
                     || r.thumbs != thumbs
                     || r.locale != locale
@@ -159,12 +163,20 @@ impl Cell {
             None => true,
         };
         if stale {
-            let (body, meta) =
-                build_body(&self.kind, theme, width as usize, expanded, thumbs, locale);
+            let (body, meta) = build_body(
+                &self.kind,
+                theme,
+                tone,
+                width as usize,
+                expanded,
+                thumbs,
+                locale,
+            );
             self.render = Some(CellRender {
                 version: self.version,
                 width,
                 theme: *theme,
+                tone,
                 expanded,
                 thumbs,
                 locale,
@@ -183,6 +195,7 @@ impl Cell {
 fn build_body(
     kind: &CellKind,
     theme: &Theme,
+    tone: ToneMode,
     width: usize,
     expanded: bool,
     _thumbs: bool,
@@ -210,7 +223,7 @@ fn build_body(
             if text.trim().is_empty() {
                 return (Vec::new(), 0);
             }
-            (crate::markdown::render(text, theme, width), 0)
+            (crate::markdown::render(text, theme, tone, width), 0)
         }
         CellKind::Tool {
             request, result, ok, error, ..
@@ -1057,8 +1070,14 @@ impl Transcript {
 
     /// Render every cell to wrapped, styled lines for `width` columns.
     #[allow(dead_code)] // kept for tests; the UI uses `layout` for ownership
-    pub fn lines(&mut self, theme: &Theme, width: u16, spinner: char) -> Vec<Line<'static>> {
-        self.layout(theme, width, spinner, false).lines
+    pub fn lines(
+        &mut self,
+        theme: &Theme,
+        tone: ToneMode,
+        width: u16,
+        spinner: char,
+    ) -> Vec<Line<'static>> {
+        self.layout(theme, tone, width, spinner, false).lines
     }
 
     /// Render every cell to wrapped, styled lines, plus per-line ownership so
@@ -1068,6 +1087,7 @@ impl Transcript {
     pub fn layout(
         &mut self,
         theme: &Theme,
+        tone: ToneMode,
         width: u16,
         spinner: char,
         thumbs: bool,
@@ -1093,7 +1113,7 @@ impl Transcript {
                     | CellKind::Tool { .. }
                     | CellKind::Shell { .. }
             ) {
-                cell.ensure_render(theme, width as u16, expanded, thumbs, self.locale);
+                cell.ensure_render(theme, tone, width as u16, expanded, thumbs, self.locale);
             }
             match &cell.kind {
                 CellKind::User { text, queued } => {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -14,6 +14,7 @@ use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
 use crate::app::{App, RunState};
 use crate::logo;
+use crate::markdown::ToneMode;
 use crate::pet::{SPRITE_H, SPRITE_W, WHALE_XS};
 use crate::theme::{lerp, Mode, Theme};
 
@@ -823,6 +824,7 @@ fn force_full_rewrite(f: &mut Frame, area: Rect) {
 
 fn draw_view_overlay(f: &mut Frame, app: &mut App, screen: Rect) {
     let theme = app.theme;
+    let tone = app.tone_mode;
     let Some(view) = app.view_overlay.as_mut() else {
         return;
     };
@@ -838,7 +840,7 @@ fn draw_view_overlay(f: &mut Frame, app: &mut App, screen: Rect) {
     // continuation lines stay aligned.
     const POPUP_INDENT: u16 = 2;
     let inner_width = width.saturating_sub(2 + POPUP_INDENT) as usize;
-    let mut lines = crate::slots::render_nodes(&view.nodes, &theme, inner_width);
+    let mut lines = crate::slots::render_nodes(&view.nodes, &theme, tone, inner_width);
     let indent = " ".repeat(POPUP_INDENT as usize);
     for line in &mut lines {
         line.spans.insert(0, Span::raw(indent.clone()));
@@ -1004,7 +1006,7 @@ fn draw_right_slot(f: &mut Frame, app: &App, area: Rect) {
     };
     let theme = app.theme;
     let inner_width = area.width.saturating_sub(4) as usize;
-    let lines = crate::slots::render(snapshot, &theme, inner_width);
+    let lines = crate::slots::render(snapshot, &theme, app.tone_mode, inner_width);
     let block = Block::default()
         .borders(Borders::ALL)
         .border_type(BorderType::Rounded)
@@ -1222,8 +1224,8 @@ fn draw_navigation_dock(f: &mut Frame, app: &mut App, area: Rect, embedded: bool
         .nodes
         .iter()
         .filter_map(|node| {
-            compact_node_spans(node, &theme, area.width as usize, app.spinner()).map(|spans| {
-                CompactSlotSection {
+            compact_node_spans(node, &theme, app.tone_mode, area.width as usize, app.spinner())
+                .map(|spans| CompactSlotSection {
                     spans,
                     action: node.action().cloned(),
                     essential: matches!(
@@ -1233,8 +1235,7 @@ fn draw_navigation_dock(f: &mut Frame, app: &mut App, area: Rect, embedded: bool
                             ..
                         } if matches!(tone.as_str(), "brand" | "brand_soft")
                     ),
-                }
-            })
+                })
         })
         .collect::<Vec<_>>();
     if sections.is_empty() {
@@ -2007,6 +2008,7 @@ struct CompactSlotSection {
 fn compact_slot_sections(
     snapshot: &crate::slots::SlotSnapshot,
     theme: &Theme,
+    tone: ToneMode,
     width: usize,
     spinner: char,
 ) -> Vec<CompactSlotSection> {
@@ -2014,7 +2016,7 @@ fn compact_slot_sections(
         .nodes
         .iter()
         .filter_map(|node| {
-            compact_node_spans(node, theme, width, spinner).map(|spans| CompactSlotSection {
+            compact_node_spans(node, theme, tone, width, spinner).map(|spans| CompactSlotSection {
                 spans,
                 action: node.action().cloned(),
                 essential: false,
@@ -2038,6 +2040,7 @@ fn compact_slot_sections(
 fn compact_input_dock_sections(
     snapshot: &crate::slots::SlotSnapshot,
     theme: &Theme,
+    tone: ToneMode,
     width: usize,
     spinner: char,
 ) -> Vec<CompactSlotSection> {
@@ -2046,7 +2049,7 @@ fn compact_input_dock_sections(
         .iter()
         .filter(|node| matches!(node, crate::slots::TuiNode::Generic { .. }))
         .filter_map(|node| {
-            compact_node_spans(node, theme, width, spinner).map(|spans| CompactSlotSection {
+            compact_node_spans(node, theme, tone, width, spinner).map(|spans| CompactSlotSection {
                 spans,
                 action: node.action().cloned(),
                 essential: false,
@@ -2077,7 +2080,7 @@ fn input_dock_body_lines(app: &App, width: usize) -> Vec<Line<'static>> {
         .filter(|node| !matches!(node, crate::slots::TuiNode::Generic { .. }))
         .cloned()
         .collect::<Vec<_>>();
-    crate::slots::render_nodes(&nodes, &app.theme, width)
+    crate::slots::render_nodes(&nodes, &app.theme, app.tone_mode, width)
 }
 
 /// The composer stats dock below the box: one compact row of plugin
@@ -2105,6 +2108,7 @@ fn draw_composer_dock(f: &mut Frame, app: &App, area: Rect, pet_pad: u16) {
         Paragraph::new(compact_slot_line(
             snapshot,
             &theme,
+            app.tone_mode,
             inner.width as usize,
             app.spinner(),
         )),
@@ -2115,10 +2119,11 @@ fn draw_composer_dock(f: &mut Frame, app: &App, area: Rect, pet_pad: u16) {
 fn compact_slot_line(
     snapshot: &crate::slots::SlotSnapshot,
     theme: &Theme,
+    tone: ToneMode,
     width: usize,
     spinner: char,
 ) -> Line<'static> {
-    let sections = compact_slot_sections(snapshot, theme, width, spinner);
+    let sections = compact_slot_sections(snapshot, theme, tone, width, spinner);
     compact_slot_sections_line(&sections, theme)
 }
 
@@ -2163,6 +2168,7 @@ fn running_progress_color(theme: &Theme, spinner: char) -> ratatui::style::Color
 fn compact_node_spans(
     node: &crate::slots::TuiNode,
     theme: &Theme,
+    tone: ToneMode,
     width: usize,
     spinner: char,
 ) -> Option<Vec<Span<'static>>> {
@@ -2230,7 +2236,7 @@ fn compact_node_spans(
         spans.push(Span::styled(title.clone(), title_style));
         return Some(spans);
     }
-    crate::slots::render_nodes(std::slice::from_ref(node), theme, width)
+    crate::slots::render_nodes(std::slice::from_ref(node), theme, tone, width)
         .into_iter()
         .next()
         .map(|line| line.spans)
@@ -2257,9 +2263,10 @@ fn draw_chat(f: &mut Frame, app: &mut App, area: Rect) {
     };
     let thumbs = crate::pet::kitty_supported();
     let spinner = app.spinner();
+    let tone = app.tone_mode;
     let layout = app
         .displayed_transcript_mut()
-        .layout(&theme, inner.width, spinner, thumbs);
+        .layout(&theme, tone, inner.width, spinner, thumbs);
     if app.show_banner && lines.len() < inner.height as usize {
         let remaining = inner.height as usize - lines.len();
         let top = remaining / 2;
@@ -2620,7 +2627,9 @@ fn draw_composer_box(
     let dock_sections = has_input_dock
         .then(|| app.slot_snapshots.get("conversation.input.dock"))
         .flatten()
-        .map(|snapshot| compact_input_dock_sections(snapshot, &theme, title_budget, app.spinner()));
+        .map(|snapshot| {
+            compact_input_dock_sections(snapshot, &theme, app.tone_mode, title_budget, app.spinner())
+        });
     let dock_line = dock_sections
         .as_ref()
         .map(|sections| compact_input_dock_sections_line(sections, &theme));
@@ -3582,7 +3591,7 @@ fn draw_elicitation_form(f: &mut Frame, app: &mut App, screen: Rect) {
         .field
         .description
         .as_ref()
-        .map(|text| crate::markdown::render(text, &theme, content_width));
+        .map(|text| crate::markdown::render(text, &theme, app.tone_mode, content_width));
     let mut bottom = Vec::new();
     bottom.push(Line::default());
     let mut field_cursor = None;
@@ -3789,6 +3798,7 @@ fn banner_lines(app: &App, width: u16) -> Vec<Line<'static>> {
         out.extend(crate::slots::render_welcome_hero(
             hero,
             theme,
+            app.tone_mode,
             width as usize,
         ));
     } else if app.ui_preset == "deepseek" {
@@ -3831,7 +3841,7 @@ fn banner_lines(app: &App, width: u16) -> Vec<Line<'static>> {
         ) {
             out.extend(welcome_info_lines(app));
         } else {
-            out.extend(crate::slots::render(info, theme, width as usize));
+            out.extend(crate::slots::render(info, theme, app.tone_mode, width as usize));
         }
     } else {
         out.extend(welcome_info_lines(app));

--- a/tests/unit/app__mode_tests.rs
+++ b/tests/unit/app__mode_tests.rs
@@ -181,6 +181,29 @@ fn lang_switch_repaints_immediately_and_persists_for_the_workspace() {
     );
 }
 
+/// The markdown body tone is a quiet, settings-only preference: no command
+/// surface. Absent `markdownTone` → single (the default look); `"two"`
+/// opts back into the two-tone CJK/Latin body.
+#[test]
+fn tone_defaults_to_single_and_loads_the_hidden_markdown_tone_setting() {
+    let cfg = test_cfg();
+    let (tx, _rx) = std::sync::mpsc::channel::<AppEvent>();
+    let app = App::new(Some(Theme::dark()), cfg.clone(), "s1".into(), true, false, tx.clone());
+    assert_eq!(app.tone_mode, ToneMode::Single, "single tone is the default");
+
+    // Seed the hidden opt-in: a fresh App over the same session root picks
+    // the two-tone scheme from settings.json without any command.
+    let settings = std::path::Path::new(&cfg.session_root).join("settings.json");
+    std::fs::write(&settings, r#"{"markdownTone":"two"}"#).expect("seed settings");
+    let opted = App::new(Some(Theme::dark()), cfg.clone(), "s2".into(), true, false, tx.clone());
+    assert_eq!(opted.tone_mode, ToneMode::Two, "markdownTone:two opts in");
+
+    // Unknown values fall back to the single-tone default.
+    std::fs::write(&settings, r#"{"markdownTone":"bogus"}"#).expect("seed settings");
+    let bogus = App::new(Some(Theme::dark()), cfg.clone(), "s3".into(), true, false, tx.clone());
+    assert_eq!(bogus.tone_mode, ToneMode::Single, "unparsable markdownTone keeps the default");
+}
+
 #[test]
 fn liang_toggle_is_transient_and_keeps_the_empty_welcome_centered() {
     let (mut app, ctl, _rx) = test_app();
@@ -435,7 +458,7 @@ fn child_session_updates_do_not_enter_the_parent_transcript() {
 
     let rendered = app
         .transcript
-        .lines(&Theme::dark(), 80, '⠋')
+        .lines(&Theme::dark(), crate::markdown::ToneMode::Single, 80, '⠋')
         .iter()
         .flat_map(|line| line.spans.iter().map(|span| span.content.as_ref()))
         .collect::<String>();
@@ -458,7 +481,7 @@ fn subagent_started_updates_navigation_without_a_timeline_notice() {
     assert!(app.subagents[0].running);
     let rendered = app
         .transcript
-        .lines(&Theme::dark(), 80, '⠋')
+        .lines(&Theme::dark(), crate::markdown::ToneMode::Single, 80, '⠋')
         .iter()
         .flat_map(|line| line.spans.iter().map(|span| span.content.as_ref()))
         .collect::<String>();
@@ -484,7 +507,7 @@ fn subagent_finished_updates_navigation_without_a_timeline_notice() {
     assert!(!app.subagents[0].running);
     let rendered = app
         .transcript
-        .lines(&Theme::dark(), 80, '⠋')
+        .lines(&Theme::dark(), crate::markdown::ToneMode::Single, 80, '⠋')
         .iter()
         .flat_map(|line| line.spans.iter().map(|span| span.content.as_ref()))
         .collect::<String>();
@@ -1325,6 +1348,7 @@ fn prompt_jump_anchor(app: &mut App, cell: usize) -> usize {
     let spinner = app.spinner();
     let layout = app.transcript.layout(
         &theme,
+        crate::markdown::ToneMode::Single,
         area.width,
         spinner,
         crate::pet::kitty_supported(),

--- a/tests/unit/app__persistent_shell_tests.rs
+++ b/tests/unit/app__persistent_shell_tests.rs
@@ -30,7 +30,7 @@ fn wait_for_shell(rx: &Receiver<AppEvent>) -> (Option<i32>, String) {
 
 fn transcript_text(transcript: &mut crate::transcript::Transcript) -> String {
     transcript
-        .lines(&Theme::dark(), 80, ' ')
+        .lines(&Theme::dark(), crate::markdown::ToneMode::Single, 80, ' ')
         .iter()
         .flat_map(|l| l.spans.iter().map(|s| s.content.to_string()))
         .collect()

--- a/tests/unit/app__resume_tests.rs
+++ b/tests/unit/app__resume_tests.rs
@@ -57,7 +57,7 @@ fn resume_replays_transcript_modes_and_usage() {
     assert_eq!(app.transcript.usage.output, 5);
     let text = app
         .transcript
-        .lines(&Theme::dark(), 80, ' ')
+        .lines(&Theme::dark(), crate::markdown::ToneMode::Single, 80, ' ')
         .iter()
         .flat_map(|l| l.spans.iter().map(|s| s.content.to_string()))
         .collect::<String>();

--- a/tests/unit/app__session_tabs_tests.rs
+++ b/tests/unit/app__session_tabs_tests.rs
@@ -38,7 +38,7 @@ fn test_app() -> (App, Controller, Receiver<AppEvent>) {
 
 fn transcript_text(transcript: &mut Transcript) -> String {
     transcript
-        .lines(&Theme::dark(), 80, ' ')
+        .lines(&Theme::dark(), crate::markdown::ToneMode::Single, 80, ' ')
         .iter()
         .flat_map(|l| l.spans.iter().map(|s| s.content.to_string()))
         .collect()

--- a/tests/unit/input__keymap__tests.rs
+++ b/tests/unit/input__keymap__tests.rs
@@ -373,7 +373,7 @@ fn keys_markdown_renders_within_the_terminal_width() {
         for zh in [false, true] {
             for mac in [false, true] {
                 let md = keys_markdown(zh, mac);
-                let lines = crate::markdown::render(&md, &theme, width);
+                let lines = crate::markdown::render(&md, &theme, crate::markdown::ToneMode::Single, width);
                 assert!(!lines.is_empty());
                 for line in lines {
                     let w = line.width() as usize;

--- a/tests/unit/markdown__tests.rs
+++ b/tests/unit/markdown__tests.rs
@@ -8,7 +8,7 @@ fn plain(lines: &[Line]) -> String {
 }
 
 fn render_dark(md: &str, width: usize) -> Vec<Line<'static>> {
-    render(md, &Theme::dark(), width)
+    render(md, &Theme::dark(), ToneMode::Single, width)
 }
 
 fn line_width(line: &Line) -> usize {
@@ -18,7 +18,7 @@ fn line_width(line: &Line) -> usize {
 #[test]
 fn inline_emphasis_styles_runs() {
     let theme = Theme::dark();
-    let lines = render("a **bold** b *it* c `code` d ~~x~~", &theme, 60);
+    let lines = render("a **bold** b *it* c `code` d ~~x~~", &theme, ToneMode::Single, 60);
     let text = plain(&lines);
     assert_eq!(text, "a bold b it c code d x");
     let spans: Vec<&Span> = lines.iter().flat_map(|l| l.spans.iter()).collect();
@@ -52,7 +52,7 @@ fn link_and_image_render_with_urls() {
 #[test]
 fn code_block_renders_as_framed_box_with_lang_label() {
     let theme = Theme::dark();
-    let lines = render("before\n\n```rust\nlet x = 1;\n```\n\nafter", &theme, 40);
+    let lines = render("before\n\n```rust\nlet x = 1;\n```\n\nafter", &theme, ToneMode::Single, 40);
     let text = plain(&lines);
     assert!(text.contains("let x = 1;"), "{text}");
     // Fence delimiters become frame edges; the top one names the language.
@@ -81,7 +81,7 @@ fn code_block_renders_as_framed_box_with_lang_label() {
 fn code_line_with_box_chars_is_not_mistaken_for_a_table() {
     let theme = Theme::dark();
     let md = "```\n│ diagram text that runs well past the wrap column\n```";
-    let lines = render(md, &theme, 20);
+    let lines = render(md, &theme, ToneMode::Single, 20);
     let text = plain(&lines);
     // Box-drawing code content wraps (mid-word if needed) instead of
     // truncating…
@@ -102,7 +102,7 @@ fn code_line_with_box_chars_is_not_mistaken_for_a_table() {
 #[test]
 fn blockquote_gets_prefix_and_italic() {
     let theme = Theme::dark();
-    let lines = render("> quoted", &theme, 40);
+    let lines = render("> quoted", &theme, ToneMode::Single, 40);
     let text = plain(&lines);
     assert!(text.contains("> quoted"), "{text}");
     let spans: Vec<&Span> = lines.iter().flat_map(|l| l.spans.iter()).collect();
@@ -112,7 +112,8 @@ fn blockquote_gets_prefix_and_italic() {
             && s.style.fg == Some(theme.fg_tertiary)
             && s.style.add_modifier.contains(Modifier::ITALIC)
     }));
-    // …while Latin body text takes the brighter two-tone foreground.
+    // …while body text takes the brighter foreground (single tone keeps
+    // CJK and Latin alike).
     assert!(spans.iter().any(|s| {
         s.content.contains("quoted")
             && s.style.fg == Some(theme.fg)
@@ -144,7 +145,7 @@ fn list_wrap_hangs_under_marker() {
 #[test]
 fn task_list_checkboxes_render_as_status_glyphs() {
     let theme = Theme::dark();
-    let lines = render("- [x] done\n- [ ] pending\n- [X] also done", &theme, 40);
+    let lines = render("- [x] done\n- [ ] pending\n- [X] also done", &theme, ToneMode::Single, 40);
     let text = plain(&lines);
     assert!(text.contains("✓ done"), "checked:\n{text}");
     assert!(text.contains("○ pending"), "open:\n{text}");
@@ -195,7 +196,7 @@ fn task_list_continuations_hang_under_the_glyph_prefix() {
 #[test]
 fn rule_renders_full_width() {
     let theme = Theme::dark();
-    let lines = render("above\n\n---\n\nbelow", &theme, 30);
+    let lines = render("above\n\n---\n\nbelow", &theme, ToneMode::Single, 30);
     let rule = lines
         .iter()
         .find(|l| l.spans.iter().any(|s| s.content.contains('─')))
@@ -235,10 +236,13 @@ fn heading_levels_have_distinct_colors() {
         .all(|l| l.spans[0].style.add_modifier.contains(Modifier::BOLD)));
 }
 
+/// The opt-in two-tone mode splits plain body runs into CJK vs
+/// Latin/digit runs: CJK keeps the muted body gray, Latin/digits take the
+/// brighter `fg`.
 #[test]
-fn cjk_and_latin_body_use_different_colors() {
+fn two_tone_body_cjk_and_latin_use_different_colors() {
     let theme = Theme::dark();
-    let lines = render("你好 world 123", &theme, 40);
+    let lines = render("你好 world 123", &theme, ToneMode::Two, 40);
     let segs: Vec<&Span> = lines.iter().flat_map(|l| l.spans.iter()).collect();
     let cjk = segs
         .iter()
@@ -261,11 +265,29 @@ fn cjk_and_latin_body_use_different_colors() {
     assert_ne!(cjk.style.fg, latin.style.fg);
 }
 
+/// Default single tone: CJK and Latin/digits share the main `fg` — one
+/// body color, no script split (the two-tone pass is opt-in).
+#[test]
+fn single_tone_body_colors_cjk_and_latin_alike() {
+    let theme = Theme::dark();
+    let lines = render("你好 world 123", &theme, ToneMode::Single, 40);
+    let segs: Vec<&Span> = lines.iter().flat_map(|l| l.spans.iter()).collect();
+    let body: Vec<&Span> = segs
+        .iter()
+        .copied()
+        .filter(|s| s.content.contains("你好") || s.content.contains("world"))
+        .collect();
+    assert!(!body.is_empty(), "body spans present: {segs:?}");
+    for span in body {
+        assert_eq!(span.style.fg, Some(theme.fg), "uniform body fg: {span:?}");
+    }
+}
+
 #[test]
 fn table_renders_as_box_with_header_and_rows() {
     let theme = Theme::dark();
     let md = "| 样式 | 语法 |\n|------|------|\n| 粗体 | `**b**` |";
-    let lines = render(md, &theme, 40);
+    let lines = render(md, &theme, ToneMode::Single, 40);
     let text = plain(&lines);
     assert!(text.contains('┌'), "top border: {text}");
     assert!(text.contains('├'), "header separator: {text}");
@@ -294,7 +316,7 @@ fn table_borders_keep_border_color_when_a_palette_aliases_it() {
     let mut theme = Theme::dark();
     theme.border = theme.fg_secondary;
     let md = "| A |\n|---|\n| 1 |\n| 2 |";
-    let lines = render(md, &theme, 40);
+    let lines = render(md, &theme, ToneMode::Two, 40);
     for l in &lines {
         for s in &l.spans {
             let box_drawing = s
@@ -330,7 +352,7 @@ fn table_borders_keep_border_color_when_a_palette_aliases_it() {
 fn table_body_rows_are_separated_by_frame_lines() {
     let theme = Theme::dark();
     let md = "| A | B |\n|---|---|\n| 1 | 2 |\n| 3 | 4 |\n| 5 | 6 |";
-    let lines = render(md, &theme, 40);
+    let lines = render(md, &theme, ToneMode::Single, 40);
     let texts: Vec<String> = lines
         .iter()
         .map(|l| plain(std::slice::from_ref(l)))
@@ -543,7 +565,7 @@ fn autolink_is_not_duplicated() {
 #[test]
 fn nested_blockquote_keeps_markers_together() {
     let theme = Theme::dark();
-    let lines = render("> outer\n> > inner", &theme, 60);
+    let lines = render("> outer\n> > inner", &theme, ToneMode::Single, 60);
     let text = plain(&lines);
     assert!(text.contains(">> inner"), "nested markers: {text}");
     assert!(lines
@@ -558,7 +580,7 @@ fn four_backtick_fences_survive_nested_backtick_content() {
     // toggle the frame logic on the content lines, breaking the block into
     // two frames with an unframed middle.
     let text = "````\n```rust\nlet x = 1;\n```\nplain\n````\n";
-    let lines = render(text, &Theme::dark(), 40);
+    let lines = render(text, &Theme::dark(), ToneMode::Single, 40);
     let texts: Vec<String> = lines
         .iter()
         .map(|l| l.spans.iter().map(|s| s.content.as_ref()).collect())

--- a/tests/unit/transcript__tests.rs
+++ b/tests/unit/transcript__tests.rs
@@ -60,7 +60,7 @@ fn streaming_assistant_keeps_its_cursor_without_a_fallback_loading_icon() {
     });
 
     let mut rendered = |spinner| {
-        tr.lines(&Theme::dark(), 80, spinner)
+        tr.lines(&Theme::dark(), crate::markdown::ToneMode::Single, 80, spinner)
             .iter()
             .flat_map(|line| line.spans.iter().map(|span| span.content.as_ref()))
             .collect::<String>()
@@ -223,7 +223,7 @@ fn user_bubble_stays_within_the_pane_width() {
     tr.push_user("深度求索深度求索深度求索深度求索深度求索".into(), false);
     let theme = Theme::dark();
     for width in [20u16, 40, 80] {
-        for (i, line) in tr.lines(&theme, width, '⠋').iter().enumerate() {
+        for (i, line) in tr.lines(&theme, crate::markdown::ToneMode::Single, width, '⠋').iter().enumerate() {
             assert!(
                 line_width(line) <= width as usize,
                 "line {i} at pane width {width} paints {} cells: {line:?}",
@@ -282,7 +282,7 @@ fn write_tool_tab_indented_body_fits_terminal_width() {
     });
     let theme = Theme::dark();
     let width = 120u16;
-    let layout = tr.layout(&theme, width, ' ', false);
+    let layout = tr.layout(&theme, crate::markdown::ToneMode::Single, width, ' ', false);
     for (i, line) in layout.lines.iter().enumerate() {
         let w = line_width(line);
         let text: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
@@ -295,6 +295,42 @@ fn write_tool_tab_indented_body_fits_terminal_width() {
 }
 
 #[test]
+fn assistant_body_rerenders_when_the_tone_changes() {
+    let mut tr = t("s");
+    tr.apply(UiEvent::TextDelta {
+        session: "s".into(),
+        text: "你好 world".into(),
+    });
+    tr.apply(UiEvent::AssistantFinal {
+        session: "s".into(),
+        text: "你好 world".into(),
+        model: Some("m".into()),
+    });
+    let theme = Theme::dark();
+    let mut fg_of = |tone: ToneMode| -> (Option<ratatui::style::Color>, Option<ratatui::style::Color>) {
+        let lines = tr.lines(&theme, tone, 60, ' ');
+        let segs: Vec<&ratatui::text::Span> =
+            lines.iter().flat_map(|l| l.spans.iter()).collect();
+        let cjk = segs
+            .iter()
+            .find(|s| s.content.contains("你好"))
+            .expect("cjk run");
+        let latin = segs
+            .iter()
+            .find(|s| s.content.contains("world"))
+            .expect("latin run");
+        (cjk.style.fg, latin.style.fg)
+    };
+    let (cjk_single, latin_single) = fg_of(ToneMode::Single);
+    assert_eq!(cjk_single, Some(theme.fg), "single tone colors CJK with fg");
+    assert_eq!(latin_single, Some(theme.fg), "single tone colors Latin with fg");
+    let (cjk_two, latin_two) = fg_of(ToneMode::Two);
+    assert_eq!(cjk_two, Some(theme.fg_secondary), "two-tone dims CJK");
+    assert_eq!(latin_two, Some(theme.fg), "two-tone keeps Latin bright");
+    assert_ne!(cjk_single, cjk_two, "tone change invalidates the render cache");
+}
+
+#[test]
 fn render_smoke() {
     let mut tr = t("s");
     tr.push_user("hi".into(), false);
@@ -303,7 +339,7 @@ fn render_smoke() {
         text: "yo".into(),
     });
     let theme = Theme::dark();
-    let lines = tr.lines(&theme, 40, '⠋');
+    let lines = tr.lines(&theme, crate::markdown::ToneMode::Single, 40, '⠋');
     assert!(lines.len() >= 3);
 }
 
@@ -369,7 +405,7 @@ fn plan_snapshots_replace_the_existing_plan_in_place() {
         "a full plan snapshot updates one client-side view instead of appending chat history"
     );
     let rendered = tr
-        .lines(&Theme::dark(), 80, '⠋')
+        .lines(&Theme::dark(), crate::markdown::ToneMode::Single, 80, '⠋')
         .iter()
         .flat_map(|line| line.spans.iter().map(|span| span.content.as_ref()))
         .collect::<String>();
@@ -390,7 +426,7 @@ fn empty_plan_snapshot_hides_the_existing_plan() {
     });
 
     let rendered = tr
-        .lines(&Theme::dark(), 80, '⠋')
+        .lines(&Theme::dark(), crate::markdown::ToneMode::Single, 80, '⠋')
         .iter()
         .flat_map(|line| line.spans.iter().map(|span| span.content.as_ref()))
         .collect::<String>();
@@ -424,7 +460,7 @@ fn tool_preview_shows_a_fixed_tail_and_expand_all_opens_it() {
     };
 
     // Default: a fixed 4-line tail preview (l5..l8) + expand hint.
-    let lines = tr.lines(&theme, 40, ' ');
+    let lines = tr.lines(&theme, crate::markdown::ToneMode::Single, 40, ' ');
     let p = plain(&lines);
     assert!(
         p.contains("last 4/8 lines"),
@@ -439,7 +475,7 @@ fn tool_preview_shows_a_fixed_tail_and_expand_all_opens_it() {
 
     // expand_all (ctrl+o) opens the whole body and drops the footer.
     tr.expand_all = true;
-    let lines = tr.lines(&theme, 40, ' ');
+    let lines = tr.lines(&theme, crate::markdown::ToneMode::Single, 40, ' ');
     let p = plain(&lines);
     assert!(p.contains("l1"), "expand_all shows the top: {p}");
     assert!(
@@ -465,7 +501,7 @@ fn image_cell_reserves_thumbnail_or_falls_back_to_path() {
     let theme = Theme::dark();
 
     // Thumbnails on: reserve blank lines and report the placement.
-    let layout = tr.layout(&theme, 40, ' ', true);
+    let layout = tr.layout(&theme, crate::markdown::ToneMode::Single, 40, ' ', true);
     assert_eq!(layout.images.len(), 1, "PNG image reports one shot");
     let shot = &layout.images[0];
     assert_eq!(shot.cols, 24);
@@ -485,7 +521,7 @@ fn image_cell_reserves_thumbnail_or_falls_back_to_path() {
     );
 
     // Thumbnails off: no reservation, path shown as the fallback.
-    let layout = tr.layout(&theme, 40, ' ', false);
+    let layout = tr.layout(&theme, crate::markdown::ToneMode::Single, 40, ' ', false);
     assert!(layout.images.is_empty());
     let text: String = layout
         .lines

--- a/tests/unit/ui__tests.rs
+++ b/tests/unit/ui__tests.rs
@@ -2884,7 +2884,7 @@ fn composer_dock_title_uses_the_tertiary_tone() {
         selected: false,
         action: None,
     };
-    let spans = compact_node_spans(&node, &theme, 60, '⣋').expect("generic spans");
+    let spans = compact_node_spans(&node, &theme, crate::markdown::ToneMode::Single, 60, '⣋').expect("generic spans");
     let title = spans
         .iter()
         .find(|s| s.content == "1.2k tokens")
@@ -2981,8 +2981,8 @@ fn compact_running_progress_pulses_without_a_spinner_prefix() {
         action: None,
     };
 
-    let soft = compact_node_spans(&node, &app.theme, 60, '⠋').expect("generic spans");
-    let bright = compact_node_spans(&node, &app.theme, 60, '⠴').expect("generic spans");
+    let soft = compact_node_spans(&node, &app.theme, crate::markdown::ToneMode::Single, 60, '⠋').expect("generic spans");
+    let bright = compact_node_spans(&node, &app.theme, crate::markdown::ToneMode::Single, 60, '⠴').expect("generic spans");
     let text = |spans: &[Span]| {
         spans
             .iter()


### PR DESCRIPTION
## What

Markdown body text now renders **single-tone by default**: CJK and Latin/digit runs share the main `fg`, instead of the previous always-on two-tone split (Chinese on the muted body gray, English brighter).

The two-tone look is kept as a deliberately **quiet, settings-only** preference — no `/tone` command or picker surface for now. Set `markdownTone` to `"two"` in the UI settings file (`settings.json`, next to `themeMode`) to opt back in.

## Why

The CJK/Latin two-color body was surprising as a hard default; most mixed-language replies should read in one color. The capability stays available without advertising it.

## How

- `src/markdown.rs`: new `ToneMode` (`Single` default / `Two`); `single_tone` paints every plain body run with `theme.fg` (no script split), `two_tone` keeps the old CJK-muted split. Tables (`render_table`/`paint_row`/`paint_fit`) follow the same tone.
- `src/transcript.rs`: tone joins the per-cell body-render cache key, so toggling the setting rebuilds cached assistant text immediately.
- `src/slots.rs` / `src/ui.rs`: tone threaded through plugin slot rendering, compact docks, welcome/banner, and elicitation-form markdown, so every markdown surface follows the loaded setting.
- `src/app.rs` / `src/locale.rs`: `App.tone_mode` loaded from persisted `markdownTone` at startup and preserved on later settings writes.

## Verification

- `cargo test --locked`: 718 unit + 3 integration tests pass (added tests: single-tone body colors CJK/Latin alike, two-tone explicit opt-in, transcript render-cache rebuild on tone change, settings-driven load incl. invalid-value fallback).
- `martty --dump-frame` smoke in both modes exits cleanly.
- `CHANGELOG.md` updated under `[Unreleased]`.
