### PR TITLE
fix: bump embedded ACP to 0.4.29 for dsh 0.1.2 agent presets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,11 @@ All notable changes to this project are documented here. The project follows
 
 ### Fixed
 
+- Fix `dsh --profile martty` startup against dsh 0.1.2 hosts: the embedded
+  ACP plugin now resolves agent presets from a self-shipping
+  `@deepseek-ai/dsh-agent-presets` instead of requiring the legacy
+  `@deepseek-ai/dsh/config/agent-presets` layout removed in dsh 0.1.2-rc.1
+  (bump `@openma/deepseek-harness-acp` to 0.4.29).
 - Preserve queue selection and edits across session tabs, including pausing
   background delivery until an edit is saved or cancelled. Failed session
   configuration operations no longer mark a running prompt idle.

--- a/npm/package-lock.json
+++ b/npm/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@openma/deepseek-harness-acp": "0.4.27"
+        "@openma/deepseek-harness-acp": "0.4.29"
       },
       "bin": {
         "dsh-tui": "bin/martty.js",
@@ -5270,9 +5270,9 @@
       }
     },
     "node_modules/@openma/deepseek-harness-acp": {
-      "version": "0.4.27",
-      "resolved": "https://registry.npmjs.org/@openma/deepseek-harness-acp/-/deepseek-harness-acp-0.4.27.tgz",
-      "integrity": "sha512-O3rQjdZVtqFzHMoCVziwZSTxL+dWFtCBA4bBSA+64puZDiW9GRJ4efmEjVjYbZZ4JncipAWwGfMiajvE99WTzQ==",
+      "version": "0.4.29",
+      "resolved": "https://registry.npmjs.org/@openma/deepseek-harness-acp/-/deepseek-harness-acp-0.4.29.tgz",
+      "integrity": "sha512-6FbEqyv5a/u9m0H0sV0keljI7PYUFsFmtBUaBmRXWbgzJc5K6VI/xhgyj/WBLUho1dsESM9ImPTAPTFLCdVi/w==",
       "license": "Apache-2.0",
       "dependencies": {
         "@agentclientprotocol/sdk": "1.4.0",

--- a/npm/package.json
+++ b/npm/package.json
@@ -75,7 +75,7 @@
   },
   "dependencies": {
     "@deepseek-ai/cordis": "^4.0.1",
-    "@openma/deepseek-harness-acp": "0.4.27"
+    "@openma/deepseek-harness-acp": "0.4.29"
   },
   "devDependencies": {
     "@deepseek-ai/dsh": "0.1.1-rc.2"


### PR DESCRIPTION
## Problem

`dsh --profile martty` fails to boot after dsh 0.1.2-rc.1: the plugin tree
loads but `tui-acp-host` never provides `agentPresets`/`acpServer`, leaving
the runner and creator-overlay pending:

```
Error: dsh: 2 entries did not activate
@openma/deepseek-harness-tui/creator-overlay: pending (waiting for services: agentPresets, dynamicCordisRunner)
@openma/deepseek-harness-tui/runner: pending (waiting for service: acpServer)
```

Root cause: the embedded ACP host plugin (pinned 0.4.27) resolves shipped
agent presets only from the legacy `@deepseek-ai/dsh/config/agent-presets`
directory. dsh 0.1.2-rc.1 removed that layout — presets now ship inside
`@deepseek-ai/dsh-agent-presets` itself — so `shippedPresetRoot()` throws
`cannot resolve the dsh shipped agent presets` and the whole host surface
fails to activate.

## Fix

Bump `@openma/deepseek-harness-acp` 0.4.27 → 0.4.29 (published the same day
as dsh 0.1.2-rc.1). 0.4.29's `shippedPresetRoots()` falls back to a
self-shipping `@deepseek-ai/dsh-agent-presets` and lets the roster
self-ship via `includeShippedRoot`, so the profile host mounts cleanly.

Verified: after the bump, `dsh --profile martty` boots into the interactive
TUI (checked under a pty; previously it aborted during plugin-tree load).

## Changes

- `npm/package.json` + `npm/package-lock.json`: ACP dependency 0.4.27 → 0.4.29
- `CHANGELOG.md`: Fixed entry under [Unreleased]

(npm-martty is generated from npm/ via package-alias and regenerated locally.)