### PR TITLE
fix(tui): grapheme metrics, switch errors, atomic settings, mux UTF-8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,27 @@ All notable changes to this project are documented here. The project follows
 
 ### Fixed
 
+- Transcript wrapping, picker/status truncation and the composer layout mirror
+  now measure grapheme clusters (via `UnicodeWidthStr`) instead of summing
+  per-`char` widths. ZWJ family emoji, skin-tone modifiers and variation
+  selectors stay on one line and no longer push a line past its pane budget
+  (a family emoji counted as 6 cells instead of 2).
+- A rejected `/model` or effort switch is reported instead of silently dropped:
+  the agent's error lands in the owning session's transcript and the optimistic
+  chip/effort reverts, while a successful switch folds the response's
+  `configOptions` back even when the agent sends no notification.
+- `settings.json` is written through a same-directory temp file plus rename
+  (painter and compositor both write it), and a file that exists but cannot be
+  parsed is quarantined as `settings.json.corrupt-<timestamp>` instead of being
+  silently replaced with `{}` (which dropped theme/UI-preset/harness keys).
+- A full queue shelf or input dock plus an expanded draft on a short terminal
+  no longer overflows the frame and panics (`index outside of buffer`): the
+  chrome stack compresses the optional dock rows, then the draft viewport, then
+  the queue shelf before layout, and the composer's direct buffer writes are
+  clipped to the frame as a fallback.
+- ACP frames no longer corrupt multi-byte UTF-8 characters split across stream
+  chunk boundaries. The mux now decodes with a `StringDecoder` (agent→TUI and
+  TUI→agent), instead of decoding each chunk independently into U+FFFD.
 - Markdown rendering no longer emits stray emoji/text variation selectors
   (`U+FE0F` / `U+FE0E`, e.g. the one that makes `⚠️` a black block): a terminal
   monospace font without the emoji glyph draws the orphaned selector as a tofu

--- a/npm/lib/mux.js
+++ b/npm/lib/mux.js
@@ -9,6 +9,7 @@
  * off the painter.
  */
 
+import { StringDecoder } from 'node:string_decoder'
 import { CORDIS_CAPABILITY, CORDIS_METHODS, readCordisCapability } from './cordis-protocol.js'
 
 const COMPOSITOR_METHODS = Object.freeze(new Set([
@@ -95,13 +96,20 @@ export function writeJsonLine(dest, value) {
 
 /**
  * Pipe NDJSON, invoking `onLine` for each complete line (trimmed, non-empty).
+ *
+ * Frames are UTF-8: decoding each chunk with `chunk.toString('utf8')` would
+ * turn any multi-byte character split across a chunk boundary into U+FFFD
+ * replacement characters (silent corruption in both directions). A
+ * `StringDecoder` carries the incomplete tail across chunks, and `end()`
+ * flushes a final frame that arrived without a trailing newline.
+ *
  * @param {import('node:stream').Readable} source
  * @param {(line: string) => void} onLine
  */
 export function onJsonLines(source, onLine) {
   let buffer = ''
-  source.on('data', (chunk) => {
-    buffer += chunk.toString('utf8')
+  const decoder = new StringDecoder('utf8')
+  const drain = () => {
     for (;;) {
       const newline = buffer.indexOf('\n')
       if (newline < 0) break
@@ -110,6 +118,17 @@ export function onJsonLines(source, onLine) {
       if (line.length === 0) continue
       onLine(line)
     }
+  }
+  source.on('data', (chunk) => {
+    buffer += typeof chunk === 'string' ? chunk : decoder.write(chunk)
+    drain()
+  })
+  source.on('end', () => {
+    buffer += decoder.end()
+    drain()
+    const line = buffer.trim()
+    buffer = ''
+    if (line.length > 0) onLine(line)
   })
 }
 

--- a/npm/lib/tui-presets.js
+++ b/npm/lib/tui-presets.js
@@ -1,6 +1,6 @@
 /** UI Presets compose several UI plugin contributions into one saved choice. */
 
-import { mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { mkdirSync, readFileSync, renameSync, writeFileSync } from 'node:fs'
 import path from 'node:path'
 import { Service } from '@deepseek-ai/cordis'
 import { CORDIS_METHODS } from './cordis-protocol.js'
@@ -72,7 +72,13 @@ function writePreferred(settingsPath, id) {
   const settings = readSettings(settingsPath)
   settings.uiPreset = id
   mkdirSync(path.dirname(settingsPath), { recursive: true })
-  writeFileSync(settingsPath, `${JSON.stringify(settings, null, 2)}\n`)
+  // Atomic write (temp + rename), matching tui-theme.js: a crash mid-write
+  // must never leave a truncated settings.json behind — every later launch
+  // would otherwise start from an unreadable file that also carries the
+  // painter's language/themeMode keys.
+  const temporary = `${settingsPath}.${process.pid}.${Date.now()}.tmp`
+  writeFileSync(temporary, `${JSON.stringify(settings, null, 2)}\n`)
+  renameSync(temporary, settingsPath)
 }
 
 function releaseOf(value) {

--- a/scripts/mux.test.mjs
+++ b/scripts/mux.test.mjs
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict'
 import { PassThrough } from 'node:stream'
 import test from 'node:test'
-import { isCompositorMessage, muxAcpAndCompositor } from '../npm/lib/mux.js'
+import { isCompositorMessage, muxAcpAndCompositor, onJsonLines } from '../npm/lib/mux.js'
 
 test('compositor methods stay off the agent stream', () => {
   assert.equal(isCompositorMessage({ method: '_dsh/cordis/tui/theme/update' }), true)
@@ -246,4 +246,88 @@ test('mux keeps Cordis disabled when the initialize response omits the capabilit
       error: { code: -32601, message: 'agent has not advertised _dsh/cordis' },
     },
   )
+})
+
+test('mux decodes multi-byte UTF-8 split across chunks in both directions', async () => {
+  const agentIn = new PassThrough()
+  const agentOut = new PassThrough()
+  const tuiIn = new PassThrough()
+  const tuiOut = new PassThrough()
+  const toAgent = []
+  const toTui = []
+  // Keep Buffers: decoding each chunk with String(chunk) in the assertion
+  // harness would itself mangle a split character and hide the regression.
+  agentIn.on('data', (chunk) => toAgent.push(chunk))
+  tuiOut.on('data', (chunk) => toTui.push(chunk))
+
+  muxAcpAndCompositor({
+    agent: { stdin: agentIn, stdout: agentOut },
+    tui: { input: tuiIn, output: tuiOut },
+  })
+
+  const agentFrame = Buffer.from(`${JSON.stringify({
+    jsonrpc: '2.0',
+    method: 'session/update',
+    params: {
+      sessionId: 's',
+      update: {
+        sessionUpdate: 'agent_message_chunk',
+        content: { type: 'text', text: '中文测试 👨‍👩‍👧' },
+      },
+    },
+  })}\n`, 'utf8')
+  // Split inside the 3-byte 中 and the 4-byte family emoji.
+  const agentCut = agentFrame.indexOf(Buffer.from('中', 'utf8')) + 1
+  const agentCut2 = agentFrame.indexOf(Buffer.from('👨', 'utf8')) + 2
+  agentOut.write(agentFrame.subarray(0, agentCut))
+  await new Promise((resolve) => setImmediate(resolve))
+  agentOut.write(agentFrame.subarray(agentCut, agentCut2))
+  await new Promise((resolve) => setImmediate(resolve))
+  agentOut.write(agentFrame.subarray(agentCut2))
+
+  const tuiFrame = Buffer.from(`${JSON.stringify({
+    jsonrpc: '2.0',
+    id: 9,
+    method: 'initialize',
+    params: { clientInfo: { name: '中文' } },
+  })}\n`, 'utf8')
+  const tuiCut = tuiFrame.indexOf(Buffer.from('中', 'utf8')) + 2
+  tuiIn.write(tuiFrame.subarray(0, tuiCut))
+  await new Promise((resolve) => setImmediate(resolve))
+  tuiIn.write(tuiFrame.subarray(tuiCut))
+
+  await new Promise((resolve) => setTimeout(resolve, 20))
+
+  const updates = Buffer.concat(toTui)
+    .toString('utf8')
+    .trim()
+    .split('\n')
+    .filter(Boolean)
+    .map((line) => JSON.parse(line))
+  const update = updates.find((message) => message.method === 'session/update')
+  assert.equal(update.params.update.content.text, '中文测试 👨‍👩‍👧')
+
+  const requests = Buffer.concat(toAgent)
+    .toString('utf8')
+    .trim()
+    .split('\n')
+    .filter(Boolean)
+    .map((line) => JSON.parse(line))
+  const initialize = requests.find((message) => message.method === 'initialize')
+  assert.equal(initialize.params.clientInfo.name, '中文')
+})
+
+test('onJsonLines carries split characters and flushes a final unterminated line', async () => {
+  const source = new PassThrough()
+  const lines = []
+  onJsonLines(source, (line) => lines.push(line))
+  const frame = Buffer.from(JSON.stringify({ text: '👨‍👩‍👧 中文' }), 'utf8')
+  const cut = frame.indexOf(Buffer.from('👨', 'utf8')) + 2
+  source.write(frame.subarray(0, cut))
+  await new Promise((resolve) => setImmediate(resolve))
+  source.write(frame.subarray(cut))
+  source.end()
+  await new Promise((resolve) => setImmediate(resolve))
+  assert.equal(lines.length, 1)
+  assert.equal(JSON.parse(lines[0]).text, '👨‍👩‍👧 中文')
 })

--- a/scripts/tui-presets.test.mjs
+++ b/scripts/tui-presets.test.mjs
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict'
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { mkdtempSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
 import test from 'node:test'
@@ -163,4 +163,46 @@ test('UI Plugin catalog retains stopped dynamic owners and routes restore throug
   await commands.run('focused')
   assert.deepEqual(restored, [{ id: 'focused', owner: 'panel-1' }])
   service.dispose()
+})
+
+test('UI preset writes are atomic and preserve unrelated settings keys', async () => {
+  assert.equal(typeof presetsPlugin.installTuiPresets, 'function')
+  if (typeof presetsPlugin.installTuiPresets !== 'function') return
+
+  const root = mkdtempSync(path.join(tmpdir(), 'martty-ui-presets-atomic-'))
+  const settingsPath = path.join(root, 'settings.json')
+  writeFileSync(
+    settingsPath,
+    JSON.stringify({ language: 'zh', theme: 'ember', customKey: 7 }),
+  )
+  const inodeBefore = statSync(settingsPath).ino
+  const commands = commandService()
+  const service = presetsPlugin.installTuiPresets({ tuiCommands: commands }, { settingsPath })
+  service.register({ id: 'default', label: 'Martty' }, () => () => {})
+  service.register({ id: 'deepseek', label: 'DeepSeek' }, () => () => {})
+
+  service.activate('deepseek')
+
+  assert.deepEqual(JSON.parse(readFileSync(settingsPath, 'utf8')), {
+    language: 'zh',
+    theme: 'ember',
+    customKey: 7,
+    uiPreset: 'deepseek',
+  })
+  assert.deepEqual(
+    readdirSync(root).filter((name) => name.endsWith('.tmp')),
+    [],
+    'atomic write must not leave temp files behind',
+  )
+  if (process.platform !== 'win32') {
+    // temp + rename replaces the directory entry, so the inode changes; an
+    // in-place writeFileSync would keep the original inode.
+    assert.notEqual(
+      statSync(settingsPath).ino,
+      inodeBefore,
+      'expected a rename-based (atomic) write',
+    )
+  }
+  service.dispose()
+  rmSync(root, { recursive: true, force: true })
 })

--- a/src/acp/control.rs
+++ b/src/acp/control.rs
@@ -147,7 +147,7 @@ async fn run_control(
                         _ => model.clone(),
                     }
                 };
-                let _ = cx
+                match cx
                     .send_request(SetSessionConfigOptionRequest::new(
                         sid.clone(),
                         "model",
@@ -155,39 +155,71 @@ async fn run_control(
                     ))
                     .block_task_deadline()
                     .await
-                    .map_err(|err| {
-                        if is_auth_required_error(&err) {
-                            emit_needs_auth_open(
-                                &bus,
-                                methods.clone(),
-                                selected.as_ref(),
-                                Some(acp_error_message(&err)),
-                            );
+                {
+                    Ok(response) => {
+                        // Fold the authoritative configOptions back even when
+                        // the agent sends no notification, like SetConfigOption.
+                        if let Ok(value) = serde_json::to_value(&response) {
+                            let _ = apply_config_response(&value, &sid, &surface, &bus);
                         }
-                    });
+                    }
+                    Err(err) if is_auth_required_error(&err) => {
+                        emit_needs_auth_open(
+                            &bus,
+                            methods.clone(),
+                            selected.as_ref(),
+                            Some(acp_error_message(&err)),
+                        );
+                    }
+                    Err(err) => {
+                        let _ = bus.send(AppEvent::Ctl(CtlEvent::ModelSwitchFailed {
+                            session_id: sid.to_string(),
+                            model: Some(model),
+                            effort: None,
+                            message: format!("model switch failed: {err}"),
+                        }));
+                    }
+                }
             }
             if let Some(effort) = effort {
-                let config_id = surface.lock().unwrap_or_else(|e| e.into_inner())
-                    .session(&sid.0).effort_config_id.clone()
+                let config_id = surface
+                    .lock()
+                    .unwrap_or_else(|e| e.into_inner())
+                    .session(&sid.0)
+                    .effort_config_id
+                    .clone()
                     .unwrap_or_else(|| "effort".into());
-                let _ = cx
+                match cx
                     .send_request(SetSessionConfigOptionRequest::new(
-                        sid,
+                        sid.clone(),
                         config_id,
-                        SessionConfigOptionValue::value_id(effort),
+                        SessionConfigOptionValue::value_id(effort.clone()),
                     ))
                     .block_task_deadline()
                     .await
-                    .map_err(|err| {
-                        if is_auth_required_error(&err) {
-                            emit_needs_auth_open(
-                                &bus,
-                                methods.clone(),
-                                selected.as_ref(),
-                                Some(acp_error_message(&err)),
-                            );
+                {
+                    Ok(response) => {
+                        if let Ok(value) = serde_json::to_value(&response) {
+                            let _ = apply_config_response(&value, &sid, &surface, &bus);
                         }
-                    });
+                    }
+                    Err(err) if is_auth_required_error(&err) => {
+                        emit_needs_auth_open(
+                            &bus,
+                            methods.clone(),
+                            selected.as_ref(),
+                            Some(acp_error_message(&err)),
+                        );
+                    }
+                    Err(err) => {
+                        let _ = bus.send(AppEvent::Ctl(CtlEvent::ModelSwitchFailed {
+                            session_id: sid.to_string(),
+                            model: None,
+                            effort: Some(effort),
+                            message: format!("effort switch failed: {err}"),
+                        }));
+                    }
+                }
             }
         }
         Cmd::FetchStaticPlugins => match fetch_static_plugins(&cx).await {

--- a/src/app.rs
+++ b/src/app.rs
@@ -3849,6 +3849,44 @@ impl App {
                             slot.transcript.push_notice(NoticeLevel::Error, message);
                         }
                     }
+                    CtlEvent::ModelSwitchFailed {
+                        session_id,
+                        model,
+                        effort,
+                        message,
+                    } => {
+                        // The agent rejected a switch the UI had already shown
+                        // optimistically: revert that value in the owning tab
+                        // and surface the error instead of leaving a lie.
+                        if session_id == self.session_id {
+                            if let Some(model) = &model {
+                                if self.selected_model.as_deref() == Some(model.as_str()) {
+                                    self.selected_model = None;
+                                }
+                            }
+                            if let Some(effort) = &effort {
+                                if self.modes.effort.as_deref() == Some(effort.as_str()) {
+                                    self.modes.effort = None;
+                                }
+                            }
+                            self.transcript.push_notice(NoticeLevel::Error, message);
+                        } else if let Some(slot) = self.parked.iter_mut()
+                            .find(|slot| slot.id == session_id)
+                        {
+                            if let Some(model) = &model {
+                                if slot.selected_model.as_deref() == Some(model.as_str()) {
+                                    slot.selected_model = None;
+                                }
+                            }
+                            if let Some(effort) = &effort {
+                                if slot.modes.effort.as_deref() == Some(effort.as_str()) {
+                                    slot.modes.effort = None;
+                                }
+                            }
+                            slot.transcript.push_notice(NoticeLevel::Error, message);
+                        }
+                        self.needs_redraw = true;
+                    }
                     CtlEvent::SessionError {
                         session_id,
                         message,
@@ -5457,9 +5495,9 @@ impl App {
         {
             return settings;
         }
-        if current.exists() {
-            return UiSettings::default();
-        }
+        // A current file that exists but does not parse is quarantined by the
+        // next save; until then fall through to the legacy file rather than
+        // silently dropping the user's preferences.
         let legacy = legacy_settings_path(&cfg.session_root);
         let Some((text, settings)) = std::fs::read_to_string(legacy).ok().and_then(|text| {
             serde_json::from_str::<UiSettings>(&text)
@@ -5482,16 +5520,31 @@ impl App {
         if let Some(dir) = path.parent() {
             let _ = std::fs::create_dir_all(dir);
         }
-        let mut current: serde_json::Value = std::fs::read_to_string(&path)
-            .ok()
-            .and_then(|text| serde_json::from_str(&text).ok())
-            .filter(|value: &serde_json::Value| value.is_object())
-            .unwrap_or_else(|| serde_json::json!({}));
+        let existing = std::fs::read_to_string(&path).ok();
+        let mut current = match existing
+            .as_deref()
+            .and_then(|text| serde_json::from_str::<serde_json::Value>(text).ok())
+            .filter(serde_json::Value::is_object)
+        {
+            Some(value) => value,
+            None => {
+                // The same file carries compositor-owned keys (theme,
+                // uiPreset, harness recipes). An unparseable file must not be
+                // silently replaced with `{}`: keep it for recovery.
+                if existing
+                    .as_deref()
+                    .is_some_and(|text| !text.trim().is_empty())
+                {
+                    let _ = std::fs::rename(&path, quarantined_settings_path(&path));
+                }
+                serde_json::json!({})
+            }
+        };
         current["language"] = serde_json::json!(self.locale);
         current["themeMode"] = serde_json::json!(self.theme.mode.as_str());
         current["markdownTone"] = serde_json::json!(self.tone_mode.as_str());
         if let Ok(text) = serde_json::to_string_pretty(&current) {
-            let _ = std::fs::write(path, text);
+            let _ = write_settings_atomic(&path, &text);
         }
     }
 
@@ -9493,6 +9546,34 @@ impl App {
 #[cfg(test)]
 #[path = "../tests/unit/app__persistent_shell_tests.rs"]
 mod persistent_shell_tests;
+
+/// `settings.json` → `settings.json.corrupt-<timestamp>`, preserving a file
+/// that exists but cannot be parsed for manual recovery.
+fn quarantined_settings_path(path: &std::path::Path) -> std::path::PathBuf {
+    let name = path.file_name().unwrap_or_default().to_string_lossy();
+    path.with_file_name(format!("{name}.corrupt-{}", timestamp()))
+}
+
+/// Write `text` to `path` through a same-directory temporary file plus a
+/// rename: a crash or full disk can never leave a truncated settings.json
+/// (the painter and the compositor both write this file).
+fn write_settings_atomic(path: &std::path::Path, text: &str) -> std::io::Result<()> {
+    let name = path.file_name().unwrap_or_default().to_string_lossy();
+    let tmp = path.with_file_name(format!(
+        "{name}.{}.{}.tmp",
+        std::process::id(),
+        timestamp()
+    ));
+    if let Err(err) = std::fs::write(&tmp, text) {
+        let _ = std::fs::remove_file(&tmp);
+        return Err(err);
+    }
+    if let Err(err) = std::fs::rename(&tmp, path) {
+        let _ = std::fs::remove_file(&tmp);
+        return Err(err);
+    }
+    Ok(())
+}
 
 pub fn timestamp() -> String {
     use std::sync::atomic::{AtomicU64, Ordering};

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -142,6 +142,15 @@ pub enum CtlEvent {
         session_id: String,
         message: String,
     },
+    /// A `/model` or effort switch was rejected by the agent (non-auth).
+    /// The UI had already set the optimistic chip: revert the value it sent
+    /// and surface the error instead of silently keeping a lie.
+    ModelSwitchFailed {
+        session_id: String,
+        model: Option<String>,
+        effort: Option<String>,
+        message: String,
+    },
     /// A failed prompt: settle this session's delivery state and report the error.
     SessionError {
         session_id: String,

--- a/src/input/composer.rs
+++ b/src/input/composer.rs
@@ -13,7 +13,7 @@
 
 use ratatui_textarea::{CursorMove, DataCursor, TextArea};
 use unicode_segmentation::UnicodeSegmentation;
-use unicode_width::UnicodeWidthChar;
+use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
 /// Tab stops, matching the widget's default `tab_length`.
 const TAB_LEN: u8 = 4;
@@ -52,7 +52,15 @@ pub struct LayoutMap {
 
 /// Display width of one grapheme starting at display column `col`
 /// (tab advances to the next stop; control chars have no width).
+///
+/// The cluster is measured as a whole: ZWJ/modifier/variation-selector
+/// sequences render as a single 2-cell glyph, so summing their `char` widths
+/// (6 cells for a family emoji) would desynchronize this mirror from the
+/// widget's own grapheme-based wrap.
 fn grapheme_width(grapheme: &str, col: usize) -> usize {
+    if !grapheme.contains('\t') {
+        return UnicodeWidthStr::width(grapheme);
+    }
     let mut width = 0usize;
     for c in grapheme.chars() {
         if c == '\t' {

--- a/src/transcript.rs
+++ b/src/transcript.rs
@@ -11,7 +11,8 @@ use std::time::Instant;
 
 use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
-use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
+use unicode_segmentation::UnicodeSegmentation;
+use unicode_width::UnicodeWidthStr;
 
 use crate::events::UiEvent;
 use crate::locale::Locale;
@@ -1568,6 +1569,18 @@ fn one_line(s: &str) -> String {
     clamp_str(&s.replace('\n', " ⏎ "), 120)
 }
 
+/// Grapheme clusters of `s` with their terminal display width.
+///
+/// Cells are painted per grapheme (ratatui measures with
+/// `UnicodeSegmentation` + `UnicodeWidthStr`), so wrapping and truncation must
+/// use the same unit. A ZWJ family emoji is one 2-cell cluster even though its
+/// chars sum to 6 cells, and `❤️` is 2 cells though its chars sum to 1 — the
+/// per-`char` sums this module used before split clusters and mismeasured
+/// lines.
+pub(crate) fn graphemes_with_width(s: &str) -> impl DoubleEndedIterator<Item = (&str, usize)> {
+    UnicodeSegmentation::graphemes(s, true).map(|g| (g, UnicodeWidthStr::width(g)))
+}
+
 pub(crate) fn clamp_str(s: &str, max: usize) -> String {
     if max == 0 {
         return String::new();
@@ -1579,12 +1592,11 @@ pub(crate) fn clamp_str(s: &str, max: usize) -> String {
     let mut out = String::new();
     let mut w = 0usize;
     let budget = max.saturating_sub(1);
-    for ch in s.chars() {
-        let cw = UnicodeWidthChar::width(ch).unwrap_or(0);
+    for (g, cw) in graphemes_with_width(&s) {
         if w + cw > budget {
             break;
         }
-        out.push(ch);
+        out.push_str(g);
         w += cw;
     }
     out.push('…');
@@ -1596,14 +1608,14 @@ pub(crate) fn clamp_str(s: &str, max: usize) -> String {
 fn expand_tabs(s: &str) -> String {
     let mut out = String::new();
     let mut col = 0usize;
-    for ch in s.chars() {
-        if ch == '\t' {
+    for (g, cw) in graphemes_with_width(s) {
+        if g == "\t" {
             let pad = 8 - (col % 8);
             out.push_str(&" ".repeat(pad));
             col += pad;
         } else {
-            out.push(ch);
-            col += UnicodeWidthChar::width(ch).unwrap_or(0);
+            out.push_str(g);
+            col += cw;
         }
     }
     out
@@ -1623,8 +1635,7 @@ pub fn wrap(text: &str, width: usize) -> Vec<String> {
         let raw = expand_tabs(raw);
         let mut line = String::new();
         let mut w = 0usize;
-        for ch in raw.chars() {
-            let cw = UnicodeWidthChar::width(ch).unwrap_or(0);
+        for (g, cw) in graphemes_with_width(&raw) {
             if w + cw > width && !line.is_empty() {
                 // Prefer breaking at the last space when it is not too early.
                 match line.rfind(' ') {
@@ -1644,7 +1655,7 @@ pub fn wrap(text: &str, width: usize) -> Vec<String> {
                 out.push(std::mem::take(&mut line));
                 w = 0;
             }
-            line.push(ch);
+            line.push_str(g);
             w += cw;
         }
         out.push(line);

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -10,7 +10,7 @@ use ratatui::widgets::{
 };
 use ratatui::widgets::Widget;
 use ratatui::Frame;
-use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
+use unicode_width::UnicodeWidthStr;
 
 use crate::app::{App, RunState};
 use crate::logo;
@@ -166,6 +166,14 @@ fn pet_rect(area: Rect, app: &App) -> Option<Rect> {
     ))
 }
 
+/// Take up to `*over` rows out of `*rows`, for compressing the chrome stack
+/// on terminals too short for the full composer + dock + queue layout.
+fn shrink_rows(over: &mut u16, rows: &mut u16) {
+    let take = (*over).min(*rows);
+    *rows -= take;
+    *over -= take;
+}
+
 pub fn draw(f: &mut Frame, app: &mut App) {
     let area = f.area();
     let theme = app.theme;
@@ -245,7 +253,7 @@ pub fn draw(f: &mut Frame, app: &mut App) {
     // The box's top border is the cap row and its bottom border carries
     // the meta row, so the box costs no extra rows — the input well stays
     // exactly as tall as the borderless layout.
-    let composer_h = if child_view {
+    let mut composer_h = if child_view {
         1
     } else {
         resolved_composer_height(main, app)
@@ -254,8 +262,29 @@ pub fn draw(f: &mut Frame, app: &mut App) {
     // the box when the terminal is tall enough.
     let composer_dock_h = composer_dock_height(app, main.height, child_view);
     let navigation_dock_h = navigation_dock_height(app, main.height);
-    let input_dock_body_h = input_dock_body_height(app, main.width, main.height, child_view);
-    let queue_shelf_h = queue_shelf_height(app, main.height, child_view);
+    let mut input_dock_body_h = input_dock_body_height(app, main.width, main.height, child_view);
+    let mut queue_shelf_h = queue_shelf_height(app, main.height, child_view);
+    // A full queue shelf, a tall input dock and an expanded draft can outgrow
+    // a short terminal. Compress the flexible rows *before* laying anything
+    // out: `draw_input` writes the prompt gutter straight into the buffer, so
+    // a composer that extends past the frame would panic in ratatui's
+    // `Buffer::index_of` instead of merely clipping. Optional dock content
+    // gives way first, then the draft viewport (down to its minimum), then
+    // the queue shelf. The rects below are also clipped to the frame, so even
+    // a terminal too small for the minimum stack cannot write out of bounds.
+    let fixed_h = cap_h + composer_dock_h + navigation_dock_h + approval_h + gap_h;
+    let min_composer_h = if child_view {
+        1
+    } else {
+        composer_height(main.height).max(1)
+    };
+    let mut over =
+        (fixed_h + composer_h + input_dock_body_h + queue_shelf_h).saturating_sub(main.height);
+    shrink_rows(&mut over, &mut input_dock_body_h);
+    let mut composer_extra = composer_h.saturating_sub(min_composer_h);
+    shrink_rows(&mut over, &mut composer_extra);
+    composer_h = min_composer_h + composer_extra;
+    shrink_rows(&mut over, &mut queue_shelf_h);
     let chat_h = main.height.saturating_sub(
         composer_h
             + cap_h
@@ -267,16 +296,19 @@ pub fn draw(f: &mut Frame, app: &mut App) {
             + gap_h,
     );
 
-    let chat = Rect::new(main.x, main.y, main.width, chat_h);
+    let frame = f.area();
+    let chat = Rect::new(main.x, main.y, main.width, chat_h).intersection(frame);
     let chrome_y = main.y + chat_h + gap_h;
-    let approval = Rect::new(main.x, chrome_y, main.width, approval_h);
-    let queue_shelf = Rect::new(main.x, chrome_y + approval_h, main.width, queue_shelf_h);
+    let approval = Rect::new(main.x, chrome_y, main.width, approval_h).intersection(frame);
+    let queue_shelf = Rect::new(main.x, chrome_y + approval_h, main.width, queue_shelf_h)
+        .intersection(frame);
     let composer_box = Rect::new(
         main.x,
         queue_shelf.y + queue_shelf.height,
         main.width,
         cap_h + input_dock_body_h + composer_h + navigation_dock_h,
-    );
+    )
+    .intersection(frame);
     let composer = if child_view {
         Rect::new(
             main.x,
@@ -293,13 +325,15 @@ pub fn draw(f: &mut Frame, app: &mut App) {
             main.width,
             composer_h,
         )
-    };
+    }
+    .intersection(frame);
     let composer_dock = Rect::new(
         main.x,
         composer_box.y + composer_box.height,
         main.width,
         composer_dock_h,
-    );
+    )
+    .intersection(frame);
     let navigation_dock = if child_view {
         Rect::new(main.x, composer_box.y, main.width, navigation_dock_h)
     } else {
@@ -309,7 +343,8 @@ pub fn draw(f: &mut Frame, app: &mut App) {
             main.width,
             navigation_dock_h,
         )
-    };
+    }
+    .intersection(frame);
 
     draw_chat(f, app, chat);
     if approval_h > 0 {
@@ -833,12 +868,11 @@ fn ellipsize_to(s: &str, cells: usize) -> String {
     }
     let mut out = String::new();
     let mut used = 0;
-    for ch in s.chars() {
-        let cw = UnicodeWidthChar::width(ch).unwrap_or(0);
+    for (g, cw) in crate::transcript::graphemes_with_width(s) {
         if used + cw > cells.saturating_sub(1) {
             break;
         }
-        out.push(ch);
+        out.push_str(g);
         used += cw;
     }
     out.push('…');
@@ -854,13 +888,12 @@ fn wrap_line(s: &str, cells: usize) -> Vec<String> {
     let mut out = Vec::new();
     let mut cur = String::new();
     let mut used = 0usize;
-    for ch in s.chars() {
-        let cw = UnicodeWidthChar::width(ch).unwrap_or(0);
+    for (g, cw) in crate::transcript::graphemes_with_width(s) {
         if used > 0 && used + cw > cells {
             out.push(std::mem::take(&mut cur));
             used = 0;
         }
-        cur.push(ch);
+        cur.push_str(g);
         used += cw;
     }
     if !cur.is_empty() {
@@ -1408,6 +1441,12 @@ fn draw_navigation_dock(f: &mut Frame, app: &mut App, area: Rect, embedded: bool
 
 fn draw_agent_rail(f: &mut Frame, app: &App, area: Rect, embedded: bool) {
     let theme = app.theme;
+    // The embedded borders index cells directly; a clipped rail must not be
+    // able to panic in `Buffer::index_of`.
+    let area = area.intersection(f.area());
+    if area.is_empty() {
+        return;
+    }
     let choosing = app.agent_selection.is_some();
     f.render_widget(
         Block::default().style(Style::default().bg(theme.panel)),
@@ -2073,12 +2112,11 @@ fn truncate_spans(spans: &[Span<'static>], budget: usize) -> Vec<Span<'static>> 
         let remaining = budget.saturating_sub(used);
         let mut text = String::new();
         let mut taken = 0usize;
-        for c in span.content.chars() {
-            let cw = unicode_width::UnicodeWidthChar::width(c).unwrap_or(0);
+        for (g, cw) in crate::transcript::graphemes_with_width(&span.content) {
             if taken + cw > remaining {
                 break;
             }
-            text.push(c);
+            text.push_str(g);
             taken += cw;
         }
         if budget > 0 {
@@ -2609,12 +2647,11 @@ fn compact_workspace(path: &str, max_width: usize) -> String {
     }
     let mut suffix = String::new();
     let mut used = 0;
-    for ch in leaf.chars().rev() {
-        let width = UnicodeWidthChar::width(ch).unwrap_or(0);
+    for (g, width) in crate::transcript::graphemes_with_width(leaf).rev() {
         if used + width > max_width - 1 {
             break;
         }
-        suffix.insert(0, ch);
+        suffix.insert_str(0, g);
         used += width;
     }
     format!("…{suffix}")
@@ -2681,12 +2718,11 @@ fn ellipsize_line(line: Line<'static>, max_width: usize, style: Style) -> Line<'
             break;
         }
         let mut text = String::new();
-        for ch in span.content.chars() {
-            let width = UnicodeWidthChar::width(ch).unwrap_or(0);
+        for (g, width) in crate::transcript::graphemes_with_width(&span.content) {
             if width > remaining {
                 break;
             }
-            text.push(ch);
+            text.push_str(g);
             remaining -= width;
         }
         if !text.is_empty() {
@@ -2965,6 +3001,10 @@ fn layout_expand_btn(app: &mut App, cap: Rect) {
 /// always wins the pixels.
 fn paint_composer_buttons(f: &mut Frame, app: &mut App) {
     let theme = app.theme;
+    // Button rects are derived from the (already clipped) composer layout,
+    // but `set_string` indexes the buffer directly: skip any cell that a
+    // pathological frame put outside it.
+    let frame = f.area();
     let b = f.buffer_mut();
     if let Some(rect) = app.prompt_jump_btn {
         if rect.width >= JUMP_BTN_W && rect.height >= EXPAND_BTN_H {
@@ -2974,12 +3014,10 @@ fn paint_composer_buttons(f: &mut Frame, app: &mut App) {
                 theme.caption
             };
             // Glyph = the rect's rightmost cell, one cell left of the ⛶.
-            b.set_string(
-                rect.x.saturating_add(rect.width).saturating_sub(1),
-                rect.y,
-                "↥",
-                Style::default().fg(tone),
-            );
+            let x = rect.x.saturating_add(rect.width).saturating_sub(1);
+            if frame.contains(ratatui::layout::Position::new(x, rect.y)) {
+                b.set_string(x, rect.y, "↥", Style::default().fg(tone));
+            }
         }
     }
     let Some(rect) = app.expand_btn else {
@@ -2996,7 +3034,9 @@ fn paint_composer_buttons(f: &mut Frame, app: &mut App) {
     } else {
         theme.caption
     };
-    b.set_string(x, rect.y, "⛶", Style::default().fg(tone));
+    if frame.contains(ratatui::layout::Position::new(x, rect.y)) {
+        b.set_string(x, rect.y, "⛶", Style::default().fg(tone));
+    }
 }
 
 /// The input well. Long prompts wrap across the (now taller) well, and the
@@ -3012,6 +3052,11 @@ fn paint_composer_buttons(f: &mut Frame, app: &mut App) {
 fn draw_input(f: &mut Frame, app: &mut App, area: Rect) {
     let theme = app.theme;
     let composer_owns_cursor = app.elicitation_ask.is_none();
+    // The prompt gutter below writes cells straight into the buffer, and
+    // `Buffer::index_of` panics (rather than clipping) on an out-of-bounds
+    // index. Clip to the frame first; the layout above already keeps the
+    // composer inside it, this is the last line of defense.
+    let area = area.intersection(f.area());
     if area.width < 4 || area.height == 0 {
         return;
     }
@@ -3411,12 +3456,11 @@ fn pad_or_ellipsize(s: &str, w: usize) -> String {
     }
     let mut out = String::new();
     let mut used = 0;
-    for ch in s.chars() {
-        let cw = UnicodeWidthChar::width(ch).unwrap_or(0);
+    for (g, cw) in crate::transcript::graphemes_with_width(s) {
         if used + cw > w.saturating_sub(1) {
             break;
         }
-        out.push(ch);
+        out.push_str(g);
         used += cw;
     }
     out.push('…');

--- a/tests/unit/acp__control_tests.rs
+++ b/tests/unit/acp__control_tests.rs
@@ -301,3 +301,109 @@ async fn prompts_and_steers_outlive_the_control_request_deadline() {
         .await
         .unwrap();
 }
+
+fn model_switch_agent(reject: bool) -> impl ConnectTo<Client> + 'static {
+    Agent
+        .builder()
+        .on_receive_request(
+            async move |req: InitializeRequest, responder, _cx| {
+                responder.respond(
+                    InitializeResponse::new(req.protocol_version)
+                        .agent_capabilities(AgentCapabilities::new()),
+                )
+            },
+            on_receive_request!(),
+        )
+        .on_receive_request(
+            async move |_req: NewSessionRequest, responder, _cx| {
+                responder.respond(NewSessionResponse::new(SessionId::new("s1")))
+            },
+            on_receive_request!(),
+        )
+        .on_receive_request(
+            async move |_req: SetSessionConfigOptionRequest, responder, _cx| {
+                if reject {
+                    responder.respond_with_error(AcpError::new(-32602, "unknown model"))
+                } else {
+                    responder.respond(SetSessionConfigOptionResponse::new(vec![]))
+                }
+            },
+            on_receive_request!(),
+        )
+}
+
+fn model_switch_cfg() -> RuntimeConfig {
+    RuntimeConfig {
+        bin: "demo".into(),
+        cordis: "demo".into(),
+        workspace: "/tmp".into(),
+        session_root: "/tmp".into(),
+        provider: "test".into(),
+        model: "test".into(),
+        max_tokens: None,
+        base_url: None,
+        api_key: None,
+    }
+}
+
+/// A rejected `/model` switch used to be dropped silently while the UI kept
+/// showing the optimistic pick. It must report the failure for rollback.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn rejected_model_switch_reports_failure() {
+    let (bus, events) = std::sync::mpsc::channel();
+    let (cmds, commands) = std::sync::mpsc::channel();
+    let task = tokio::spawn(connect(model_switch_agent(true), model_switch_cfg(), bus, commands));
+    wait_event(&events, |event| {
+        matches!(event, AppEvent::Ctl(CtlEvent::SessionBound { session_id, .. }) if session_id == "s1")
+    })
+    .await;
+    cmds.send(Cmd::SelectModel {
+        session_id: "s1".into(),
+        provider: None,
+        model: Some("ghost".into()),
+        effort: None,
+    })
+    .unwrap();
+    wait_event(&events, |event| {
+        matches!(
+            event,
+            AppEvent::Ctl(CtlEvent::ModelSwitchFailed {
+                session_id,
+                model: Some(model),
+                ..
+            }) if session_id == "s1" && model == "ghost"
+        )
+    })
+    .await;
+    let _ = cmds.send(Cmd::Shutdown);
+    let _ = tokio::time::timeout(Duration::from_secs(2), task).await;
+}
+
+/// A successful switch folds the response's `configOptions` back (Catalog
+/// event) instead of relying on a follow-up notification.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn accepted_model_switch_folds_config_response() {
+    let (bus, events) = std::sync::mpsc::channel();
+    let (cmds, commands) = std::sync::mpsc::channel();
+    let task = tokio::spawn(connect(model_switch_agent(false), model_switch_cfg(), bus, commands));
+    wait_event(&events, |event| {
+        matches!(event, AppEvent::Ctl(CtlEvent::SessionBound { session_id, .. }) if session_id == "s1")
+    })
+    .await;
+    cmds.send(Cmd::SelectModel {
+        session_id: "s1".into(),
+        provider: None,
+        model: Some("next".into()),
+        effort: None,
+    })
+    .unwrap();
+    wait_event(&events, |event| {
+        matches!(
+            event,
+            AppEvent::Ctl(CtlEvent::Catalog { session_id: Some(sid), .. }) if sid == "s1"
+        )
+    })
+    .await;
+    let _ = cmds.send(Cmd::Shutdown);
+    let _ = tokio::time::timeout(Duration::from_secs(2), task).await;
+}

--- a/tests/unit/app__mode_tests.rs
+++ b/tests/unit/app__mode_tests.rs
@@ -181,6 +181,93 @@ fn lang_switch_repaints_immediately_and_persists_for_the_workspace() {
     );
 }
 
+/// A settings.json that cannot be parsed must be quarantined for recovery,
+/// not silently replaced with `{}` (the same file carries the compositor's
+/// theme/uiPreset keys and the harness recipes).
+#[test]
+fn corrupt_settings_are_quarantined_instead_of_clobbered() {
+    let cfg = test_cfg();
+    let dir = std::path::Path::new(&cfg.session_root).to_path_buf();
+    let current = dir.join("settings.json");
+    std::fs::write(&current, "{ this is not json").expect("seed corrupt settings");
+    let (tx, _rx) = std::sync::mpsc::channel::<AppEvent>();
+    let (ctl, _commands) = crate::controller::tests::test_controller();
+    let mut app = App::new(Some(Theme::dark()), cfg.clone(), "s1".into(), true, false, tx);
+
+    app.run_slash("lang", "zh", &ctl);
+
+    let quarantined: Vec<std::path::PathBuf> = std::fs::read_dir(&dir)
+        .expect("read settings dir")
+        .flatten()
+        .map(|entry| entry.path())
+        .filter(|path| {
+            path.file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| name.starts_with("settings.json.corrupt-"))
+        })
+        .collect();
+    assert_eq!(quarantined.len(), 1, "corrupt file kept for recovery: {quarantined:?}");
+    assert_eq!(
+        std::fs::read_to_string(&quarantined[0]).expect("read quarantined file"),
+        "{ this is not json",
+    );
+    let saved: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&current).expect("read new settings"))
+            .expect("new settings parse");
+    assert_eq!(saved["language"], "zh", "the save still landed");
+}
+
+/// A normal save keeps every key it does not own (compositor theme/uiPreset,
+/// harness recipes, future fields) and leaves no temp file behind.
+#[test]
+fn settings_save_preserves_unknown_keys_and_cleans_up_temp_files() {
+    let cfg = test_cfg();
+    let dir = std::path::Path::new(&cfg.session_root).to_path_buf();
+    let current = dir.join("settings.json");
+    std::fs::write(
+        &current,
+        r#"{"uiPreset":"deepseek","theme":"ember","harnesses":[{"id":"x"}],"customKey":7}"#,
+    )
+    .expect("seed settings");
+    #[cfg(unix)]
+    let inode_before = {
+        use std::os::unix::fs::MetadataExt;
+        std::fs::metadata(&current).expect("stat settings").ino()
+    };
+    let (tx, _rx) = std::sync::mpsc::channel::<AppEvent>();
+    let (ctl, _commands) = crate::controller::tests::test_controller();
+    let mut app = App::new(Some(Theme::dark()), cfg.clone(), "s1".into(), true, false, tx);
+
+    app.run_slash("lang", "zh", &ctl);
+
+    let saved: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&current).expect("read settings"))
+            .expect("settings parse");
+    assert_eq!(saved["language"], "zh");
+    assert_eq!(saved["uiPreset"], "deepseek", "compositor key preserved");
+    assert_eq!(saved["theme"], "ember", "compositor key preserved");
+    assert_eq!(saved["harnesses"][0]["id"], "x", "harness recipes preserved");
+    assert_eq!(saved["customKey"], 7, "unknown keys preserved");
+    let leftovers: Vec<String> = std::fs::read_dir(&dir)
+        .expect("read settings dir")
+        .flatten()
+        .filter_map(|entry| entry.file_name().into_string().ok())
+        .filter(|name| name.ends_with(".tmp"))
+        .collect();
+    assert!(leftovers.is_empty(), "atomic write left temp files: {leftovers:?}");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        // temp + rename replaces the directory entry, so the inode changes;
+        // an in-place `std::fs::write` would keep the original inode.
+        assert_ne!(
+            std::fs::metadata(&current).expect("stat settings").ino(),
+            inode_before,
+            "expected a rename-based (atomic) write",
+        );
+    }
+}
+
 /// The markdown body tone is a quiet, settings-only preference: no command
 /// surface. Absent `markdownTone` → single (the default look); `"two"`
 /// opts back into the two-tone CJK/Latin body.

--- a/tests/unit/input__composer__tests.rs
+++ b/tests/unit/input__composer__tests.rs
@@ -433,3 +433,15 @@ fn explicit_range_kills_ignore_an_active_selection() {
     e.kill_to_start(80);
     assert_eq!(e.buf(), "rld", "kill_to_start killed from the row head to the cursor");
 }
+
+/// A ZWJ family emoji is one 2-cell grapheme, not the 6 cells its chars sum
+/// to: the mirror must keep it and the following glyph on the same row.
+#[test]
+fn zwj_emoji_is_one_two_cell_grapheme() {
+    let map = LayoutMap::new(&lines(&["👨‍👩‍👧x"]), 4);
+    assert_eq!(map.row_count(), 1, "cluster + x fit one 4-cell row");
+    assert_eq!(map.rows[0].graphemes.len(), 2);
+    assert_eq!(map.rows[0].graphemes[0].width, 2, "cluster is one 2-cell glyph");
+    assert_eq!(map.rows[0].graphemes[0].start_col, 0);
+    assert_eq!(map.rows[0].graphemes[1].start_col, 2, "x follows the cluster");
+}

--- a/tests/unit/transcript__tests.rs
+++ b/tests/unit/transcript__tests.rs
@@ -594,3 +594,49 @@ fn stats_accumulate_turns_steps_and_ttft() {
     assert_eq!(tr.stats.ttft_count, 1, "only the first delta samples TTFT");
     assert!(tr.stats.tool_millis <= tr.stats.turn_millis);
 }
+
+/// ZWJ emoji clusters must be measured as one 2-cell grapheme. Summing the
+/// per-`char` widths (6 for a family emoji) used to overflow the line budget
+/// and split the sequence across lines.
+#[test]
+fn wrap_keeps_zwj_emoji_clusters_whole() {
+    let lines = wrap("aaaa👨‍👩‍👧bbbb", 4);
+    assert_eq!(lines.len(), 3, "cluster occupies its own row: {lines:?}");
+    for line in &lines {
+        assert!(
+            UnicodeWidthStr::width(line.as_str()) <= 4,
+            "line over budget: {line:?}",
+        );
+        if line.contains('👨') || line.contains('👩') || line.contains('👧') {
+            assert!(
+                line.contains("👨‍👩‍👧"),
+                "cluster split across lines: {line:?}",
+            );
+        }
+    }
+}
+
+/// A variation-selector cluster is 2 cells, not the 1 its chars sum to; the
+/// wrapped line must stay inside the budget instead of being clipped.
+#[test]
+fn wrap_measures_variation_selector_clusters_as_two_cells() {
+    let lines = wrap("ab❤️cd", 4);
+    assert_eq!(lines.len(), 2, "{lines:?}");
+    for line in &lines {
+        assert!(
+            UnicodeWidthStr::width(line.as_str()) <= 4,
+            "line over budget: {line:?}",
+        );
+    }
+    assert!(lines.concat().contains("❤️"), "cluster kept: {lines:?}");
+}
+
+/// `clamp_str` ellipsizes on cluster boundaries: the ZWJ sequence either fits
+/// whole or moves entirely into the dropped tail.
+#[test]
+fn clamp_str_never_splits_an_emoji_cluster() {
+    let out = clamp_str("abc👨‍👩‍👧def", 6);
+    assert!(out.ends_with('…'), "{out:?}");
+    assert!(UnicodeWidthStr::width(out.as_str()) <= 6, "{out:?}");
+    assert!(out.contains("👨‍👩‍👧"), "cluster split: {out:?}");
+}

--- a/tests/unit/ui__tests.rs
+++ b/tests/unit/ui__tests.rs
@@ -3650,3 +3650,73 @@ fn prompt_jump_button_sits_between_path_and_expand_and_hovers() {
         "idle tone restored when the pointer leaves"
     );
 }
+
+/// Regression: a full queue shelf plus an expanded draft used to push the
+/// composer past the frame; `draw_input` then wrote the prompt gutter at
+/// y == frame height and ratatui's `Buffer::index_of` panicked
+/// (`index outside of buffer`). The chrome stack must compress instead.
+#[test]
+fn overflowing_chrome_stack_keeps_the_composer_inside_the_frame() {
+    use ratatui::backend::TestBackend;
+    use ratatui::Terminal;
+    let mut app = test_app();
+    app.show_banner = false;
+    app.queued = 12;
+    app.input
+        .set((0..30).map(|i| format!("line {i}")).collect::<Vec<_>>().join("\n"));
+    let backend = TestBackend::new(80, 22);
+    let mut terminal = Terminal::new(backend).expect("test terminal");
+    terminal.draw(|f| draw(f, &mut app)).expect("draw frame");
+    assert!(
+        app.input_area.height > 0,
+        "the composer must keep at least one row: {:?}",
+        app.input_area,
+    );
+    assert!(
+        app.input_area.bottom() <= 22,
+        "composer escaped the 22-row frame: {:?}",
+        app.input_area,
+    );
+    assert!(app.chat_view.area.bottom() <= 22);
+}
+
+/// The 20-row / 8-queued configuration sat exactly at the old boundary; it
+/// must keep fitting (and must not panic) without extra compression.
+#[test]
+fn queue_shelf_and_expanded_draft_at_the_old_boundary_still_fit() {
+    use ratatui::backend::TestBackend;
+    use ratatui::Terminal;
+    let mut app = test_app();
+    app.show_banner = false;
+    app.queued = 8;
+    app.input
+        .set((0..30).map(|i| format!("line {i}")).collect::<Vec<_>>().join("\n"));
+    let backend = TestBackend::new(80, 20);
+    let mut terminal = Terminal::new(backend).expect("test terminal");
+    terminal.draw(|f| draw(f, &mut app)).expect("draw frame");
+    assert!(
+        app.input_area.bottom() <= 20,
+        "composer escaped the 20-row frame: {:?}",
+        app.input_area,
+    );
+}
+
+/// A roomy terminal must keep a real conversation area: the compression pass
+/// only engages when the chrome stack actually overflows.
+#[test]
+fn roomy_chrome_stack_keeps_the_conversation_visible() {
+    use ratatui::backend::TestBackend;
+    use ratatui::Terminal;
+    let mut app = test_app();
+    app.show_banner = false;
+    app.queued = 3;
+    app.input.set("one\ntwo\nthree\nfour\nfive".into());
+    let backend = TestBackend::new(100, 30);
+    let mut terminal = Terminal::new(backend).expect("test terminal");
+    terminal.draw(|f| draw(f, &mut app)).expect("draw frame");
+    assert!(
+        app.chat_view.area.height > 0,
+        "chat collapsed on a terminal with room to spare",
+    );
+    assert!(app.input_area.bottom() <= 30);
+}


### PR DESCRIPTION
## Summary

Five robustness fixes, each with regression tests (790 Rust tests pass; 436 JS tests pass):

- **Grapheme-aware measuring**: transcript wrapping, picker/status truncation and the composer layout mirror now measure grapheme clusters (`UnicodeWidthStr`) instead of per-`char` width sums. ZWJ family emoji, skin-tone modifiers and variation selectors stay on one line and no longer push a line past its pane budget (a family emoji counted as 6 cells instead of 2).
- **`/model` and effort switch errors are reported**: a rejection emits `CtlEvent::ModelSwitchFailed`; the agent's error lands in the owning session's transcript and the optimistic chip/effort reverts instead of silently keeping a lie. A successful switch folds the response's `configOptions` back (Catalog) even when the agent sends no follow-up notification.
- **`settings.json` is written atomically** (same-directory temp file + rename; painter and compositor both write it), and a file that exists but cannot be parsed is quarantined as `settings.json.corrupt-<timestamp>` instead of being silently replaced with `{}` (which dropped theme/uiPreset/harness keys).
- **Short-terminal composer overflow panic fixed**: a full queue shelf plus an expanded draft no longer overflows the frame (`index outside of buffer`) — the chrome stack compresses the optional dock rows, then the draft viewport, then the queue shelf before layout, and the composer's direct buffer writes are clipped to the frame as a fallback.
- **mux UTF-8 chunk boundaries**: ACP frames are decoded with a `StringDecoder` in both directions instead of per-chunk `toString('utf8')`, so a multi-byte character split across stream chunks no longer becomes U+FFFD; a final unterminated line is flushed on stream end.

## Test plan

- [x] `cargo check --locked --tests`
- [x] `cargo test --locked` — 790 passed / 0 failed (11 new regression tests)
- [x] `npm test --prefix npm` — 436 passed / 3 skipped / 0 failed (2 new suites extended)
- [x] `cargo run -- --dump-frame 100x34` renders the canned frame cleanly (no panic, no tofu)