### PR TITLE
perf(tui): speed up /resume listing on large session stores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,11 @@ All notable changes to this project are documented here. The project follows
 
 ### Fixed
 
+- `/resume` no longer decompresses and JSON-parses every durable session log
+  on each invocation. Logs are streamed line by line and pre-filtered instead
+  of parsed whole, candidate logs are summarized a few files at a time in
+  parallel, `/resume <id>` resolves the prefix by reading only session headers,
+  and the ACP picker summarizes only the ids the agent listed.
 - Transcript wrapping, picker/status truncation and the composer layout mirror
   now measure grapheme clusters (via `UnicodeWidthStr`) instead of summing
   per-`char` widths. ZWJ family emoji, skin-tone modifiers and variation

--- a/src/app.rs
+++ b/src/app.rs
@@ -7125,12 +7125,41 @@ impl App {
     /// keeps appending to the same log.
     fn resume_session(&mut self, id_or_prefix: &str, ctl: &Controller) {
         if self.resume_candidates.is_empty() {
-            self.resume_candidates = crate::sessions::list_sessions(
+            // Direct `/resume <id>`: resolve the prefix against the store
+            // without summarizing every session — only the chosen log is
+            // fully read. (The picker path below reuses its rows.)
+            match crate::sessions::resolve_session(
                 &self.cfg.session_root,
                 &self.cfg.workspace,
                 &self.session_id,
-                usize::MAX,
-            );
+                id_or_prefix,
+            ) {
+                crate::sessions::SessionResolution::One(session)
+                | crate::sessions::SessionResolution::Exact(session) => {
+                    self.replay_local_session(session, ctl);
+                }
+                crate::sessions::SessionResolution::None => {
+                    self.transcript.push_notice(
+                        NoticeLevel::Warn,
+                        self.locale.trf(
+                            "no session matches “{}” — /resume lists them",
+                            "没有会话匹配「{}」—— /resume 可列出全部",
+                            &[id_or_prefix.into()],
+                        ),
+                    );
+                }
+                crate::sessions::SessionResolution::Ambiguous(count) => {
+                    self.transcript.push_notice(
+                        NoticeLevel::Warn,
+                        self.locale.trf(
+                            "“{}” is ambiguous ({} matches) — /resume lists them",
+                            "「{}」有 {} 个匹配，存在歧义 —— /resume 可列出全部",
+                            &[id_or_prefix.into(), count.to_string()],
+                        ),
+                    );
+                }
+            }
+            return;
         }
         let matches: Vec<crate::sessions::SessionSummary> = self
             .resume_candidates
@@ -7166,6 +7195,16 @@ impl App {
                 }
             },
         };
+        self.replay_local_session(session, ctl);
+    }
+
+    /// Replay one chosen session log into a tab and point the next prompt at
+    /// the same id. Shared by the picker and the direct `/resume <id>` path.
+    fn replay_local_session(
+        &mut self,
+        session: crate::sessions::SessionSummary,
+        ctl: &Controller,
+    ) {
         let events = match crate::sessions::read_session_events(&session.file) {
             Ok(events) => events,
             Err(err) => {
@@ -7507,16 +7546,15 @@ impl App {
         }
         // Local JSONL summaries (turns, age, prompt preview) for the same
         // workspace; the local log is the only source for those fields.
+        // Only the listed ids are summarized — never the whole local store.
+        let ids: Vec<String> = sessions.iter().map(|s| s.id.clone()).collect();
         let local_by_id: std::collections::HashMap<String, crate::sessions::SessionSummary> =
-            crate::sessions::list_sessions(
+            crate::sessions::sessions_for_ids(
                 &self.cfg.session_root,
                 &self.cfg.workspace,
                 &self.session_id,
-                usize::MAX,
-            )
-            .into_iter()
-            .map(|s| (s.id.clone(), s))
-            .collect();
+                &ids,
+            );
         let items: Vec<PickerItem> = sessions
             .iter()
             .map(|s| {

--- a/src/sessions.rs
+++ b/src/sessions.rs
@@ -10,10 +10,20 @@
 //! `~/.dsh/sessions`. A flat `<root>/<session-id>/session.jsonl` layout is tolerated
 //! too. The workspace slug is the absolute path with `/` mapped to `-`,
 //! wrapped in `-…--` (observed: `/Users/x/proj` → `--Users-x-proj--`).
+//!
+//! Listing stays cheap without any persisted state: a log is streamed line
+//! by line (a summary never holds the whole decompressed transcript) and
+//! skipped with a cheap needle test unless the line can contribute, cache
+//! misses are summarized a few files at a time in parallel, `/resume <id>`
+//! reads only session headers before summarizing the chosen log, and the
+//! ACP picker summarizes only the ids the agent listed.
 
-use std::io::Read;
+use std::collections::{HashMap, HashSet};
+use std::io::{BufRead, BufReader, Read};
 use std::path::{Path, PathBuf};
-use std::time::SystemTime;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Mutex;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use anyhow::{Context, Result};
 use serde_json::Value;
@@ -31,6 +41,19 @@ pub struct SessionSummary {
     /// The LLM ("provider" source) title wins over the truncated-prompt
     /// "fallback" stub.
     pub title: Option<String>,
+}
+
+/// How a typed id prefix resolved against the durable store.
+#[derive(Debug)]
+pub enum SessionResolution {
+    /// Exactly one session matched the prefix.
+    One(SessionSummary),
+    /// Several matched, but one id equals the typed prefix exactly.
+    Exact(SessionSummary),
+    /// No session matched.
+    None,
+    /// Several sessions matched and none is an exact id.
+    Ambiguous(usize),
 }
 
 /// `/Users/x/proj` → `--Users-x-proj--` (the harness's directory slug).
@@ -69,21 +92,18 @@ fn session_file(dir: &Path) -> Option<PathBuf> {
     None
 }
 
-/// List resumable sessions for `workspace`, newest first, excluding
-/// `skip_id` (the currently active session). Best effort: unreadable or
-/// foreign files are skipped, never an error.
-/// Default cap for the `/resume` picker when no explicit count is given
-/// (`/resume` behaves like `/resume 50`).
-pub const DEFAULT_SESSION_LIST_LIMIT: usize = 50;
+/// One session log found by the directory scan.
+#[derive(Clone, Debug)]
+struct Candidate {
+    file: PathBuf,
+    mtime: SystemTime,
+}
 
-pub fn list_sessions(
-    cfg_root: &str,
-    workspace: &str,
-    skip_id: &str,
-    limit: usize,
-) -> Vec<SessionSummary> {
+/// Scan the session roots for this workspace's logs, newest first. No file
+/// contents are read: only directory entries and one `stat` per log.
+fn collect_candidates(cfg_root: &str, workspace: &str, skip_id: &str) -> Vec<Candidate> {
     let slug = workspace_slug(workspace);
-    let mut candidate_files: Vec<(PathBuf, SystemTime)> = Vec::new();
+    let mut out: Vec<Candidate> = Vec::new();
     for root in session_roots(cfg_root) {
         // <root>/<slug>/<id>/session.jsonl[.zstd]
         let mut dirs: Vec<PathBuf> = Vec::new();
@@ -98,31 +118,142 @@ pub fn list_sessions(
             if dir.file_name().and_then(|n| n.to_str()) == Some(skip_id) {
                 continue;
             }
-            if let Some(file) = session_file(&dir) {
-                let mtime = std::fs::metadata(&file)
-                    .and_then(|m| m.modified())
-                    .unwrap_or(SystemTime::UNIX_EPOCH);
-                candidate_files.push((file, mtime));
+            let Some(file) = session_file(&dir) else {
+                continue;
+            };
+            let mtime = std::fs::metadata(&file)
+                .and_then(|meta| meta.modified())
+                .unwrap_or(UNIX_EPOCH);
+            out.push(Candidate { file, mtime });
+        }
+    }
+    out.sort_by(|a, b| b.mtime.cmp(&a.mtime).then_with(|| a.file.cmp(&b.file)));
+    out.dedup_by(|a, b| a.file == b.file);
+    out
+}
+
+/// Below this many logs, reading sequentially beats spawning threads.
+const PARALLEL_MIN_FILES: usize = 2;
+/// Cap the fan-out: `/resume` blocks the UI thread, so leave headroom.
+const PARALLEL_MAX_THREADS: usize = 4;
+
+/// Default cap for the `/resume` picker when no explicit count is given
+/// (`/resume` behaves like `/resume 50`).
+pub const DEFAULT_SESSION_LIST_LIMIT: usize = 50;
+
+/// List resumable sessions for `workspace`, newest first, excluding
+/// `skip_id` (the currently active session). Best effort: unreadable or
+/// foreign files are skipped, never an error.
+pub fn list_sessions(
+    cfg_root: &str,
+    workspace: &str,
+    skip_id: &str,
+    limit: usize,
+) -> Vec<SessionSummary> {
+    let candidates = collect_candidates(cfg_root, workspace, skip_id);
+    let mut out: Vec<SessionSummary> = Vec::new();
+    let mut seen: HashSet<String> = HashSet::new();
+    let mut pos = 0;
+    while out.len() < limit && pos < candidates.len() {
+        // Summarize at most the rows still missing, in parallel. A log that
+        // turns out to be unreadable or foreign does not consume a limit
+        // slot, so keep walking until `limit` real sessions are found.
+        let end = pos
+            .saturating_add(limit - out.len())
+            .min(candidates.len());
+        let files: Vec<PathBuf> = candidates[pos..end]
+            .iter()
+            .map(|candidate| candidate.file.clone())
+            .collect();
+        pos = end;
+        for summary in summarize_many(&files).into_iter().flatten() {
+            if summary.id == skip_id || !seen.insert(summary.id.clone()) {
+                continue;
+            }
+            out.push(summary);
+            if out.len() >= limit {
+                break;
             }
         }
     }
-    candidate_files.sort_by(|(f1, m1), (f2, m2)| m2.cmp(m1).then_with(|| f1.cmp(f2)));
-    candidate_files.dedup_by(|(f1, _), (f2, _)| f1 == f2);
+    out
+}
 
-    let mut out: Vec<SessionSummary> = Vec::new();
-    for (file, _) in candidate_files {
-        let Some(summary) = summarize(&file) else {
-            continue;
-        };
-        if summary.id == skip_id || out.iter().any(|s| s.id == summary.id) {
-            continue;
-        }
-        out.push(summary);
-        if out.len() >= limit {
+/// Local summaries for the given session ids, keyed by id. Used to enrich
+/// ACP `session/list` rows without summarizing the whole local store.
+pub fn sessions_for_ids(
+    cfg_root: &str,
+    workspace: &str,
+    skip_id: &str,
+    ids: &[String],
+) -> HashMap<String, SessionSummary> {
+    let wanted: HashSet<&str> = ids.iter().map(String::as_str).collect();
+    let mut found: HashMap<String, SessionSummary> = HashMap::new();
+    if wanted.is_empty() {
+        return found;
+    }
+    let candidates = collect_candidates(cfg_root, workspace, skip_id);
+    let mut claimed: HashSet<String> = HashSet::new();
+    let mut files: Vec<PathBuf> = Vec::new();
+    let mut pending_ids: Vec<String> = Vec::new();
+    for candidate in candidates {
+        if claimed.len() >= wanted.len() {
             break;
         }
+        let Some(id) = read_session_id(&candidate.file) else {
+            continue;
+        };
+        if id == skip_id || !wanted.contains(id.as_str()) || !claimed.insert(id.clone()) {
+            continue;
+        }
+        files.push(candidate.file);
+        pending_ids.push(id);
     }
-    out
+    for (id, summary) in pending_ids.into_iter().zip(summarize_many(&files)) {
+        if let Some(summary) = summary {
+            found.insert(id, summary);
+        }
+    }
+    found
+}
+
+/// Resolve `/resume <id>` without listing the store: every candidate header
+/// is read (cheap) but only the chosen log is fully summarized.
+pub fn resolve_session(
+    cfg_root: &str,
+    workspace: &str,
+    skip_id: &str,
+    prefix: &str,
+) -> SessionResolution {
+    let candidates = collect_candidates(cfg_root, workspace, skip_id);
+    let mut matches: Vec<(PathBuf, String)> = Vec::new();
+    let mut seen: HashSet<String> = HashSet::new();
+    for candidate in candidates {
+        let Some(id) = read_session_id(&candidate.file) else {
+            continue;
+        };
+        if id == skip_id || !id.starts_with(prefix) || !seen.insert(id.clone()) {
+            continue;
+        }
+        matches.push((candidate.file, id));
+    }
+    match matches.len() {
+        0 => SessionResolution::None,
+        1 => match summarize(&matches[0].0) {
+            Some(summary) => SessionResolution::One(summary),
+            None => SessionResolution::None,
+        },
+        many => {
+            let exact = matches
+                .iter()
+                .find(|(_, id)| id == prefix)
+                .and_then(|(file, _)| summarize(file));
+            match exact {
+                Some(summary) => SessionResolution::Exact(summary),
+                None => SessionResolution::Ambiguous(many),
+            }
+        }
+    }
 }
 
 /// Read and parse every JSONL event in a session log (zstd-aware).
@@ -142,7 +273,6 @@ fn read_session_text(file: &Path) -> Result<String> {
         // Appended logs are a sequence of concatenated zstd frames (one per
         // flush); a single StreamingDecoder stops at the first frame
         // boundary, so keep decoding until the reader is exhausted.
-        use std::io::BufRead;
         let mut reader = std::io::BufReader::new(raw);
         while !reader
             .fill_buf()
@@ -160,6 +290,223 @@ fn read_session_text(file: &Path) -> Result<String> {
             .with_context(|| format!("read {}", file.display()))?;
     }
     Ok(text)
+}
+
+/// Walk a session log line by line without ever holding the whole file:
+/// plain logs are read through a buffered line reader, zstd logs one frame
+/// at a time with a carry buffer for lines split across frames. `f` returns
+/// false to stop early. Empty lines are still passed to `f`; it decides
+/// whether they matter.
+fn for_each_line(file: &Path, mut f: impl FnMut(&str) -> bool) -> Result<()> {
+    let raw = std::fs::File::open(file).with_context(|| format!("open {}", file.display()))?;
+    if file.extension().is_some_and(|e| e == "zstd") {
+        let mut reader = BufReader::new(raw);
+        let mut pending = String::new();
+        loop {
+            if reader
+                .fill_buf()
+                .with_context(|| format!("read {}", file.display()))?
+                .is_empty()
+            {
+                break;
+            }
+            let mut dec = ruzstd::decoding::StreamingDecoder::new(&mut reader)
+                .with_context(|| format!("zstd frame of {}", file.display()))?;
+            let mut chunk = String::new();
+            dec.read_to_string(&mut chunk)
+                .with_context(|| format!("decompress {}", file.display()))?;
+            pending.push_str(&chunk);
+            let mut consumed = 0;
+            let mut stop = false;
+            loop {
+                let Some(pos) = pending[consumed..].find('\n') else {
+                    break;
+                };
+                let end = consumed + pos;
+                if !f(&pending[consumed..end]) {
+                    stop = true;
+                    break;
+                }
+                consumed = end + 1;
+            }
+            pending.drain(..consumed);
+            if stop {
+                return Ok(());
+            }
+        }
+        let tail = pending.strip_suffix('\n').unwrap_or(&pending);
+        let tail = tail.strip_suffix('\r').unwrap_or(tail);
+        if !tail.trim().is_empty() {
+            f(tail);
+        }
+        Ok(())
+    } else {
+        let mut reader = BufReader::new(raw);
+        let mut line = String::new();
+        loop {
+            line.clear();
+            let read = reader
+                .read_line(&mut line)
+                .with_context(|| format!("read {}", file.display()))?;
+            if read == 0 {
+                break;
+            }
+            let text = line.strip_suffix('\n').unwrap_or(&line);
+            let text = text.strip_suffix('\r').unwrap_or(text);
+            if !f(text) {
+                break;
+            }
+        }
+        Ok(())
+    }
+}
+
+/// The header id of a session log, reading only the first parseable line.
+/// Matches [`summarize`]: the first parseable line must be the `session`
+/// header, unparseable lines before it are skipped.
+fn read_session_id(file: &Path) -> Option<String> {
+    let mut id = None;
+    for_each_line(file, |line| {
+        let line = line.trim();
+        if line.is_empty() {
+            return true;
+        }
+        if let Ok(event) = serde_json::from_str::<Value>(line) {
+            if event.get("type").and_then(Value::as_str) == Some("session") {
+                id = event.get("id").and_then(Value::as_str).map(str::to_string);
+            }
+            return false;
+        }
+        true
+    })
+    .ok()?;
+    id
+}
+
+/// Summarize one session log, streaming it line by line. Lines that cannot
+/// contribute to the summary are rejected with a substring test before the
+/// (comparatively expensive) JSON parse.
+fn summarize(file: &Path) -> Option<SessionSummary> {
+    let mut id: Option<String> = None;
+    let mut header_done = false;
+    let mut turns = 0usize;
+    let mut preview: Option<String> = None;
+    let mut title: Option<String> = None;
+    let mut provider_title: Option<String> = None;
+    for_each_line(file, |line| {
+        let line = line.trim();
+        if line.is_empty() {
+            return true;
+        }
+        if !header_done {
+            // The first parseable line must be the session header.
+            if let Ok(event) = serde_json::from_str::<Value>(line) {
+                header_done = true;
+                if event.get("type").and_then(Value::as_str) == Some("session") {
+                    id = event.get("id").and_then(Value::as_str).map(str::to_string);
+                }
+            }
+            return true;
+        }
+        if id.is_none() {
+            return false; // the first parseable line was not a session header
+        }
+        // Cheap needle test first; only the event types that can contribute
+        // to the summary are worth a JSON parse.
+        let interesting = line.contains("turn/start")
+            || line.contains("session/title")
+            || (preview.is_none() && line.contains("user/message"));
+        if !interesting {
+            return true;
+        }
+        let Ok(event) = serde_json::from_str::<Value>(line) else {
+            return true;
+        };
+        match event.get("type").and_then(Value::as_str) {
+            Some("turn/start") => turns += 1,
+            Some("session/title") => {
+                if let Some(t) = event.pointer("/data/title").and_then(Value::as_str) {
+                    let t = t.trim();
+                    if !t.is_empty() {
+                        let t = t.to_string();
+                        if event.pointer("/data/source/kind").and_then(Value::as_str)
+                            == Some("provider")
+                        {
+                            provider_title = Some(t);
+                        } else {
+                            title = Some(t);
+                        }
+                    }
+                }
+            }
+            Some("user/message") if preview.is_none() => {
+                preview = user_text(&event);
+            }
+            _ => {}
+        }
+        true
+    })
+    .ok()?;
+
+    let id = id?;
+    let preview = preview
+        .map(|t| {
+            let one_line = t.replace('\n', " ");
+            let mut p: String = one_line.chars().take(40).collect();
+            if one_line.chars().count() > 40 {
+                p.push('…');
+            }
+            p
+        })
+        .unwrap_or_default();
+    // The harness titles sessions asynchronously: a "fallback" stub derived
+    // from the first prompt arrives first, the LLM-generated "provider"
+    // title later. Keep the provider title when it exists.
+    let title = provider_title.or(title);
+    Some(SessionSummary {
+        id,
+        file: file.to_path_buf(),
+        modified: std::fs::metadata(file)
+            .and_then(|m| m.modified())
+            .unwrap_or(UNIX_EPOCH),
+        turns,
+        preview,
+        title,
+    })
+}
+
+/// Summarize several logs, in order. Decompression dominates and is
+/// independent per file, so larger batches fan out over a few threads.
+fn summarize_many(files: &[PathBuf]) -> Vec<Option<SessionSummary>> {
+    if files.is_empty() {
+        return Vec::new();
+    }
+    let threads = std::thread::available_parallelism()
+        .map(|n| n.get())
+        .unwrap_or(1)
+        .min(PARALLEL_MAX_THREADS)
+        .min(files.len());
+    if files.len() < PARALLEL_MIN_FILES || threads <= 1 {
+        return files.iter().map(|file| summarize(file)).collect();
+    }
+    let next = AtomicUsize::new(0);
+    let out: Mutex<Vec<Option<SessionSummary>>> =
+        Mutex::new((0..files.len()).map(|_| None).collect());
+    std::thread::scope(|scope| {
+        for _ in 0..threads {
+            scope.spawn(|| loop {
+                let i = next.fetch_add(1, Ordering::Relaxed);
+                if i >= files.len() {
+                    break;
+                }
+                let summary = summarize(&files[i]);
+                if let Ok(mut guard) = out.lock() {
+                    guard[i] = summary;
+                }
+            });
+        }
+    });
+    out.into_inner().unwrap_or_default()
 }
 
 /// The first real user prompt inside a `user/message` event, if any.
@@ -180,65 +527,6 @@ pub fn user_text(event: &Value) -> Option<String> {
         }
     }
     (!out.is_empty()).then_some(out)
-}
-
-fn summarize(file: &Path) -> Option<SessionSummary> {
-    let events = read_session_events(file).ok()?;
-    let header = events.first()?;
-    if header.get("type").and_then(Value::as_str) != Some("session") {
-        return None;
-    }
-    let id = header.get("id").and_then(Value::as_str)?.to_string();
-    let turns = events
-        .iter()
-        .filter(|e| e.get("type").and_then(Value::as_str) == Some("turn/start"))
-        .count();
-    let preview = events
-        .iter()
-        .find_map(user_text)
-        .map(|t| {
-            let one_line = t.replace('\n', " ");
-            let mut p: String = one_line.chars().take(40).collect();
-            if one_line.chars().count() > 40 {
-                p.push('…');
-            }
-            p
-        })
-        .unwrap_or_default();
-    // The harness titles sessions asynchronously: a "fallback" stub derived
-    // from the first prompt arrives first, the LLM-generated "provider"
-    // title later. Keep the provider title when it exists.
-    let mut title: Option<String> = None;
-    let mut provider_title: Option<String> = None;
-    for ev in &events {
-        if ev.get("type").and_then(Value::as_str) != Some("session/title") {
-            continue;
-        }
-        let Some(t) = ev.pointer("/data/title").and_then(Value::as_str) else {
-            continue;
-        };
-        let t = t.trim().to_string();
-        if t.is_empty() {
-            continue;
-        }
-        if ev.pointer("/data/source/kind").and_then(Value::as_str) == Some("provider") {
-            provider_title = Some(t);
-        } else {
-            title = Some(t);
-        }
-    }
-    let title = provider_title.or(title);
-    let modified = std::fs::metadata(file)
-        .and_then(|m| m.modified())
-        .unwrap_or(SystemTime::UNIX_EPOCH);
-    Some(SessionSummary {
-        id,
-        file: file.to_path_buf(),
-        modified,
-        turns,
-        preview,
-        title,
-    })
 }
 
 /// "just now" / "5m" / "3h" / "2d" — picker-sized age.

--- a/tests/unit/sessions__tests.rs
+++ b/tests/unit/sessions__tests.rs
@@ -204,3 +204,120 @@ fn list_sessions_limit_keeps_the_most_recent_n() {
     assert_eq!(one[0].id, "dsh-newest");
     let _ = std::fs::remove_dir_all(&tmp);
 }
+
+#[test]
+fn unreadable_logs_do_not_consume_a_limit_slot() {
+    let tmp = std::env::temp_dir().join(format!("dsh-sess-badlog-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&tmp);
+    let slug = workspace_slug("/w");
+    write_session(&tmp, &slug, "dsh-old", &[header("dsh-old")]);
+    std::thread::sleep(std::time::Duration::from_millis(20));
+    write_session(&tmp, &slug, "dsh-mid", &[header("dsh-mid")]);
+    std::thread::sleep(std::time::Duration::from_millis(20));
+    write_session(&tmp, &slug, "dsh-junk", &["not json at all".to_string()]);
+
+    // The newest candidate is foreign; `/resume 2` still returns two real
+    // sessions because the junk file does not eat a row.
+    let two = list_sessions(tmp.to_str().unwrap(), "/w", "none", 2);
+    let ids: Vec<&str> = two.iter().map(|s| s.id.as_str()).collect();
+    assert_eq!(ids, ["dsh-mid", "dsh-old"]);
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+#[test]
+fn resolve_session_handles_unique_exact_ambiguous_and_missing_prefixes() {
+    let tmp = std::env::temp_dir().join(format!("dsh-sess-resolve-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&tmp);
+    let slug = workspace_slug("/w");
+    write_session(&tmp, &slug, "dsh-alpha", &[header("dsh-alpha")]);
+    write_session(&tmp, &slug, "dsh-alphabet", &[header("dsh-alphabet")]);
+    write_session(&tmp, &slug, "dsh-beta", &[header("dsh-beta")]);
+    let root = tmp.to_str().unwrap();
+
+    match resolve_session(root, "/w", "none", "dsh-beta") {
+        SessionResolution::One(s) => assert_eq!(s.id, "dsh-beta"),
+        other => panic!("unique prefix should resolve: {other:?}"),
+    }
+    match resolve_session(root, "/w", "none", "dsh-alpha") {
+        SessionResolution::Exact(s) => assert_eq!(s.id, "dsh-alpha"),
+        other => panic!("exact id beats its longer sibling: {other:?}"),
+    }
+    match resolve_session(root, "/w", "none", "dsh-al") {
+        SessionResolution::Ambiguous(2) => {}
+        other => panic!("two matches without an exact id are ambiguous: {other:?}"),
+    }
+    assert!(
+        matches!(resolve_session(root, "/w", "none", "zzz"), SessionResolution::None),
+        "unknown prefix finds nothing"
+    );
+    assert!(
+        matches!(
+            resolve_session(root, "/w", "dsh-beta", "dsh-beta"),
+            SessionResolution::None
+        ),
+        "the active session is never offered"
+    );
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+#[test]
+fn sessions_for_ids_only_returns_requested_summaries() {
+    let tmp = std::env::temp_dir().join(format!("dsh-sess-ids-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&tmp);
+    let slug = workspace_slug("/w");
+    write_session(
+        &tmp,
+        &slug,
+        "dsh-keep",
+        &[
+            header("dsh-keep"),
+            r#"{"type":"turn/start","seq":1,"data":{"turn":1}}"#.into(),
+            user_msg("kept"),
+        ],
+    );
+    write_session(&tmp, &slug, "dsh-skip", &[header("dsh-skip"), user_msg("skipped")]);
+
+    let ids = vec!["dsh-keep".to_string(), "dsh-missing".to_string()];
+    let summaries = sessions_for_ids(tmp.to_str().unwrap(), "/w", "none", &ids);
+    assert_eq!(summaries.len(), 1);
+    let kept = summaries.get("dsh-keep").expect("requested id summarized");
+    assert_eq!(kept.turns, 1);
+    assert_eq!(kept.preview, "kept");
+    assert!(!summaries.contains_key("dsh-skip"));
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+/// A JSONL line can straddle two concatenated zstd frames; the streaming
+/// summary must join the carry instead of treating the halves as lines.
+#[test]
+fn summaries_join_lines_split_across_zstd_frames() {
+    let tmp = std::env::temp_dir().join(format!("dsh-sess-split-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&tmp);
+    let dir = tmp.join(workspace_slug("/w")).join("dsh-split");
+    std::fs::create_dir_all(&dir).unwrap();
+    let text = format!(
+        "{}\n{}\n{}\n",
+        header("dsh-split"),
+        user_msg("split across frames"),
+        r#"{"type":"turn/start","seq":1,"data":{"turn":1}}"#
+    );
+    let cut = text.find("across").unwrap() + 3;
+    let frames: Vec<u8> = [&text[..cut], &text[cut..]]
+        .iter()
+        .flat_map(|chunk| {
+            ruzstd::encoding::compress_to_vec(
+                chunk.as_bytes(),
+                ruzstd::encoding::CompressionLevel::Fastest,
+            )
+        })
+        .collect();
+    std::fs::write(dir.join("session.jsonl.zstd"), frames).unwrap();
+
+    let sessions = list_sessions(tmp.to_str().unwrap(), "/w", "other", usize::MAX);
+    assert_eq!(sessions.len(), 1);
+    assert_eq!(sessions[0].id, "dsh-split");
+    assert_eq!(sessions[0].preview, "split across frames");
+    assert_eq!(sessions[0].turns, 1);
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+


### PR DESCRIPTION
- Session summaries stream each JSONL log line by line (zstd frame by frame, joining lines split across frames) instead of reading the whole decompressed transcript into a String and every event into a Vec<Value>.
- Lines are pre-filtered with a substring test, so only turn/start, session/title and user/message lines reach serde_json.
- Candidate logs are summarized in parallel (thread::scope, up to 4 threads); an unreadable or foreign log does not consume a /resume limit slot.
- /resume <id> resolves the prefix by reading only session headers and fully summarizes just the chosen log; the ACP picker summarizes only the ids the agent listed instead of the whole local store.
- Local replay moves into replay_local_session, shared by the picker and the direct /resume <id> path.

Measured on a 15-session, ~24MB-decompressed store: /resume 4.2s -> 1.3s, /resume <id> 4.2s -> 0.7s. No persisted state or cache invalidation.