### PR TITLE
fix(host): keep /resume working against dsh 0.1.5 session persistence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,14 @@ All notable changes to this project are documented here. The project follows
 
 ### Fixed
 
+- `/resume` works again after a DeepSeek Harness update to 0.1.5: the Host's
+  `sessionPersistence` service now resolves `list()` to `{ header, revision }`
+  snapshots and reads one stored log through `open(id, 'read')`, while the ACP
+  adapter still filters rows by the row's own `cwd` and replays through the
+  removed `inspect()`. The Host compatibility layer projects the older header
+  row and `inspect()` surface back onto the live service for both
+  `dsh --profile martty` and standalone launches, so the `/resume` picker
+  opens and the chosen session resumes instead of silently listing nothing.
 - Transcript wrapping, picker/status truncation and the composer layout mirror
   now measure grapheme clusters (via `UnicodeWidthStr`) instead of summing
   per-`char` widths. ZWJ family emoji, skin-tone modifiers and variation

--- a/npm/lib/acp-host.js
+++ b/npm/lib/acp-host.js
@@ -115,10 +115,101 @@ export function installPermissionPresetsCompatibility(permissionPresets) {
   return true
 }
 
+function snapshotRowHeader(row) {
+  if (row === null || typeof row !== 'object') return undefined
+  const header = row.header
+  if (header === null || typeof header !== 'object' || typeof header.id !== 'string') {
+    return undefined
+  }
+  return header
+}
+
+/**
+ * One legacy `list()` row: the header itself, plus the snapshot fields a newer
+ * Host consumer reads off the same row (`header`, `revision`, sizes).
+ */
+function legacyListRow(snapshot) {
+  const header = snapshotRowHeader(snapshot)
+  if (header === undefined) return undefined
+  const row = { ...header }
+  for (const key of ['header', 'revision', 'eventCount', 'sizeBytes']) {
+    if (snapshot[key] === undefined) continue
+    Object.defineProperty(row, key, {
+      configurable: true,
+      value: key === 'header' ? header : snapshot[key],
+    })
+  }
+  return row
+}
+
+/**
+ * dsh 0.1.5 folded `listSnapshots()` into `list()` and replaced `inspect()`
+ * with per-session handles: `list()` now resolves to `{ header, revision }`
+ * snapshots, and one stored log is read through `open(id, 'read')`. ACP 0.4.x
+ * still filters listed rows by the row's own `cwd` and replays titles and
+ * resume history through `inspect()`, so project the removed header/inspection
+ * surface back onto the live service until ACP can require the handle API.
+ *
+ * Rows stay snapshot-compatible, so a newer Host consumer reading `.header`
+ * keeps working while ACP reads the header fields directly.
+ */
+export function installSessionPersistenceCompatibility(ctx) {
+  const service = ctx?.get?.('sessionPersistence')
+  if (service === undefined || service === null) return false
+  const list = service.list
+  if (typeof list !== 'function' || typeof service.open !== 'function') return false
+  if (list.dshTuiReturnsHeaders === true) return false
+
+  const compatibleList = async function (options) {
+    const listed = await list.call(this, options)
+    if (!Array.isArray(listed)) return listed
+    return listed.map((row) => legacyListRow(row) ?? row)
+  }
+  Object.defineProperty(compatibleList, 'dshTuiReturnsHeaders', { value: true })
+
+  // The class methods live on the prototype: restore by deleting the own
+  // property when the patch shadowed one instead of replacing an own value.
+  const listDescriptor = Object.getOwnPropertyDescriptor(service, 'list')
+  Object.defineProperty(service, 'list', { configurable: true, value: compatibleList })
+
+  let compatibleInspect
+  if (typeof service.inspect !== 'function') {
+    compatibleInspect = async function (id, signal) {
+      const options = signal === undefined ? undefined : { signal }
+      const handle = await service.open(id, 'read', options)
+      try {
+        const { events } = await handle.read(0, undefined, options)
+        const header = handle.header
+        // `meta` is the old coordinator's field; `header` is what ACP reads.
+        return Object.freeze({
+          meta: header,
+          header,
+          inheritedEventCount: handle.inheritedEventCount,
+          events,
+        })
+      } finally {
+        await handle.close().catch(() => {})
+      }
+    }
+    Object.defineProperty(service, 'inspect', { configurable: true, value: compatibleInspect })
+  }
+
+  ctx.effect?.(() => () => {
+    if (service.list !== compatibleList) return
+    if (listDescriptor === undefined) delete service.list
+    else Object.defineProperty(service, 'list', listDescriptor)
+    if (service.inspect === compatibleInspect) delete service.inspect
+  }, 'dsh-tui.session-persistence-compatibility')
+  return true
+}
+
 async function mountHostCompatibility(ctx) {
   // The service can come from the active Host even when module resolution
   // below lands on ACP's older peer copy, so adapt the live instance directly.
   installPermissionPresetsCompatibility(ctx.permissionPresets ?? ctx.get?.('permissionPresets'))
+  // Not injected here on purpose: the profile's base bundle owns persistence,
+  // and `ctx.get` reads the live service without adding a mount dependency.
+  installSessionPersistenceCompatibility(ctx)
 
   const sessionModule = resolvedHostModule(ctx, '@deepseek-ai/dsh-session')
   if (sessionModule !== undefined) {

--- a/npm/lib/creator-overlay.js
+++ b/npm/lib/creator-overlay.js
@@ -4,6 +4,7 @@
  */
 
 import { readFileSync } from 'node:fs'
+import { installSessionPersistenceCompatibility } from './acp-host.js'
 import { createTuiPluginStore } from './tui-plugin-store.js'
 
 export const name = 'tui-creator-overlay'
@@ -192,6 +193,11 @@ const skillContent = skillDocument.slice(skillFrontmatter[0].length)
  * @param {{ preset?: string }} [config]
  */
 export async function apply(ctx, config = {}) {
+  // Standalone launches mount this overlay directly into the ACP Host tree,
+  // which never loads martty/acp-host; both trees need the ACP compatibility
+  // surface, and the installer is idempotent when the profile path already
+  // applied it on this service instance.
+  installSessionPersistenceCompatibility(ctx)
   const preset = config.preset ?? 'cordis'
   if (typeof preset !== 'string' || preset.length === 0) {
     throw new Error('tui-creator-overlay: preset must be a non-empty string')

--- a/scripts/creator-overlay.test.mjs
+++ b/scripts/creator-overlay.test.mjs
@@ -6,7 +6,7 @@ import test from 'node:test'
 
 import * as creatorOverlay from '../npm/lib/creator-overlay.js'
 
-function harness() {
+function harness(options = {}) {
   const skills = new Map()
   const promptSections = []
   const tools = new Map()
@@ -24,6 +24,31 @@ function harness() {
     code: { client: 'return { apply() {} }' },
     currentPackageId: 'dyn-1',
   }
+  const header = {
+    id: 'stored-1',
+    version: 3,
+    createdAt: 1,
+    cwd: '/work/one',
+    isSeeded: false,
+    delegationDepth: 0,
+  }
+  const persistence = options.persistence === true
+    ? {
+        async list() {
+          return [{ header, revision: 'rev-1', sizeBytes: 3 }]
+        },
+        async open() {
+          return {
+            header,
+            inheritedEventCount: 0,
+            async read() {
+              return { events: [] }
+            },
+            async close() {},
+          }
+        },
+      }
+    : undefined
 
   const overlay = {
     ctx: {
@@ -61,6 +86,9 @@ function harness() {
   }
 
   const ctx = {
+    get(name) {
+      return name === 'sessionPersistence' ? persistence : undefined
+    },
     agentPresets: {
       async standingKeyFor(id) {
         requestedPreset = id
@@ -96,6 +124,7 @@ function harness() {
   return {
     ctx,
     effects,
+    persistence,
     promptSections,
     skills,
     tools,
@@ -112,6 +141,16 @@ test('exports one internal Host overlay with the required injected services', ()
     creatorOverlay.inject,
     ['agentPresets', 'skills', 'systemPrompt', 'loader', 'tools', 'dynamicCordisRunner'],
   )
+})
+
+test('applies the standalone Host compatibility shim to the ACP persistence service', async () => {
+  const fixture = harness({ persistence: true })
+  await creatorOverlay.apply(fixture.ctx)
+
+  const listed = await fixture.persistence.list()
+  assert.deepEqual(listed.map((row) => row.id), ['stored-1'])
+  assert.equal(listed[0].cwd, '/work/one')
+  assert.equal(typeof fixture.persistence.inspect, 'function')
 })
 
 test('adds the TUI companion skill only to the requested preset scope', async () => {

--- a/scripts/profile-link-resolution.test.mjs
+++ b/scripts/profile-link-resolution.test.mjs
@@ -217,3 +217,108 @@ test('ACP Host lets legacy ACP read dsh 0.1.2 permission state from events', asy
   }])
   assert.equal(acpHost.installPermissionPresetsCompatibility(permissionPresets), false)
 })
+
+test('ACP Host projects dsh 0.1.5 persistence snapshots back to headers and inspection', async () => {
+  const acpHost = await import(
+    pathToFileURL(path.join(packageLib, 'acp-host.js')).href
+  )
+  const headers = [
+    {
+      id: 'a',
+      version: 3,
+      createdAt: 20,
+      cwd: '/work/one',
+      isSeeded: false,
+      delegationDepth: 0,
+    },
+    {
+      id: 'b',
+      version: 3,
+      createdAt: 10,
+      cwd: '/work/two',
+      isSeeded: false,
+      delegationDepth: 0,
+    },
+  ]
+  const events = Object.freeze([{ type: 'turn/start' }])
+  const opened = []
+  const closed = []
+  const service = {
+    async list() {
+      return headers.map((header) => ({
+        header,
+        revision: `rev-${header.id}`,
+        sizeBytes: 7,
+      }))
+    },
+    async open(id, access, options) {
+      opened.push({ id, access, options })
+      return {
+        header: headers.find((header) => header.id === id),
+        inheritedEventCount: 0,
+        async read() {
+          return { eventState: 'shared-frozen', events }
+        },
+        async close() {
+          closed.push(id)
+        },
+      }
+    },
+  }
+  const originalList = service.list
+  const effects = []
+  const ctx = {
+    get(name) {
+      return name === 'sessionPersistence' ? service : undefined
+    },
+    effect(callback) {
+      effects.push(callback())
+    },
+  }
+
+  assert.equal(acpHost.installSessionPersistenceCompatibility(ctx), true)
+  assert.equal(acpHost.installSessionPersistenceCompatibility(ctx), false)
+
+  const listed = await service.list()
+  assert.deepEqual(listed.map((row) => row.id), ['a', 'b'])
+  assert.deepEqual(listed.map((row) => row.cwd), ['/work/one', '/work/two'])
+  // Newer Host consumers read the same row through its snapshot wrapper.
+  assert.equal(listed[0].header, headers[0])
+  assert.equal(listed[0].revision, 'rev-a')
+  assert.equal(listed[0].sizeBytes, 7)
+
+  const signal = new AbortController().signal
+  const inspection = await service.inspect('b', signal)
+  assert.equal(inspection.header, headers[1])
+  assert.equal(inspection.meta, headers[1])
+  assert.equal(inspection.events, events)
+  assert.deepEqual(opened, [{ id: 'b', access: 'read', options: { signal } }])
+  assert.deepEqual(closed, ['b'])
+
+  await Promise.all(effects.map((dispose) => dispose()))
+  assert.equal(service.list, originalList)
+  assert.equal(service.inspect, undefined)
+})
+
+test('ACP Host leaves an older persistence service and a missing one untouched', async () => {
+  const acpHost = await import(
+    pathToFileURL(path.join(packageLib, 'acp-host.js')).href
+  )
+  const legacy = {
+    async list() {
+      return [{ id: 'a', cwd: '/work/one' }]
+    },
+    async inspect() {
+      return { meta: { id: 'a' }, events: [] }
+    },
+  }
+  assert.equal(
+    acpHost.installSessionPersistenceCompatibility({ get: () => legacy }),
+    false,
+  )
+  assert.deepEqual(await legacy.list(), [{ id: 'a', cwd: '/work/one' }])
+  assert.equal(
+    acpHost.installSessionPersistenceCompatibility({ get: () => undefined }),
+    false,
+  )
+})


### PR DESCRIPTION
## Symptom

With a dsh Host at 0.1.5, `/resume` lists nothing: stored sessions are invisible and a selected session never reopens. `/resume` works again on 0.1.4-.

## Cause

dsh 0.1.5 changed the Host `sessionPersistence` service:

| before | 0.1.5 |
|---|---|
| `listSnapshots()`, with `list()` returning header rows | `list()` resolves to `{ header, revision, sizeBytes }` snapshots |
| `inspect(id)` returning `{ meta, events }` | per-session handle: `open(id, 'read')` then `read()` / `close()` |

ACP 0.4.x still filters listed rows by the row's own `cwd` and replays titles and resume history through `inspect()`. After the Host update the adapter matched no rows and found no inspection surface, so the picker opened empty.

## Fix

`npm/lib/acp-host.js` gains `installSessionPersistenceCompatibility()`, mounted beside the existing dsh 0.1.2 permission/session compatibility shims:

- `list()` rows project back to header rows, while keeping the snapshot fields a newer Host consumer reads off the same row (`.header`, `.revision`, `.sizeBytes`);
- `inspect(id, signal)` is rebuilt on `open(id, 'read')` + `read(0, undefined, { signal })` + `close()`;
- idempotent (marked once per service instance) and disposed through `ctx.effect`, restoring the original descriptors;
- a missing service, a pure-legacy service, or a service without `open()` is left untouched.

`npm/lib/creator-overlay.js` installs the same shim for standalone launches, which mount the creator overlay without loading `acp-host`.

## Verification

- `node --test scripts/profile-link-resolution.test.mjs scripts/creator-overlay.test.mjs` → 15/15 pass
- `npm test --prefix npm` → 439 pass, 0 fail, 3 skipped
- No Rust changes; `cargo test --locked` unaffected (not run)

New cases cover the projection (header fields plus snapshot wrapper), `inspect` handle access/close and signal forwarding, idempotency, disposer restore, and the untouched legacy/missing-service paths.

CHANGELOG entry added under `[Unreleased] / Fixed`.
