### PR TITLE
feat(tui): live theme preview on highlight; Enter confirms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,13 @@ All notable changes to this project are documented here. The project follows
   flow; Esc closes without switching. Removal dialogs support stepwise back navigation.
 - CLI and TUI walkthroughs, README quick starts and screenshots.
 - Plan progress uses an animated running marker and a distinct in-progress label.
+- Theme selection previews in both picker surfaces without confirming:
+  moving the highlight in the `/theme` dialog (↑/↓, pgup/pgdn, home/end,
+  mouse wheel) or across the `/theme ` slash popup candidates immediately
+  previews that palette on screen — stopped Theme Plugins preview from
+  their registered token maps. Only Enter confirms and switches the theme
+  (loading the owning Plugin and persisting the preference); Esc or moving
+  the highlight off the row reverts to the confirmed theme.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -141,7 +141,10 @@ Cordis Plugin Package
 
 Theme Plugin 与明暗模式彼此独立。使用 `/theme` 选择 Theme Plugin，使用
 `/theme toggle` 或 `ctrl+t` 切换当前 Theme Plugin 的 dark/light 变体。输入
-`/theme ` 时，上拉候选会把 `toggle` 与 Theme Plugin 分区显示。
+`/theme ` 时，上拉候选会把 `toggle` 与 Theme Plugin 分区显示。在 `/theme`
+对话框与 `/theme ` 上拉候选里移动高亮（↑/↓、翻页键、滚轮）会**即时预览**
+高亮所在的主题包，方便逐套对比——此时只是预览，并未确定；按 **Enter** 才真正
+切换 Theme Plugin 并持久化；按 Esc 或把高亮移开则会回到已经确定的主题。
 
 ### 六个 Slot
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -1281,6 +1281,15 @@ pub struct App {
     pub tone_mode: ToneMode,
     pub palettes: Vec<crate::theme::PalettePack>,
     pub active_palette_id: String,
+    /// Palette currently only *previewed* (dialog row or `/theme ` slash
+    /// candidate under the highlight) but not yet confirmed with Enter.
+    /// Preview repaints `theme` without touching `active_palette_id`, so
+    /// Esc or a moved highlight reverts to the committed theme.
+    theme_preview: Option<String>,
+    /// Palette confirmed with Enter whose Theme Plugin has not delivered
+    /// its loaded palette yet. The preview colors stay on screen (no flash
+    /// back to the old theme) until the palette arrival commits it.
+    theme_pending: Option<String>,
     /// Persisted UI Preset id. The Client compositor owns activation; Rust
     /// keeps this only as a startup fallback before slot snapshots arrive.
     pub ui_preset: String,
@@ -1827,6 +1836,8 @@ impl App {
             tone_mode,
             palettes,
             active_palette_id: "default".into(),
+            theme_preview: None,
+            theme_pending: None,
             ui_preset: settings.ui_preset,
             slot_snapshots: HashMap::new(),
             transcript: Transcript::new(session_id.clone()),
@@ -2514,6 +2525,10 @@ impl App {
         if !self.palettes.iter().any(|p| p.id == id) {
             return;
         }
+        // A commit (Enter, or the palette arrival of a pending Enter)
+        // supersedes any preview still on screen.
+        self.theme_preview = None;
+        self.theme_pending = None;
         self.active_palette_id = id.to_string();
         self.sync_theme_from_active();
         self.show_tip(self.locale.trf(
@@ -2527,7 +2542,12 @@ impl App {
     }
 
     fn select_palette(&mut self, id: &str, ctl: &Controller) {
-        let Some(palette) = self.palettes.iter().find(|palette| palette.id == id) else {
+        let Some(palette) = self
+            .palettes
+            .iter()
+            .find(|palette| palette.id == id)
+            .cloned()
+        else {
             return;
         };
         if palette.loaded {
@@ -2538,6 +2558,18 @@ impl App {
                 "正在加载主题插件 {}…",
                 &[id.to_string()],
             ));
+            // Enter confirmed this pack: paint its registered colors right
+            // away and keep them on screen while the Plugin loads, so the
+            // commit never flashes back to the previous theme. The loaded
+            // palette arrival converts the pending preview into the
+            // committed theme (`activate_palette`).
+            if self.active_palette_id != id {
+                let mode = self.theme.mode;
+                self.theme = palette.theme(mode);
+                self.theme_preview = Some(id.to_string());
+                self.theme_pending = Some(id.to_string());
+                self.needs_redraw = true;
+            }
         }
         ctl.send(Cmd::PluginThemeSelected {
             agent_id: self.session_id.clone(),
@@ -2553,6 +2585,105 @@ impl App {
             .find(|p| p.id == self.active_palette_id)
         {
             self.theme = pack.theme(mode);
+        }
+    }
+
+    /// Live-switch the painter to a palette's colors without committing it:
+    /// arrows over the theme dialog rows or the `/theme ` slash candidates
+    /// only *preview*. The committed palette stays `active_palette_id`
+    /// until Enter (`select_palette`); Esc or a moved highlight restores
+    /// the committed theme. Stopped packs carry their full token maps from
+    /// registration, so previews are pixel-exact either way.
+    fn preview_palette(&mut self, id: &str) {
+        if self.active_palette_id == id {
+            // Highlight back on the committed pack — nothing to preview.
+            self.clear_theme_preview();
+            return;
+        }
+        let Some(pack) = self.palettes.iter().find(|palette| palette.id == id) else {
+            return;
+        };
+        let mode = self.theme.mode;
+        self.theme = pack.theme(mode);
+        self.theme_preview = Some(id.to_string());
+        // A different palette was previewed → the pending Enter commit for
+        // the previous one is stale; only Enter re-arms it.
+        if self.theme_pending.as_deref().is_some_and(|pending| pending != id) {
+            self.theme_pending = None;
+        }
+        self.needs_redraw = true;
+    }
+
+    /// Drop a pending palette preview and repaint the committed theme.
+    fn clear_theme_preview(&mut self) {
+        if self.theme_preview.take().is_some() || self.theme_pending.is_some() {
+            self.theme_pending = None;
+            self.sync_theme_from_active();
+            self.needs_redraw = true;
+        }
+    }
+
+    /// The palette candidate under the open `/theme ` slash popup highlight,
+    /// if the row names a registered pack (never the dark/light toggle row).
+    fn slash_theme_candidate(&self) -> Option<String> {
+        if self.slash_completion_dismissed {
+            return None;
+        }
+        let matches = self.slash_matches();
+        if matches.is_empty() {
+            return None;
+        }
+        let entry = matches.get(self.slash_sel.min(matches.len() - 1))?;
+        if entry.plugin || entry.skill || entry.name != "theme" {
+            return None;
+        }
+        entry
+            .completion
+            .as_deref()
+            .and_then(|completion| completion.strip_prefix("/theme "))
+            .map(str::to_string)
+    }
+
+    /// The open theme dialog applies the row under the highlight.
+    fn preview_picker_theme(&mut self) {
+        let Some(id) = self.picker.as_ref().and_then(|picker| {
+            (picker.kind == PickerKind::Theme)
+                .then(|| picker.items.get(picker.sel))
+                .flatten()
+                .map(|item| item.id.clone())
+        }) else {
+            return;
+        };
+        self.preview_palette(&id);
+    }
+
+    /// The open `/theme ` slash popup applies the palette candidate under
+    /// the highlight; non-palette rows (`toggle` dark/light) never fire.
+    fn preview_slash_theme(&mut self) {
+        if let Some(id) = self.slash_theme_candidate() {
+            self.preview_palette(&id);
+        }
+    }
+
+    /// A palette preview only lives while its row is still highlighted (or
+    /// its Enter commit is still loading its Plugin). Every handled event
+    /// ends here, so Esc, a closed list, a moved highlight or an edited
+    /// draft reverts to the committed theme — preview never sticks.
+    fn reconcile_theme_preview(&mut self) {
+        if self.theme_preview.is_none() {
+            return;
+        }
+        let preview = match self.theme_preview.clone() {
+            Some(preview) => preview,
+            None => return,
+        };
+        let still_highlighted = self.picker.as_ref().is_some_and(|picker| {
+            picker.kind == PickerKind::Theme
+                && picker.items.get(picker.sel).is_some_and(|item| item.id == preview)
+        }) || self.slash_theme_candidate().as_deref() == Some(preview.as_str());
+        let commit_loading = self.theme_pending.as_deref() == Some(preview.as_str());
+        if !still_highlighted && !commit_loading {
+            self.clear_theme_preview();
         }
     }
 
@@ -2619,8 +2750,8 @@ impl App {
             title: self
                 .locale
                 .tr(
-                    " theme · enter apply · esc close · /theme toggle · ctrl+t ",
-                    " 主题 · enter 应用 · esc 关闭 · /theme toggle · ctrl+t ",
+                    " theme · ↑↓ preview · enter apply · esc close · ctrl+t ",
+                    " 主题 · ↑↓ 预览 · enter 确定 · esc 关闭 · ctrl+t ",
                 )
                 .into(),
             sel,
@@ -3159,6 +3290,10 @@ impl App {
         let agents_before = (!self.demo).then(|| self.agents_fingerprint());
         let active_before = (!self.demo).then(|| (self.session_id.clone(), self.session_bound));
         self.handle_inner(ev, ctl);
+        // Previewed palettes never stick: after every event, a preview that
+        // is no longer under a highlight (and whose Enter commit is not
+        // still loading) reverts the painter to the committed theme.
+        self.reconcile_theme_preview();
         // A turn ran on the picked model → the stream is the truth again.
         if self.selected_model.is_some()
             && self.selected_model.as_deref() == self.transcript.last_model.as_deref()
@@ -5086,6 +5221,8 @@ impl App {
     /// notch never teleports the highlight to the list tail.
     fn picker_scroll_by(&mut self, delta: i64) {
         let Some(picker) = &mut self.picker else { return };
+        let kind = picker.kind;
+        let sel_before = picker.sel;
         let last = picker.items.len().saturating_sub(1);
         if delta < 0 {
             picker.sel = picker
@@ -5096,6 +5233,16 @@ impl App {
             picker.sel = picker.sel.saturating_add(delta as usize).min(last);
         }
         self.needs_redraw = true;
+        // One notch equals one ↑/↓ press, so the theme dialog previews the
+        // pack the wheel moved the highlight onto.
+        if kind == PickerKind::Theme
+            && self
+                .picker
+                .as_ref()
+                .is_some_and(|picker| picker.sel != sel_before)
+        {
+            self.preview_picker_theme();
+        }
     }
 
     /// Wheel over an ACP permission ask (which floats above host pickers)
@@ -5863,6 +6010,9 @@ impl App {
                     _ => {}
                 }
                 if matches!(key.code, KeyCode::Up | KeyCode::Down) {
+                    // The `/theme ` candidate popup previews the palette the
+                    // highlight just landed on (mirrors the theme dialog).
+                    self.preview_slash_theme();
                     return;
                 }
             }
@@ -6450,10 +6600,12 @@ impl App {
         let Some(picker) = &mut self.picker else {
             return;
         };
+        let kind = picker.kind;
         let n = picker.items.len().max(1);
         // Page keys jump a screenful of the open popup (rows recorded by the
         // draw pass); they never wrap, unlike ↑/↓.
         let page = self.picker_page_rows.max(1);
+        let sel_before = picker.sel;
         match key.code {
             KeyCode::Esc => self.picker = None,
             KeyCode::Up => picker.sel = picker.sel.checked_sub(1).unwrap_or(n - 1),
@@ -6562,6 +6714,26 @@ impl App {
                 }
             }
             _ => {}
+        }
+        // The theme dialog lives on its highlight: moving the selection
+        // instantly applies the palette row under it, without waiting for
+        // Enter. Enter above still closes and commits (Theme-Plugin load +
+        // persisted preference); Esc just closes and keeps the preview.
+        if kind == PickerKind::Theme
+            && matches!(
+                key.code,
+                KeyCode::Up
+                    | KeyCode::Down
+                    | KeyCode::PageUp
+                    | KeyCode::PageDown
+                    | KeyCode::Home
+                    | KeyCode::End
+            )
+            && self.picker.as_ref().is_some_and(|picker| {
+                picker.kind == PickerKind::Theme && picker.sel != sel_before
+            })
+        {
+            self.preview_picker_theme();
         }
     }
 

--- a/tests/unit/app__palette_tests.rs
+++ b/tests/unit/app__palette_tests.rs
@@ -369,13 +369,13 @@ fn theme_picker_can_leave_and_return_to_a_dynamic_plugin_pack() {
     );
     assert_eq!(picker.sel, 1, "the active dynamic pack is preselected");
 
-    app.handle_key(KeyEvent::new(KeyCode::Up, KeyModifiers::NONE), &ctl);
-    app.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE), &ctl);
+    app.handle(AppEvent::Term(Event::Key(KeyEvent::new(KeyCode::Up, KeyModifiers::NONE))), &ctl);
+    app.handle(AppEvent::Term(Event::Key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE))), &ctl);
     assert_eq!(app.active_palette_id, "default");
 
     app.run_slash("theme", "", &ctl);
-    app.handle_key(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE), &ctl);
-    app.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE), &ctl);
+    app.handle(AppEvent::Term(Event::Key(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE))), &ctl);
+    app.handle(AppEvent::Term(Event::Key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE))), &ctl);
     assert_eq!(app.active_palette_id, "ember");
     assert_eq!(app.theme.brand, Color::Rgb(247, 140, 60));
 }
@@ -426,6 +426,242 @@ fn invalid_palette_keeps_previous_theme() {
     );
     assert_eq!(app.active_palette_id, "default");
     assert_eq!(app.theme.brand, DEEPSEEK_450);
+}
+
+#[test]
+fn theme_dialog_arrows_preview_and_only_enter_commits() {
+    let (mut app, ctl, _rx) = test_app();
+    app.handle(
+        AppEvent::Rpc {
+            method: crate::cordis::THEME_UPDATE.into(),
+            params: ember_params(false),
+        },
+        &ctl,
+    );
+    app.handle(
+        AppEvent::Rpc {
+            method: crate::cordis::THEME_UPDATE.into(),
+            params: gallery_params("ayu", false),
+        },
+        &ctl,
+    );
+    app.run_slash("theme", "", &ctl);
+    let picker = app.picker.as_ref().expect("theme picker opens");
+    assert_eq!(
+        picker
+            .items
+            .iter()
+            .map(|item| item.id.as_str())
+            .collect::<Vec<_>>(),
+        ["default", "ember", "ayu"]
+    );
+    assert_eq!(app.active_palette_id, "default");
+
+    // One ↓ lands on ember: the painter previews ember immediately, but the
+    // committed theme is still "default" — arrows never confirm.
+    app.handle(AppEvent::Term(Event::Key(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE))), &ctl);
+    assert_eq!(app.theme.brand, Color::Rgb(247, 140, 60)); // ember dark brand
+    assert_eq!(
+        app.active_palette_id, "default",
+        "arrows only preview; the committed theme must stay default"
+    );
+    assert!(
+        app.picker.is_some(),
+        "preview must keep the dialog open for further browsing"
+    );
+
+    // ↓ again → ayu preview, still uncommitted.
+    app.handle(AppEvent::Term(Event::Key(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE))), &ctl);
+    assert_eq!(app.active_palette_id, "default");
+    assert!(app.picker.is_some());
+
+    // Home jumps back onto the committed row → the preview is gone.
+    app.handle(AppEvent::Term(Event::Key(KeyEvent::new(KeyCode::Home, KeyModifiers::NONE))), &ctl);
+    assert_eq!(app.theme.brand, DEEPSEEK_450);
+    assert_eq!(app.active_palette_id, "default");
+
+    // ↓ to ember, then Enter confirms: dialog closes and ember commits.
+    app.handle(AppEvent::Term(Event::Key(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE))), &ctl);
+    assert_eq!(app.theme.brand, Color::Rgb(247, 140, 60));
+    assert_eq!(app.active_palette_id, "default", "still only previewed");
+    app.handle(AppEvent::Term(Event::Key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE))), &ctl);
+    assert!(app.picker.is_none());
+    assert_eq!(app.active_palette_id, "ember");
+    assert_eq!(app.theme.brand, Color::Rgb(247, 140, 60));
+}
+
+#[test]
+fn theme_dialog_esc_reverts_the_preview_to_the_committed_theme() {
+    let (mut app, ctl, _rx) = test_app();
+    app.handle(
+        AppEvent::Rpc {
+            method: crate::cordis::THEME_UPDATE.into(),
+            params: ember_params(false),
+        },
+        &ctl,
+    );
+    app.run_slash("theme", "", &ctl);
+    assert_eq!(app.theme.brand, DEEPSEEK_450);
+
+    // Preview ember with ↓ and with the wheel…
+    app.handle(AppEvent::Term(Event::Key(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE))), &ctl);
+    assert_eq!(app.theme.brand, Color::Rgb(247, 140, 60));
+    app.handle(AppEvent::Term(Event::Key(KeyEvent::new(KeyCode::Up, KeyModifiers::NONE))), &ctl);
+    assert_eq!(app.theme.brand, DEEPSEEK_450);
+    app.handle(
+        AppEvent::Term(Event::Mouse(crossterm::event::MouseEvent {
+            kind: crossterm::event::MouseEventKind::ScrollDown,
+            column: 40,
+            row: 10,
+            modifiers: crossterm::event::KeyModifiers::NONE,
+        })),
+        &ctl,
+    );
+    assert_eq!(app.theme.brand, Color::Rgb(247, 140, 60));
+    assert!(app.picker.is_some(), "wheel preview keeps the dialog open");
+
+    // …Esc closes without confirming: the committed theme comes back.
+    app.handle(AppEvent::Term(Event::Key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE))), &ctl);
+    assert!(app.picker.is_none());
+    assert_eq!(app.active_palette_id, "default");
+    assert_eq!(
+        app.theme.brand, DEEPSEEK_450,
+        "Esc must revert the preview — arrows never confirm"
+    );
+}
+
+#[test]
+fn slash_theme_popup_previews_and_reverts_without_enter() {
+    let (mut app, ctl, _rx) = test_app();
+    app.handle(
+        AppEvent::Rpc {
+            method: crate::cordis::THEME_UPDATE.into(),
+            params: ember_params(false),
+        },
+        &ctl,
+    );
+    app.input.set("/theme ".into());
+    app.snap_slash_sel();
+    assert!(
+        app.slash_completion_open(),
+        "the /theme candidate popup must be open"
+    );
+    assert_eq!(app.slash_sel, 1, "default row is the current theme");
+    assert_eq!(app.active_palette_id, "default");
+
+    // ↓ to ember → preview only; draft and popup stay, theme uncommitted.
+    app.handle(AppEvent::Term(Event::Key(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE))), &ctl);
+    assert_eq!(app.theme.brand, Color::Rgb(247, 140, 60));
+    assert_eq!(app.active_palette_id, "default");
+    assert!(
+        app.slash_completion_open(),
+        "preview must not consume the draft"
+    );
+
+    // ↓ wraps to the dark/light toggle row — no theme highlighted, so the
+    // committed theme shows again.
+    app.handle(AppEvent::Term(Event::Key(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE))), &ctl);
+    assert_eq!(app.theme.brand, DEEPSEEK_450);
+    assert_eq!(app.active_palette_id, "default");
+
+    // ↓↓ back onto ember, then Esc dismisses the popup and reverts too.
+    app.handle(AppEvent::Term(Event::Key(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE))), &ctl);
+    app.handle(AppEvent::Term(Event::Key(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE))), &ctl);
+    assert_eq!(app.theme.brand, Color::Rgb(247, 140, 60));
+    app.handle(AppEvent::Term(Event::Key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE))), &ctl);
+    assert!(!app.slash_completion_open());
+    assert_eq!(
+        app.theme.brand, DEEPSEEK_450,
+        "Esc must revert the popup preview"
+    );
+}
+
+#[test]
+fn slash_theme_popup_enter_commits_the_previewed_palette() {
+    let (mut app, ctl, _rx) = test_app();
+    app.handle(
+        AppEvent::Rpc {
+            method: crate::cordis::THEME_UPDATE.into(),
+            params: ember_params(false),
+        },
+        &ctl,
+    );
+    app.input.set("/theme ".into());
+    app.snap_slash_sel();
+    app.handle(AppEvent::Term(Event::Key(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE))), &ctl);
+    assert_eq!(app.theme.brand, Color::Rgb(247, 140, 60));
+    assert_eq!(app.active_palette_id, "default");
+
+    // Enter on the highlighted ember row is the confirmation.
+    app.handle(AppEvent::Term(Event::Key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE))), &ctl);
+    assert_eq!(app.active_palette_id, "ember");
+    assert_eq!(app.theme.brand, Color::Rgb(247, 140, 60));
+    assert!(
+        app.input.is_empty(),
+        "Enter on a candidate runs the command and clears the draft"
+    );
+}
+
+#[test]
+fn dialog_stopped_pack_preview_is_transient_and_enter_holds_it_while_loading() {
+    let (mut app, ctl, _rx) = test_app();
+    let mut loaded = ember_params(false);
+    loaded["owner"] = json!({ "pluginId": "night-lime-1" });
+    loaded["loaded"] = json!(true);
+    app.handle(
+        AppEvent::Rpc {
+            method: crate::cordis::THEME_UPDATE.into(),
+            params: loaded,
+        },
+        &ctl,
+    );
+    let mut stopped = ember_params(false);
+    stopped["owner"] = json!({ "pluginId": "night-lime-1" });
+    stopped["loaded"] = json!(false);
+    app.handle(
+        AppEvent::Rpc {
+            method: crate::cordis::THEME_UPDATE.into(),
+            params: stopped,
+        },
+        &ctl,
+    );
+    let (client_ctl, commands) = crate::controller::tests::test_controller();
+    app.run_slash("theme", "", &client_ctl);
+
+    // The stopped pack's stored token map previews while the Plugin stays
+    // stopped — arrows need no client round trip and confirm nothing.
+    app.handle(AppEvent::Term(Event::Key(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE))), &client_ctl);
+    assert_eq!(app.theme.brand, Color::Rgb(247, 140, 60));
+    assert_eq!(app.active_palette_id, "default");
+    assert!(
+        commands
+            .recv_timeout(std::time::Duration::from_millis(50))
+            .is_err(),
+        "preview alone must not ask the client Theme registry"
+    );
+
+    // Esc without Enter reverts the preview.
+    app.handle(AppEvent::Term(Event::Key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE))), &client_ctl);
+    assert!(app.picker.is_none());
+    assert_eq!(app.theme.brand, DEEPSEEK_450);
+
+    // Enter confirms: the client registry is asked, and the previewed
+    // colors stay on screen while the Plugin loads (no flash to default).
+    app.run_slash("theme", "", &client_ctl);
+    app.handle(AppEvent::Term(Event::Key(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE))), &client_ctl);
+    assert_eq!(app.theme.brand, Color::Rgb(247, 140, 60));
+    app.handle(AppEvent::Term(Event::Key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE))), &client_ctl);
+    assert!(app.picker.is_none());
+    assert_eq!(app.active_palette_id, "default");
+    assert_eq!(
+        app.theme.brand, Color::Rgb(247, 140, 60),
+        "the confirmed pack must not flash back while its Plugin loads"
+    );
+    assert!(matches!(
+        commands.recv_timeout(std::time::Duration::from_secs(1)),
+        Ok(Cmd::PluginThemeSelected { agent_id, id })
+            if agent_id == app.session_id && id == "ember"
+    ));
 }
 
 #[test]


### PR DESCRIPTION
### 需求
用户在选择主题时（slash popup 与 `/theme` dialog 两种界面），上下移动高亮即可**即时预览**主题；预览不等于确定，按 **Enter** 才算确定（真正切换 Theme Plugin 并持久化）。

### 行为
- `/theme` 对话框与 `/theme ` 上拉候选里移动高亮（↑/↓、PgUp/PgDn、Home/End、滚轮）会立即把界面预览成高亮主题的颜色；
- 预览是瞬态的：只有 Enter 提交（切换已确定主题、加载 Theme Plugin、持久化偏好）；Esc、移开高亮或关闭/离开列表都会回到已确定的主题；
- “✓ 当前”标记始终指向已确定主题（`active_palette_id`），高亮行只表示预览；
- 已停止的 Theme Plugin 用注册时下发的完整 token map 预览（像素级一致）；Enter 确认后颜色保持、不闪回旧主题，插件 palette 到达后正式转正提交。

### 实现（src/app.rs）
- 新增 `theme_preview` / `theme_pending` 状态：预览只重画 `self.theme`，不动 `active_palette_id`；
- `preview_palette` / `preview_picker_theme` / `preview_slash_theme` 统一预览入口；
- `reconcile_theme_preview()` 在每个 `handle()` 事件后收敛：预览只有在高亮仍在那一行或 Enter 提交仍在加载时才保留，否则还原到已确定主题；
- `activate_palette()`（提交原语）清理残留预览；`select_palette()` 对 stopped 插件先落预览色并置 pending。

### 测试
- 新增/改写 6 个用例（tests/unit/app__palette_tests.rs）：对话框箭头“预览但不提交”、Esc（键盘+滚轮）还原、Enter 才提交、slash popup 预览/移开 toggle 行还原/Esc 还原/Enter 提交、stopped 包预览瞬时且 Enter 后不闪回（预览阶段不发 Client 请求，Enter 后才发 `PluginThemeSelected`）。
- `cargo test --locked`：773 passed / 0 failed；`cargo check --locked --tests` 通过。

### 文档
- README.md、CHANGELOG.md（[Unreleased]）同步描述“预览 vs Enter 确定”语义。