### PR TITLE
fix(tui): strip emoji variation selectors to avoid tofu black blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,11 @@ All notable changes to this project are documented here. The project follows
 
 ### Fixed
 
+- Markdown rendering no longer emits stray emoji/text variation selectors
+  (`U+FE0F` / `U+FE0E`, e.g. the one that makes `⚠️` a black block): a terminal
+  monospace font without the emoji glyph draws the orphaned selector as a tofu
+  black block, so it is stripped to let the base glyph fall back to its
+  always-renderable text form (issue #120).
 - The scroll-position indicator beside the model chip now reads `↓ N` instead
   of an up-pointing triangle.
 - The model chip in the meta row now uses the same muted color as the reasoning

--- a/src/markdown.rs
+++ b/src/markdown.rs
@@ -32,6 +32,8 @@ use tui_markdown::{AlertKind, ImageFallback, Options, StyleSheet};
 use unicode_segmentation::UnicodeSegmentation;
 use unicode_width::UnicodeWidthStr;
 
+use std::borrow::Cow;
+
 use crate::theme::{
     Theme, DEEPSEEK_200, DEEPSEEK_300, DEEPSEEK_400, DEEPSEEK_450, DEEPSEEK_500, DEEPSEEK_600,
     DEEPSEEK_800, DEEPSEEK_900,
@@ -70,9 +72,15 @@ impl ToneMode {
 /// `tone` picks the body-color scheme (see [`ToneMode`]).
 pub fn render(text: &str, theme: &Theme, tone: ToneMode, width: usize) -> Vec<Line<'static>> {
     let width = width.max(8);
+    // Emoji presentation selectors (U+FE0F / U+FE0E) are zero-width and only
+    // meaningful when the terminal font has the matching emoji glyph. A plain
+    // monospace font without one draws the orphaned selector as a solid tofu
+    // box — the stray "black block" that showed up in table cells (issue #120).
+    // Strip them so the base glyph falls back to its text presentation.
+    let text = strip_emoji_variation_selectors(text);
     let options =
         Options::new(DeepSeekStyleSheet(*theme)).image_fallback(ImageFallback::AltTextAndUrl);
-    let parsed = tui_markdown::from_str_with_options(text, &options);
+    let parsed = tui_markdown::from_str_with_options(&text, &options);
 
     let mut out: Vec<Line<'static>> = Vec::new();
     let mut in_code = false;
@@ -109,7 +117,7 @@ pub fn render(text: &str, theme: &Theme, tone: ToneMode, width: usize) -> Vec<Li
                 out.push(with_prefix(&code_prefix, code_frame_top(lang, frame_width, theme)));
                 // tui-markdown joins separate Text events in quoted code.
                 // Preserve their exact newlines from the parser instead.
-                let content = code_blocks.get_or_insert_with(|| code_block_texts(text))
+                let content = code_blocks.get_or_insert_with(|| code_block_texts(&text))
                     .pop_front().unwrap_or_default();
                 let inner = frame_width - 4;
                 for raw in content.lines() {
@@ -349,6 +357,22 @@ fn code_block_texts(text: &str) -> std::collections::VecDeque<String> {
 
 fn segments_width(segs: &[Seg]) -> usize {
     segs.iter().map(|s| s.text.width()).sum()
+}
+
+/// Drop emoji/text variation selectors (U+FE0F, U+FE0E) — zero-width
+/// presentational-form modifiers. A terminal font that only ships the text
+/// presentation of the base glyph (e.g. `⚠`) paints the orphaned selector as a
+/// tofu black block; stripping it lets the base glyph render cleanly in every
+/// font. Cheap for the common case: borrowed as-is when no selector is present.
+fn strip_emoji_variation_selectors(text: &str) -> Cow<'_, str> {
+    if !text.contains('\u{fe0f}') && !text.contains('\u{fe0e}') {
+        return Cow::Borrowed(text);
+    }
+    Cow::Owned(
+        text.chars()
+            .filter(|c| *c != '\u{fe0f}' && *c != '\u{fe0e}')
+            .collect(),
+    )
 }
 
 fn with_prefix(prefix: &[Seg], mut line: Line<'static>) -> Line<'static> {

--- a/tests/unit/markdown__tests.rs
+++ b/tests/unit/markdown__tests.rs
@@ -744,3 +744,39 @@ fn deeply_nested_lists_keep_the_body_inside_the_viewport() {
         assert!(plain(&lines).contains("long"));
     }
 }
+
+#[test]
+fn emoji_variation_selectors_do_not_leak_tofu_black_blocks() {
+    // `⚠️` (U+26A0 + U+FE0F) in a table cell: a monospace terminal font
+    // without the emoji-presentation glyph draws the orphaned variation
+    // selector as a tofu black block. The fallback must be the bare `⚠`.
+    let md = "| 项目 | 结果 |\n|---|---|\n| zig build test (PR head) | ⚠️ 8577 过 / 18 跳过 / 30 失败 / 7 崩溃 |";
+    let lines = render_dark(md, 60);
+    let text = plain(&lines);
+    assert!(!text.contains('\u{fe0f}'), "stray variation selector-16 in: {text:?}");
+    assert!(!text.contains('\u{fe0e}'), "stray variation selector-15 in: {text:?}");
+    assert!(text.contains('\u{26a0}'), "warning base glyph kept: {text:?}");
+    assert!(text.contains("8577"), "cell content kept: {text:?}");
+    // Every rendered line keeps the box width — no half-width leftover from
+    // the selector shifting the frame geometry.
+    let widths: Vec<usize> = lines.iter().map(|l| line_width(l)).collect();
+    let first = widths[0];
+    for (l, w) in lines.iter().zip(&widths) {
+        assert_eq!(*w, first, "all frame lines share the box width: {}", plain(std::slice::from_ref(l)));
+    }
+}
+
+#[test]
+fn emoji_variation_selectors_are_stripped_in_prose_code_and_blockquote() {
+    for md in [
+        "before ⚠️ after",
+        "> quoted ⚠️ text",
+        "`inline ⚠️ code`",
+        "```\ncode ⚠️ line\n```",
+    ] {
+        let lines = render_dark(md, 40);
+        let text = plain(&lines);
+        assert!(!text.contains('\u{fe0f}'), "selector leaked for {md:?}: {text:?}");
+        assert!(text.contains('\u{26a0}'), "base glyph dropped for {md:?}: {text:?}");
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #120 — a stray **black block** appearing in Markdown-rendered table cells, right before the pass counts (e.g. `⚠️ 8577 过 / 18 跳过 / 30 失败 / 7 崩溃`).

The cell text is `⚠️`, which is two code points: the warning sign **`U+26A0`** plus the **variation selector `U+FE0F`** that requests emoji presentation. Markdown rendering passed this through verbatim. Most monospace terminal fonts only ship the *text* presentation of `⚠` and have no emoji glyph to combine the selector with, so the orphaned `U+FE0F` gets drawn as a **tofu black block** — exactly the reported "黑块".

The other table rows confirm the diagnosis: `✅` and `⛔` render fine because they are inherently-emoji single code points that need no variation selector. Martty's own UI chrome already uses the plain `⚠` glyph without a selector, so stripping the selector is the intended fallback.

## Change

In `src/markdown.rs`, add `strip_emoji_variation_selectors` and call it at the top of `render()`. It removes the zero-width presentational-form selectors `U+FE0F` / `U+FE0E`, letting the base glyph fall back to its always-renderable text presentation.

- Cheap no-op (`Cow::Borrowed`) when no selector is present.
- Covers prose, blockquotes, inline code, fenced code blocks, and table cells.
- Does not split grapheme clusters (family/flag emoji unaffected).

## Verification

- Reproduced the exact issue table: prior output contained `⚠\u{fe0f}`; after the fix it renders `⚠ 8577 …` with `CONTAINS_FE0F=false` and unchanged frame width.
- Added two regression tests covering table cells and prose/blockquote/code paths.
- `cargo test --locked`: 775 passed, 0 failed. `cargo check --locked --tests`: clean (only two pre-existing, unrelated warnings).
- Added a `CHANGELOG.md` `[Unreleased]` → `Fixed` entry.