### PR TITLE
Two small status meta-row tweaks in the TUI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@ All notable changes to this project are documented here. The project follows
 
 ### Fixed
 
+- The scroll-position indicator beside the model chip now reads `↓ N` instead
+  of an up-pointing triangle.
+- The model chip in the meta row now uses the same muted color as the reasoning
+  effort label beside it, instead of the brand accent.
 - Harness switching reinitializes ACP and starts a fresh empty session. All old
   connection projections and requests are cleared, while session-scoped state
   remains isolated across tabs within one connection. Saved configuration is

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1715,14 +1715,14 @@ fn meta_line(app: &App, width: usize) -> Line<'static> {
         let mut compact = Vec::new();
         if app.scroll_up > 0 {
             compact.push(Span::styled(
-                format!("▲{} · ", app.scroll_up),
+                format!("↓ {} · ", app.scroll_up),
                 Style::default().fg(theme.caption),
             ));
         }
         if let Some(shown_model) = &shown_model {
             compact.push(Span::styled(
                 format!("{shown_model} "),
-                Style::default().fg(theme.brand_soft),
+                Style::default().fg(theme.caption),
             ));
         }
         let compact_width = span_widths(&compact);
@@ -1735,7 +1735,7 @@ fn meta_line(app: &App, width: usize) -> Line<'static> {
             let shown_model = shown_model.expect("checked above");
             right_spans = vec![Span::styled(
                 format!("{shown_model} "),
-                Style::default().fg(theme.brand_soft),
+                Style::default().fg(theme.caption),
             )];
         } else {
             right_spans = Vec::new();
@@ -1992,7 +1992,7 @@ fn status_right(app: &App) -> Vec<Span<'static>> {
     }
     if app.scroll_up > 0 {
         spans.push(Span::styled(
-            format!("▲{} · ", app.scroll_up),
+            format!("↓ {} · ", app.scroll_up),
             Style::default().fg(theme.caption),
         ));
     }
@@ -2001,7 +2001,7 @@ fn status_right(app: &App) -> Vec<Span<'static>> {
         if let Some(shown_model) = displayed_model(app) {
             spans.push(Span::styled(
                 shown_model,
-                Style::default().fg(theme.brand_soft),
+                Style::default().fg(theme.caption),
             ));
             if let Some(effort) = &app.modes.effort {
                 spans.push(Span::styled(

--- a/tests/unit/ui__tests.rs
+++ b/tests/unit/ui__tests.rs
@@ -2497,7 +2497,7 @@ fn scroll_up_survives_draw_and_shows_indicator() {
     app.scroll_by(20);
     let frame = dump_frame(&mut app, 100, 14);
     assert!(app.scroll_up > 0, "scroll_up clamped to zero");
-    assert!(frame.contains("▲"), "scroll indicator missing:\n{frame}");
+    assert!(frame.contains("↓"), "scroll indicator missing:\n{frame}");
 }
 
 #[test]


### PR DESCRIPTION
Two small status meta-row tweaks in the TUI:

Scroll indicator: the scrolled-up position marker beside the model chip
now reads ↓ N (downward arrow) instead of an up-pointing triangle.
Model chip color: the model name now uses the same muted caption tone as
the reasoning-effort label (max) beside it, instead of the brand accent.
Verification

cargo check --locked --tests — clean (only pre-existing warnings).
cargo test --locked model_chip — 2 passed.
cargo test --locked scroll_up_survives_draw_and_shows_indicator — 1 passed.