### PR TITLE
fix(tui): pace redraws and stop hidden subagent output from repainting; build: devlocalinstall.sh builds the shipped release profile by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,6 +134,11 @@ All notable changes to this project are documented here. The project follows
 
 ### Fixed
 
+- High CPU usage while multiple subagents stream into a long conversation:
+  hidden subagent output no longer repaints the visible transcript, ordinary
+  streaming redraws are paced, and event batches are bounded so painting and
+  input keep progressing. Tool requests and user input still paint immediately.
+
 - Bold Markdown table text now follows the selected body color mode while
   retaining its emphasis, fixing emphasized text appearing darker than
   surrounding text in single-tone mode, especially with the One theme.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,6 +132,12 @@ All notable changes to this project are documented here. The project follows
   instead of being wrapped apart like prose. Tables that already fit the
   width are painted unchanged.
 
+- `scripts/devlocalinstall.sh` now builds the shipped `release` Cargo
+  profile (fat LTO, stripped) by default and swaps the built binary into
+  the installed bundle under `dsh --profile <name>`;
+  `DSH_TUI_CARGO_PROFILE=devlocal` opts back into the fast debug build
+  loop when quick turnaround matters more than release fidelity.
+
 ### Fixed
 
 - High CPU usage while multiple subagents stream into a long conversation:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,11 +38,10 @@ tokio = { version = "1.53.1", features = ["test-util"] }
 lto = true
 strip = true
 
-# Fast local build profile for `scripts/devlocalinstall.sh` (and local
+# Opt-in fast local build profile (DSH_TUI_CARGO_PROFILE=devlocal for
+# `scripts/devlocalinstall.sh`, or `cargo build --profile devlocal` while
 # iterating): plain debug codegen — no optimizations, incremental — the
-# fastest turnaround for build/test loops; the shipped npm packages keep
-# [profile.release] (fat LTO, stripped) untouched. If the debug binary runs
-# too slow for a big workspace, DSH_TUI_CARGO_PROFILE=release falls back to
-# the shipped config.
+# fastest turnaround for build/test loops. `scripts/devlocalinstall.sh` and
+# the shipped npm packages build [profile.release] (fat LTO, stripped).
 [profile.devlocal]
 inherits = "dev"

--- a/README.en.md
+++ b/README.en.md
@@ -264,10 +264,11 @@ From this checkout (need `cargo build --release` or `scripts/build-npm.sh`, bina
 MARTTY_BIN=$(pwd)/target/release/martty martty --agent dsh-acp
 ```
 
-For local iterating, `scripts/devlocalinstall.sh` builds with the fast
-`devlocal` Cargo profile (debug codegen, incremental — the quickest
-turnaround) and stages the binary into the running `dsh --profile <name>`
-setup; `DSH_TUI_CARGO_PROFILE=release` restores the shipped config.
+For local iterating, `scripts/devlocalinstall.sh` builds the shipped
+`release` Cargo profile (fat LTO, stripped — same binary the npm bundles
+carry), then swaps it into the bundle installed under the running
+`dsh --profile <name>` setup;
+`DSH_TUI_CARGO_PROFILE=devlocal` opts back into the fast debug build loop.
 
 Third-party capabilities are ordinary Cordis plugins on the client tree: they
 declare the services they need, register contributions in `apply`, and retract

--- a/scripts/devlocalinstall.sh
+++ b/scripts/devlocalinstall.sh
@@ -7,11 +7,13 @@ cd "$(dirname "${BASH_SOURCE[0]}")/.."
 # primary dev profile). Must match the `dsh --profile <name>` you run.
 PROFILE="${1:-${DSH_TUI_PROFILE:-martty}}"
 
-# Cargo profile for the local build: devlocal (debug codegen) by default —
-# the fastest turnaround for build/test loops; release matches the shipped
-# npm bundles when the debug binary is too slow. The names map 1:1 to the
-# [profile.*] sections in Cargo.toml.
-CARGO_PROFILE="${DSH_TUI_CARGO_PROFILE:-devlocal}"
+# Cargo profile for the local build: release by default — the same fat-LTO,
+# stripped binary the shipped npm bundles carry, so what gets installed
+# behaves like a real install (and runs fast enough for big workspaces).
+# DSH_TUI_CARGO_PROFILE=devlocal opts back into the fast debug-codegen loop
+# when a quick build/test turnaround matters more than fidelity. The names
+# map 1:1 to the [profile.*] sections in Cargo.toml.
+CARGO_PROFILE="${DSH_TUI_CARGO_PROFILE:-release}"
 
 # 1. Build first so the installed copy always reflects the current source.
 # The target dir must match where cargo actually writes (CARGO_TARGET_DIR
@@ -23,7 +25,7 @@ if [ "$TARGET_DIR" = "target" ]; then
   TARGET_DIR="$(pwd)/target"
 fi
 BIN="${TARGET_DIR}/${CARGO_PROFILE}/martty"
-echo "building $BIN (cargo build --profile $CARGO_PROFILE --locked)…" >&2
+echo "building $BIN (cargo build --profile $CARGO_PROFILE --locked; first release build takes a while — fat LTO)…" >&2
 cargo build --profile "$CARGO_PROFILE" --locked
 
 # 2. Resolve exactly the binary `dsh --profile $PROFILE` runs — no hardcoded

--- a/src/app.rs
+++ b/src/app.rs
@@ -3568,7 +3568,8 @@ impl App {
                         self.dispatch_session_queue(&session, ctl);
                     }
                 }
-                self.needs_redraw = true;
+                // apply_ui decides whether a fact affects the visible
+                // frame; background chunks and unknown notifications do not.
             }
             AppEvent::RuntimeStderr(_line) => {
                 // kept in proto's tail buffer for diagnostics; stay quiet here
@@ -4433,8 +4434,12 @@ impl App {
         if let Some(session) = ui_session(&ui) {
             if session != self.session_id {
                 if let Some(view) = self.subagents.iter_mut().find(|view| view.id == session) {
+                    let visible = self.active_subagent.as_deref() == Some(session);
                     view.transcript.apply(ui);
-                    self.needs_redraw = true;
+                    // Hidden child output only changes its own transcript.
+                    // Lifecycle events above still redraw the Agents dock;
+                    // tick drives its running animation independently.
+                    self.needs_redraw |= visible;
                     return;
                 }
                 for slot in &mut self.parked {
@@ -4445,7 +4450,6 @@ impl App {
                     }
                     if let Some(view) = slot.subagents.iter_mut().find(|view| view.id == session) {
                         view.transcript.apply(ui);
-                        self.needs_redraw = true;
                         return;
                     }
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,7 +32,7 @@ use std::io::Write;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc;
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use anyhow::{bail, Context, Result};
 use crossterm::cursor::{Hide, MoveTo, Show};
@@ -255,11 +255,12 @@ fn build_config(args: &Args) -> Result<RuntimeConfig> {
     })
 }
 
-/// A tool request is a semantic UI transition, not just another foldable
-/// transport update. Stop the current receive burst after applying it so the
-/// pending request gets one real frame before a fast result can complete it.
+/// Input must stay responsive, and a tool request needs one real frame
+/// before a fast result can complete it. Both end the receive batch and
+/// bypass the ordinary streaming frame interval.
 fn event_requires_immediate_frame(event: &AppEvent) -> bool {
     match event {
+        AppEvent::Term(_) | AppEvent::PermissionAsk { .. } | AppEvent::ElicitationAsk { .. } => true,
         AppEvent::Ui(events::UiEvent::ToolCall { .. }) => true,
         AppEvent::Rpc { method, params } if method == "session/update" => {
             params
@@ -279,6 +280,64 @@ fn event_requires_immediate_frame(event: &AppEvent) -> bool {
         }
         _ => false,
     }
+}
+
+const FRAME_INTERVAL: Duration = Duration::from_millis(33);
+const IDLE_WAIT: Duration = Duration::from_millis(50);
+const MAX_EVENT_BATCH: usize = 256;
+
+struct FramePacer {
+    next_frame: Instant,
+    immediate: bool,
+}
+
+impl FramePacer {
+    fn new(now: Instant) -> Self {
+        Self {
+            next_frame: now,
+            immediate: false,
+        }
+    }
+
+    fn ready(&self, now: Instant, dirty: bool) -> bool {
+        dirty && (self.immediate || now >= self.next_frame)
+    }
+
+    fn painted(&mut self, now: Instant) {
+        // Leave time for input/transport even when a long history makes
+        // painting itself take longer than the target frame interval.
+        self.next_frame = now + FRAME_INTERVAL;
+        self.immediate = false;
+    }
+
+    fn wait(&self, now: Instant, dirty: bool) -> Duration {
+        if !dirty {
+            IDLE_WAIT
+        } else if self.immediate {
+            Duration::ZERO
+        } else {
+            self.next_frame
+                .saturating_duration_since(now)
+                .min(IDLE_WAIT)
+        }
+    }
+}
+
+fn collect_event_batch(first: AppEvent, rx: &mpsc::Receiver<AppEvent>) -> (Vec<AppEvent>, bool) {
+    let mut immediate = event_requires_immediate_frame(&first);
+    let mut batch = Vec::new();
+    // A continuously fed channel must still yield to painting, ticks and
+    // shutdown. Keep the first tool request/input event as the last item.
+    while !immediate && batch.len() + 1 < MAX_EVENT_BATCH {
+        let Ok(event) = rx.try_recv() else { break };
+        immediate = event_requires_immediate_frame(&event);
+        batch.push(event);
+    }
+    // Coalesce the queued tail, keeping the received event as a separate
+    // transition just as in the unpaced event loop.
+    crate::events::coalesce_session_updates(&mut batch);
+    batch.insert(0, first);
+    (batch, immediate)
 }
 
 fn main() -> Result<()> {
@@ -452,11 +511,12 @@ fn main() -> Result<()> {
 
     let run = (|| -> Result<()> {
         let mut last_tick = std::time::Instant::now();
+        let mut frames = FramePacer::new(Instant::now());
         loop {
             if app.harness_switch_in_progress() {
                 let _ = repair_tui_raw_mode();
             }
-            if app.needs_redraw {
+            if frames.ready(Instant::now(), app.needs_redraw) {
                 // One atomic frame. Synchronized updates (DECSET 2026) make
                 // supporting terminals apply the whole frame without tearing.
                 // The caret itself is painted as buffer cells (ui::paint_caret)
@@ -500,40 +560,26 @@ fn main() -> Result<()> {
                     }
                     Ok(())
                 })??;
+                frames.painted(Instant::now());
             }
+            // While a harness switch owns the terminal, poll tightly so
+            // raw-mode repair and switch progress stay prompt; otherwise
+            // defer to the frame pacer (input stays immediate through
+            // frames.immediate).
             let event_wait = if app.harness_switch_in_progress() {
-                Duration::from_millis(10)
+                frames
+                    .wait(Instant::now(), app.needs_redraw)
+                    .min(Duration::from_millis(10))
             } else {
-                Duration::from_millis(50)
+                frames.wait(Instant::now(), app.needs_redraw)
             };
             match bus_rx.recv_timeout(event_wait) {
                 Ok(ev) => {
-                    let render_boundary = event_requires_immediate_frame(&ev);
-                    app.handle(ev, &controller);
-                    // Drain ordinary transport chatter into one frame, but
-                    // never fold a tool start together with its result. Fast
-                    // background tools can otherwise begin and finish inside
-                    // the same receive burst, making the request invisible.
-                    if !render_boundary {
-                        // Buffer the burst and coalesce adjacent session
-                        // deltas first: agents may stream updates at extreme
-                        // rates (session/load replay storm, issue #94), and
-                        // applying each delta individually melts the loop.
-                        // The buffer stops right after a frame-boundary
-                        // event, preserving the original drain semantics.
-                        let mut burst: Vec<bus::AppEvent> = Vec::new();
-                        while let Ok(ev) = bus_rx.try_recv() {
-                            let boundary = event_requires_immediate_frame(&ev);
-                            burst.push(ev);
-                            if boundary {
-                                break;
-                            }
-                        }
-                        crate::events::coalesce_session_updates(&mut burst);
-                        for ev in burst {
-                            app.handle(ev, &controller);
-                        }
+                    let (batch, immediate) = collect_event_batch(ev, &bus_rx);
+                    for ev in batch {
+                        app.handle(ev, &controller);
                     }
+                    frames.immediate |= immediate && app.needs_redraw;
                 }
                 Err(mpsc::RecvTimeoutError::Timeout) => {}
                 Err(mpsc::RecvTimeoutError::Disconnected) => break,
@@ -558,6 +604,7 @@ fn main() -> Result<()> {
                 enter_tui()?;
                 input_gate.unpark();
                 app.needs_redraw = true;
+                frames.immediate = true;
                 while let Ok(ev) = bus_rx.try_recv() {
                     if !matches!(ev, AppEvent::Term(_)) {
                         app.handle(ev, &controller);

--- a/tests/unit/app__session_tabs_tests.rs
+++ b/tests/unit/app__session_tabs_tests.rs
@@ -52,6 +52,20 @@ fn final_event(session: &str, text: &str) -> crate::events::UiEvent {
     }
 }
 
+fn child_chunk(child: &str, text: &str) -> AppEvent {
+    AppEvent::Rpc {
+        method: "session/update".into(),
+        params: serde_json::json!({
+            "sessionId": "dsh-test",
+            "update": {
+                "sessionUpdate": "agent_message_chunk",
+                "content": { "type": "text", "text": text },
+                "_meta": { "dsh": { "subagent": { "childSessionId": child } } }
+            }
+        }),
+    }
+}
+
 #[test]
 fn harness_handoff_discards_old_connection_tabs_and_pending_binds() {
     let (mut app, ctl, _rx) = test_app();
@@ -225,7 +239,7 @@ fn unknown_session_events_never_reach_any_transcript() {
 
 #[test]
 fn parked_subagent_events_land_in_parked_subagent_transcript() {
-    let (mut app, _ctl, _rx) = test_app();
+    let (mut app, ctl, _rx) = test_app();
     app.apply_ui(crate::events::UiEvent::SubagentStarted {
         parent: "dsh-test".into(),
         child: "sub-1".into(),
@@ -237,7 +251,9 @@ fn parked_subagent_events_land_in_parked_subagent_transcript() {
     assert_eq!(app.parked[0].id, "dsh-test");
     assert_eq!(app.parked[0].subagents.len(), 1);
 
-    app.apply_ui(final_event("sub-1", "subagent answer in background"));
+    app.needs_redraw = false;
+    app.handle(child_chunk("sub-1", "subagent answer in background"), &ctl);
+    assert!(!app.needs_redraw, "a parked child cannot change the visible frame");
 
     let sub_text = transcript_text(&mut app.parked[0].subagents[0].transcript);
     assert!(
@@ -245,6 +261,52 @@ fn parked_subagent_events_land_in_parked_subagent_transcript() {
         "subagent event reached parked subagent transcript:\n{sub_text}"
     );
     assert!(!transcript_text(&mut app.transcript).contains("subagent answer"));
+}
+
+#[test]
+fn hidden_subagent_streams_are_retained_without_repainting_the_parent() {
+    let (mut app, _demo_ctl, _rx) = test_app();
+    let (ctl, commands) = crate::controller::tests::test_controller();
+    app.demo = false;
+    for child in ["sub-1", "sub-2", "sub-3"] {
+        app.apply_ui(crate::events::UiEvent::SubagentStarted {
+            parent: "dsh-test".into(), child: child.into(),
+        });
+    }
+    app.needs_redraw = false;
+    for _ in 0..10 {
+        for child in ["sub-1", "sub-2", "sub-3"] {
+            app.handle(child_chunk(child, "chunk "), &ctl);
+        }
+    }
+    assert!(!app.needs_redraw);
+    assert_eq!(commands.try_iter().count(), 0, "chunks do not republish navigation snapshots");
+    for view in &mut app.subagents {
+        let crate::transcript::CellKind::Assistant { text, .. } = &view.transcript.cells[0].kind else {
+            panic!("expected the child's streamed message");
+        };
+        assert_eq!(text, &"chunk ".repeat(10));
+    }
+
+    app.handle(AppEvent::Rpc {
+        method: crate::cordis::AGENTS_SELECT.into(),
+        params: serde_json::json!({ "protocol": 0, "id": "sub-2" }),
+    }, &ctl);
+    assert!(app.needs_redraw, "switching to a child immediately reveals its saved output");
+    assert_eq!(transcript_text(app.displayed_transcript_mut()).matches("chunk").count(), 10);
+    app.needs_redraw = false;
+    app.apply_ui(final_event("sub-1", "hidden final"));
+    assert!(!app.needs_redraw, "a sibling's final does not repaint the selected child");
+    app.apply_ui(final_event("sub-2", "visible final"));
+    assert!(app.needs_redraw);
+    assert!(transcript_text(app.displayed_transcript_mut()).contains("visible final"));
+
+    app.needs_redraw = false;
+    app.apply_ui(crate::events::UiEvent::SubagentFinished {
+        child: "sub-1".into(), failed: false,
+    });
+    assert!(app.needs_redraw, "completion still updates navigation for a hidden child");
+    assert!(!app.subagents[0].running);
 }
 
 #[test]

--- a/tests/unit/main__event_batch_tests.rs
+++ b/tests/unit/main__event_batch_tests.rs
@@ -66,3 +66,99 @@ fn decoded_and_legacy_tool_calls_use_the_same_frame_boundary() {
     assert!(event_requires_immediate_frame(&decoded));
     assert!(event_requires_immediate_frame(&legacy));
 }
+
+#[test]
+fn continuous_streaming_has_a_frame_limit_and_flushes_the_last_update() {
+    let start = Instant::now();
+    let mut frames = FramePacer::new(start);
+    let mut painted = 0;
+    // An update every millisecond must not turn into 1000 frames/second.
+    for millis in 0..1000 {
+        let now = start + Duration::from_millis(millis);
+        if frames.ready(now, true) {
+            painted += 1;
+            frames.painted(now);
+        }
+    }
+    assert_eq!(painted, 31);
+
+    let end = start + Duration::from_millis(1000);
+    let wait = frames.wait(end, true);
+    assert!(wait > Duration::ZERO && wait <= FRAME_INTERVAL);
+    assert!(frames.ready(end + wait, true), "flush even if no more messages arrive");
+    frames.painted(end + wait);
+    assert_eq!(frames.wait(end + Duration::from_secs(1), false), IDLE_WAIT);
+    assert!(!frames.ready(end + Duration::from_secs(1), false));
+}
+
+#[test]
+fn fast_tool_result_waits_until_the_request_gets_an_immediate_frame() {
+    let now = Instant::now();
+    let mut frames = FramePacer::new(now);
+    frames.painted(now);
+    let (tx, rx) = mpsc::channel();
+    let text = AppEvent::Ui(events::UiEvent::TextDelta {
+        session: "root".into(), text: "working".into(),
+    });
+    tx.send(AppEvent::Ui(events::UiEvent::ToolCall {
+        session: "root".into(), call_id: "fast".into(), name: "bash".into(), arguments: "{}".into(),
+    })).unwrap();
+    tx.send(AppEvent::Ui(events::UiEvent::ToolResult {
+        session: "root".into(), call_id: "fast".into(), is_error: false, text: "done".into(), error: None,
+    })).unwrap();
+
+    let (batch, immediate) = collect_event_batch(text, &rx);
+    assert_eq!(batch.len(), 2);
+    assert!(matches!(batch.last(), Some(AppEvent::Ui(events::UiEvent::ToolCall { .. }))));
+    assert!(!frames.ready(now, true));
+    frames.immediate = immediate;
+    assert!(frames.ready(now, true), "request bypasses streaming throttle");
+    frames.painted(now);
+
+    let (result, immediate) = collect_event_batch(rx.try_recv().unwrap(), &rx);
+    assert!(matches!(result.as_slice(), [AppEvent::Ui(events::UiEvent::ToolResult { .. })]));
+    assert!(!immediate);
+    assert!(!frames.ready(now, true), "ordinary updates resume pacing after the request");
+}
+
+#[test]
+fn input_interrupts_a_receive_burst_and_bypasses_the_frame_interval() {
+    let now = Instant::now();
+    let mut frames = FramePacer::new(now);
+    frames.painted(now);
+    let (tx, rx) = mpsc::channel();
+    let input = AppEvent::Term(crossterm::event::Event::Key(
+        crossterm::event::KeyEvent::new(
+            crossterm::event::KeyCode::Char('x'), crossterm::event::KeyModifiers::NONE,
+        ),
+    ));
+    tx.send(AppEvent::Ui(events::UiEvent::TextDelta {
+        session: "root".into(), text: "later".into(),
+    })).unwrap();
+
+    let (batch, immediate) = collect_event_batch(input, &rx);
+    assert_eq!(batch.len(), 1);
+    frames.immediate = immediate;
+    assert!(frames.ready(now, true));
+    assert_eq!(frames.wait(now, true), Duration::ZERO);
+    assert!(rx.try_recv().is_ok(), "transport after input waits for its frame");
+}
+
+#[test]
+fn receive_batches_yield_with_backlog_and_preserve_every_event() {
+    let (tx, rx) = mpsc::channel();
+    for n in 0..600 {
+        tx.send(AppEvent::Ui(events::UiEvent::TextDelta {
+            session: "root".into(), text: n.to_string(),
+        })).unwrap();
+    }
+    let (first, immediate) = collect_event_batch(rx.try_recv().unwrap(), &rx);
+    assert!(!immediate);
+    assert!(first.len() < 600, "the UI must regain control before draining the backlog");
+    let mut texts = Vec::new();
+    for event in first.into_iter().chain(rx.try_iter()) {
+        let AppEvent::Ui(events::UiEvent::TextDelta { text, .. }) = event else { panic!("expected delta") };
+        texts.push(text);
+    }
+    assert_eq!(texts, (0..600).map(|n| n.to_string()).collect::<Vec<_>>());
+}


### PR DESCRIPTION
## Problem

- High CPU usage while multiple subagents stream into a long conversation: hidden child output only mutated its own transcript yet forced repaints of the visible frame, streaming redraws were unpaced, and unbounded event batches could starve painting, input, and shutdown.
- `scripts/devlocalinstall.sh` built the fast debug-codegen `devlocal` profile, so the binary installed under `dsh --profile <name>` did not behave like a shipped install and ran too slowly for big workspaces.

## Fix

- **fix(tui): pace redraws and stop hidden subagent output from repainting** — hidden child output no longer forces a repaint of the visible frame, streaming redraws are paced by a `FramePacer` (~30 fps), and event batches are bounded so painting, input and shutdown keep progressing. Tool requests, permission/elicitation asks and user input still paint immediately. The event loop also keeps the harness-switch raw-mode repair (10 ms poll while a switch owns the terminal) alongside the paced loop.
- **build: devlocalinstall.sh builds the shipped release profile by default** — the script now builds the `release` profile (fat LTO, stripped) and swaps the binary into the installed bundle; `DSH_TUI_CARGO_PROFILE=devlocal` opts back into the quick build/test loop when turnaround matters more than release fidelity.

## Tests

- `hidden_subagent_streams_are_retained_without_repainting_the_parent` — hidden subagent streams stay in the parked transcript without repainting the visible parent.
- `main__event_batch_tests`: `receive_batches_yield_with_backlog_and_preserve_every_event`, `continuous_streaming_has_a_frame_limit_and_flushes_the_last_update`, `fast_tool_result_waits_until_the_request_gets_an_immediate_frame`, and `input_interrupts_a_receive_burst_and_bypasses_the_frame_interval`.

Verified with `cargo test --locked` (full run gated by CI).
