### PR TITLE
chore(deps): align ACP adapter and dsh baseline with DSH 0.1.5-rc.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,11 @@ All notable changes to this project are documented here. The project follows
 
 ### Fixed
 
+- The embedded ACP adapter moves to `@openma/deepseek-harness-acp` 0.4.31,
+  which carries DSH 0.1.5-rc.1 with session write ownership and keeps ACP
+  events and question routing intact in Web hosts. The development and CI
+  harness baseline moves to `@deepseek-ai/dsh` 0.1.5-rc.1 as well, so the
+  profile install matrix exercises the same DSH generation the adapter ships.
 - `/resume` works again after a DeepSeek Harness update to 0.1.5: the Host's
   `sessionPersistence` service now resolves `list()` to `{ header, revision }`
   snapshots and reads one stored log through `open(id, 'read')`, while the ACP

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -523,7 +523,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-harness-tui"
-version = "0.2.37"
+version = "0.2.38"
 dependencies = [
  "agent-client-protocol",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deepseek-harness-tui"
-version = "0.2.37"
+version = "0.2.38"
 edition = "2021"
 description = "Terminal-native ACP client UI with a Cordis client plugin tree"
 license = "MIT"

--- a/npm/package-lock.json
+++ b/npm/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@openma/deepseek-harness-acp": "0.4.29",
+        "@openma/deepseek-harness-acp": "0.4.31",
         "cross-spawn": "^7.0.6",
         "node-downloader-helper": "2.1.11"
       },
@@ -19,7 +19,7 @@
         "martty": "bin/martty.js"
       },
       "devDependencies": {
-        "@deepseek-ai/dsh": "0.1.1-rc.2"
+        "@deepseek-ai/dsh": "0.1.5-rc.1"
       },
       "engines": {
         "node": ">=18"
@@ -35,13 +35,14 @@
       }
     },
     "node_modules/@anthropic-ai/sdk": {
-      "version": "0.91.1",
-      "resolved": "https://registry.npmmirror.com/@anthropic-ai/sdk/-/sdk-0.91.1.tgz",
-      "integrity": "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==",
+      "version": "0.123.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.123.0.tgz",
+      "integrity": "sha512-Y9oX9mPNGZClHQOFqrWRk43Srcu/UHuPq3rfxxOq7JgW0gi+lJA2MAOK4Ul3k/+AUrwRWFJvd0tK3oC0Pw25dw==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "json-schema-to-ts": "^3.1.1"
+        "json-schema-to-ts": "^3.1.1",
+        "standardwebhooks": "^1.0.0"
       },
       "bin": {
         "anthropic-ai-sdk": "bin/cli"
@@ -57,7 +58,7 @@
     },
     "node_modules/@aws-crypto/sha256-browser": {
       "version": "5.2.0",
-      "resolved": "https://registry.npmmirror.com/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
       "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
       "devOptional": true,
       "license": "Apache-2.0",
@@ -73,7 +74,7 @@
     },
     "node_modules/@aws-crypto/sha256-js": {
       "version": "5.2.0",
-      "resolved": "https://registry.npmmirror.com/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
       "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
       "devOptional": true,
       "license": "Apache-2.0",
@@ -88,7 +89,7 @@
     },
     "node_modules/@aws-crypto/supports-web-crypto": {
       "version": "5.2.0",
-      "resolved": "https://registry.npmmirror.com/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
       "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
       "devOptional": true,
       "license": "Apache-2.0",
@@ -98,7 +99,7 @@
     },
     "node_modules/@aws-crypto/util": {
       "version": "5.2.0",
-      "resolved": "https://registry.npmmirror.com/@aws-crypto/util/-/util-5.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
       "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
       "devOptional": true,
       "license": "Apache-2.0",
@@ -110,7 +111,7 @@
     },
     "node_modules/@aws-sdk/client-bedrock-runtime": {
       "version": "3.1048.0",
-      "resolved": "https://registry.npmmirror.com/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1048.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1048.0.tgz",
       "integrity": "sha512-u+NT61JZEkRFtpL0CAw1N1dwxnaLgwVXQl/zjJxTGgLyS/jTIdg2SdoEoCTHxgDyCnqa1HEi9QOoE9/pYRNpOQ==",
       "devOptional": true,
       "license": "Apache-2.0",
@@ -135,9 +136,9 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.977.9",
-      "resolved": "https://registry.npmmirror.com/@aws-sdk/core/-/core-3.977.9.tgz",
-      "integrity": "sha512-reqPFEQrZxDZpeGj4PFMepBeR5LGYHRqq/L0motTzgFkCRBA4rFdaVXDSLYyGHhxVz7sT2PDnPN9CluGSfgyJA==",
+      "version": "3.978.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.978.0.tgz",
+      "integrity": "sha512-2yX9LUmxPklVjSGTb8dfnWRJSiFQ3TeH2nn7G1mdKHTfnabzF0+gfrS8rYfLWmZrQ8A3mEcxMJjRc51dL5KWaA==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -155,13 +156,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.70",
-      "resolved": "https://registry.npmmirror.com/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.70.tgz",
-      "integrity": "sha512-H404B7dJl2mCrBqahDEYsanB0xhdDp6tXnXcTUnXmmpy2Q3J0Ho0bUajZ2jr/RdwzCyS59Gi8xXIFwPLGBl6Uw==",
+      "version": "3.972.71",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.71.tgz",
+      "integrity": "sha512-JN+JHruYZw3GUZB8YGAlDk4wTDPOEAEEdEzj5nS0xodWR4smzHsN7PnK2j6IeOsDIj2aqua5DSbhXl9Gtf90FQ==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/core": "^3.978.0",
         "@aws-sdk/types": "^3.974.5",
         "@smithy/core": "^3.33.3",
         "@smithy/types": "^4.17.2",
@@ -172,13 +173,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.72",
-      "resolved": "https://registry.npmmirror.com/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.72.tgz",
-      "integrity": "sha512-X98zYOrVOeuosCX+6ktf29FC2N2GHPLia7qv6mzPzTc+RPAuHWCDS++Z6JK7eGYqb/v6uaW7bAXaOvDBfol+0w==",
+      "version": "3.972.73",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.73.tgz",
+      "integrity": "sha512-uyYYnJOnlis8uQzaYGPd7N1JoioCoNpXgnkXYixsWJXHXgXyYi8WXJSDfofxJeWfQIGWLe2Nwyq60Uc7MZdVOg==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/core": "^3.978.0",
         "@aws-sdk/types": "^3.974.5",
         "@smithy/core": "^3.33.3",
         "@smithy/fetch-http-handler": "^5.7.2",
@@ -191,14 +192,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/node-http-handler": {
-      "version": "4.11.3",
-      "resolved": "https://registry.npmmirror.com/@smithy/node-http-handler/-/node-http-handler-4.11.3.tgz",
-      "integrity": "sha512-2jY1tSpERfPfWqyBV2pH+iGFaghVsIJszJNsT7hxtQYhVJpWDyc0LqOWI+nXOxOAHaEfZ4PXXtp1wW1TGpHhkA==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.12.1.tgz",
+      "integrity": "sha512-ThMkboGeONWXAelq9FvGsuJC4rOi+qyC4/zhUF58xYpxUg5sQKx2VXZYJmtNjr4dSuBJ1HeJXETQILCz3wOHvw==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/core": "^3.33.3",
-        "@smithy/types": "^4.17.2",
+        "@smithy/types": "^4.18.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -206,20 +207,20 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.973.15",
-      "resolved": "https://registry.npmmirror.com/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.15.tgz",
-      "integrity": "sha512-Rykg6s5ceBuynMOGWgoowO4N+27JfnqXAnVaSunZl0hOO1XodSrxGNz6sCEbnmS0lAfQZDKyb3fbr46gSuv6Sg==",
+      "version": "3.973.16",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.16.tgz",
+      "integrity": "sha512-i++ly+0Uxa+u3ebSSyr0S/3CFhFJDxCXT3+Zj+mW2bXenEx5bKGCdTIKFu39SgXBNhWDjex/8cXUx9MUTMCrTw==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.9",
-        "@aws-sdk/credential-provider-env": "^3.972.70",
-        "@aws-sdk/credential-provider-http": "^3.972.72",
-        "@aws-sdk/credential-provider-login": "^3.972.77",
-        "@aws-sdk/credential-provider-process": "^3.972.70",
-        "@aws-sdk/credential-provider-sso": "^3.973.14",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.76",
-        "@aws-sdk/nested-clients": "^3.997.44",
+        "@aws-sdk/core": "^3.978.0",
+        "@aws-sdk/credential-provider-env": "^3.972.71",
+        "@aws-sdk/credential-provider-http": "^3.972.73",
+        "@aws-sdk/credential-provider-login": "^3.972.78",
+        "@aws-sdk/credential-provider-process": "^3.972.71",
+        "@aws-sdk/credential-provider-sso": "^3.973.15",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.77",
+        "@aws-sdk/nested-clients": "^3.997.45",
         "@aws-sdk/types": "^3.974.5",
         "@smithy/core": "^3.33.3",
         "@smithy/credential-provider-imds": "^4.4.16",
@@ -231,14 +232,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.77",
-      "resolved": "https://registry.npmmirror.com/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.77.tgz",
-      "integrity": "sha512-Jb59xfEISoN5mmbnA+HYqdtrSX3CgCtJoof+V5D8/TgUI56W63GEEd5Y58WijU3Ou6+WEgaLD1feVzaRXV5IDQ==",
+      "version": "3.972.78",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.78.tgz",
+      "integrity": "sha512-eUtswnXu0+Ii9ieRK+0L7aPFV3Z/dnW2VntJzjBP9xs8s+8p5nBNuymIXtXwZ+5r5+XJP3e32nMkuZ/r0HozEA==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.9",
-        "@aws-sdk/nested-clients": "^3.997.44",
+        "@aws-sdk/core": "^3.978.0",
+        "@aws-sdk/nested-clients": "^3.997.45",
         "@aws-sdk/types": "^3.974.5",
         "@smithy/core": "^3.33.3",
         "@smithy/types": "^4.17.2",
@@ -249,18 +250,18 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.81",
-      "resolved": "https://registry.npmmirror.com/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.81.tgz",
-      "integrity": "sha512-Rml+WitoFvXmv6JZ18U/xGdGDGGvB/mOin0ya0lTnTrdC0Z1lrVxTYh7iNklZBcvcRMrs4DoEf6xy1KWyrLQQw==",
+      "version": "3.972.83",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.83.tgz",
+      "integrity": "sha512-jdso7ejzfRnatxMUZK4S/U6KbaDPCvfIV4XL+IQAPFDBt5rj5Fq595euqlK8Le4lNCMFR9oUpt+1l0aMgaayOQ==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.70",
-        "@aws-sdk/credential-provider-http": "^3.972.72",
-        "@aws-sdk/credential-provider-ini": "^3.973.15",
-        "@aws-sdk/credential-provider-process": "^3.972.70",
-        "@aws-sdk/credential-provider-sso": "^3.973.14",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.76",
+        "@aws-sdk/credential-provider-env": "^3.972.71",
+        "@aws-sdk/credential-provider-http": "^3.972.73",
+        "@aws-sdk/credential-provider-ini": "^3.973.16",
+        "@aws-sdk/credential-provider-process": "^3.972.71",
+        "@aws-sdk/credential-provider-sso": "^3.973.15",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.77",
         "@aws-sdk/types": "^3.974.5",
         "@smithy/core": "^3.33.3",
         "@smithy/credential-provider-imds": "^4.4.16",
@@ -272,13 +273,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.70",
-      "resolved": "https://registry.npmmirror.com/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.70.tgz",
-      "integrity": "sha512-2ry03fGRJr4sV3jI+ocjj5JqALnFD6ymM5KiNCDZMvq8bX2GSbE0vji4aM43TVCl2nXqqLRZaUxdq/KeWRAY4Q==",
+      "version": "3.972.71",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.71.tgz",
+      "integrity": "sha512-lYmXJa4gvq4xN1lrT5NiP5vIYYKcGWAdj8y+8o6dlcateB5eF3Dn8DtmjjHKfMBrTPAMr2pebIiX/UOj8c1/UA==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/core": "^3.978.0",
         "@aws-sdk/types": "^3.974.5",
         "@smithy/core": "^3.33.3",
         "@smithy/types": "^4.17.2",
@@ -289,15 +290,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.973.14",
-      "resolved": "https://registry.npmmirror.com/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.14.tgz",
-      "integrity": "sha512-jkhg/8ocAAoc0RFyLMhCw+/zZh7gystQgd4F4hznNa8P4Cc501PQmxd+jGLiMHodPJ+7Zv/3znM62gZojyasmA==",
+      "version": "3.973.15",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.15.tgz",
+      "integrity": "sha512-6Jhcf4v0pSFdjk1EW2kvzuEBKD+UZ2uNcHUIglKKLndD20YhvkL2kdmDOV5/j4mYuWWwe/a1FQ1aomU86/Cg5Q==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.9",
-        "@aws-sdk/nested-clients": "^3.997.44",
-        "@aws-sdk/token-providers": "3.1116.0",
+        "@aws-sdk/core": "^3.978.0",
+        "@aws-sdk/nested-clients": "^3.997.45",
+        "@aws-sdk/token-providers": "3.1129.0",
         "@aws-sdk/types": "^3.974.5",
         "@smithy/core": "^3.33.3",
         "@smithy/types": "^4.17.2",
@@ -308,14 +309,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/token-providers": {
-      "version": "3.1116.0",
-      "resolved": "https://registry.npmmirror.com/@aws-sdk/token-providers/-/token-providers-3.1116.0.tgz",
-      "integrity": "sha512-ygIivKqh8aHzNkucOCXHyIBgBpLPfrSI0mCqXF+vLBsPTUKqj0VSqAY0GFPe7lQl4HntjOcQ+KSyS7oUV2C54Q==",
+      "version": "3.1129.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1129.0.tgz",
+      "integrity": "sha512-Sbl3rpzQdsG4ZK2zh0JWUYyZPKKorJlVOddA2T0DVbKJFrsW8J6wgnslxxUH04+WaBMr4A1HzJZvZX0xUvkniA==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.9",
-        "@aws-sdk/nested-clients": "^3.997.44",
+        "@aws-sdk/core": "^3.978.0",
+        "@aws-sdk/nested-clients": "^3.997.45",
         "@aws-sdk/types": "^3.974.5",
         "@smithy/core": "^3.33.3",
         "@smithy/types": "^4.17.2",
@@ -326,14 +327,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.76",
-      "resolved": "https://registry.npmmirror.com/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.76.tgz",
-      "integrity": "sha512-d3AGyVu759PGr35mEB2s22xxlNEA5rpdxtSPJthfPFJvoQ8dt357iVPECqWfUxXp1toJAvKmbtcIYVGigaGsCA==",
+      "version": "3.972.77",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.77.tgz",
+      "integrity": "sha512-uylIQSUWpfLuH2LovxEEfwzJGM/SabLOfLMg6YXu/E8jJEKUdpdILCVCQCdFvHyu/7dLJOHPMfrSwduxO56NkQ==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.9",
-        "@aws-sdk/nested-clients": "^3.997.44",
+        "@aws-sdk/core": "^3.978.0",
+        "@aws-sdk/nested-clients": "^3.997.45",
         "@aws-sdk/types": "^3.974.5",
         "@smithy/core": "^3.33.3",
         "@smithy/types": "^4.17.2",
@@ -345,7 +346,7 @@
     },
     "node_modules/@aws-sdk/eventstream-handler-node": {
       "version": "3.972.34",
-      "resolved": "https://registry.npmmirror.com/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.34.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.34.tgz",
       "integrity": "sha512-cTeVzpu1xEAkryTZBYhGwnQ6gOGyp8ZYZvmn0Sg/nI/ABmy/CRHHxPDJDUi9PxwxUtGGaatvfRUB3FCgT/rSWw==",
       "devOptional": true,
       "license": "Apache-2.0",
@@ -361,7 +362,7 @@
     },
     "node_modules/@aws-sdk/middleware-eventstream": {
       "version": "3.972.29",
-      "resolved": "https://registry.npmmirror.com/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.29.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.29.tgz",
       "integrity": "sha512-dlRzHCgyB8W6hLuDC5pcT5q+ziPt00n4QGgGBE17ucLVU4zMa6lsbuUdQ2Pm75Z5VA8GF+R/+SgrRcaTdIzSIQ==",
       "devOptional": true,
       "license": "Apache-2.0",
@@ -376,13 +377,13 @@
       }
     },
     "node_modules/@aws-sdk/middleware-websocket": {
-      "version": "3.972.52",
-      "resolved": "https://registry.npmmirror.com/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.52.tgz",
-      "integrity": "sha512-vsPPM+nMbKJlUCFU+eoGZbdxdxDIAX9LbpjSXaR5Ufpmqgp8TdYQnoExhLu4T3umW/JIIPny1ydbhWidZZYokQ==",
+      "version": "3.972.53",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.53.tgz",
+      "integrity": "sha512-bIrDaMENQmYRBHntOiOheqkiw5+fhKW4Lqb+mS1uqF0VwvdWI22fW2HFgWrng66CmYd+4k8ePlpj38sEfTuMLQ==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/core": "^3.978.0",
         "@aws-sdk/types": "^3.974.5",
         "@smithy/core": "^3.33.3",
         "@smithy/fetch-http-handler": "^5.7.2",
@@ -395,13 +396,13 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.997.44",
-      "resolved": "https://registry.npmmirror.com/@aws-sdk/nested-clients/-/nested-clients-3.997.44.tgz",
-      "integrity": "sha512-NhEgryjlBF9w38ZXqGymQV28IhkYa1mKhlbYnqIis57AYwWGVYfUPgg/qC2rLRqOUfblxx++irvju10kVTa8Vw==",
+      "version": "3.997.45",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.45.tgz",
+      "integrity": "sha512-mooq9Q+jLa18VoM7HouczmslZU60iiB0aKc/Ztnq/luIL1ud0z4DnYprLR/ZO1gp331S9tJctM1HZr7u6YKBXQ==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/core": "^3.978.0",
         "@aws-sdk/signature-v4-multi-region": "^3.996.46",
         "@aws-sdk/types": "^3.974.5",
         "@smithy/core": "^3.33.3",
@@ -415,14 +416,14 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/node-http-handler": {
-      "version": "4.11.3",
-      "resolved": "https://registry.npmmirror.com/@smithy/node-http-handler/-/node-http-handler-4.11.3.tgz",
-      "integrity": "sha512-2jY1tSpERfPfWqyBV2pH+iGFaghVsIJszJNsT7hxtQYhVJpWDyc0LqOWI+nXOxOAHaEfZ4PXXtp1wW1TGpHhkA==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.12.1.tgz",
+      "integrity": "sha512-ThMkboGeONWXAelq9FvGsuJC4rOi+qyC4/zhUF58xYpxUg5sQKx2VXZYJmtNjr4dSuBJ1HeJXETQILCz3wOHvw==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/core": "^3.33.3",
-        "@smithy/types": "^4.17.2",
+        "@smithy/types": "^4.18.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -431,7 +432,7 @@
     },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
       "version": "3.996.46",
-      "resolved": "https://registry.npmmirror.com/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.46.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.46.tgz",
       "integrity": "sha512-L+2xZTye/2T96f3lwCws0Zw6GG2JHZW9e8FpVgGBeeExSKyeoZ6CWRpBml/7DNiK/O26jrgPM9F+Ay8VkgzUWQ==",
       "devOptional": true,
       "license": "Apache-2.0",
@@ -447,7 +448,7 @@
     },
     "node_modules/@aws-sdk/token-providers": {
       "version": "3.1048.0",
-      "resolved": "https://registry.npmmirror.com/@aws-sdk/token-providers/-/token-providers-3.1048.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1048.0.tgz",
       "integrity": "sha512-k0y/GcuesuSfWyUM0WamrGyeZmltRYaPbHO82UDA6mZ/doB+FOHKutikPAtSXMn/hDz970cF+iRuuiYO9VEbAA==",
       "devOptional": true,
       "license": "Apache-2.0",
@@ -465,7 +466,7 @@
     },
     "node_modules/@aws-sdk/types": {
       "version": "3.974.5",
-      "resolved": "https://registry.npmmirror.com/@aws-sdk/types/-/types-3.974.5.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.5.tgz",
       "integrity": "sha512-LkwLL2BLbC6wNNm4JaH9mbEqBMdOZCct6VAYqhdN4U1xrWM+fUJQEfbHwQgDypapOWTRtlk25akb5afM0P8CIQ==",
       "devOptional": true,
       "license": "Apache-2.0",
@@ -479,7 +480,7 @@
     },
     "node_modules/@aws-sdk/util-locate-window": {
       "version": "3.965.10",
-      "resolved": "https://registry.npmmirror.com/@aws-sdk/util-locate-window/-/util-locate-window-3.965.10.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.10.tgz",
       "integrity": "sha512-ycwH6Zd2GhuSqdXX9ihbCjeGTB6xOJs+O3+Jb8/zDG9978XU80qs75dfkPJRMNKe5MvBZPuNeFpd4JZKPoUF4g==",
       "devOptional": true,
       "license": "Apache-2.0",
@@ -492,7 +493,7 @@
     },
     "node_modules/@aws-sdk/xml-builder": {
       "version": "3.972.40",
-      "resolved": "https://registry.npmmirror.com/@aws-sdk/xml-builder/-/xml-builder-3.972.40.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.40.tgz",
       "integrity": "sha512-wlFmCIGUlwF4zx/kncw+bmxTQh1HeSJq4mYV/V5cZUSJadDP3kXvGW8Rn21cimj/7y9ju+47oYWXi97vF7czaA==",
       "devOptional": true,
       "license": "Apache-2.0",
@@ -506,7 +507,7 @@
     },
     "node_modules/@aws/lambda-invoke-store": {
       "version": "0.3.0",
-      "resolved": "https://registry.npmmirror.com/@aws/lambda-invoke-store/-/lambda-invoke-store-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.3.0.tgz",
       "integrity": "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==",
       "devOptional": true,
       "license": "Apache-2.0",
@@ -516,7 +517,7 @@
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.7",
-      "resolved": "https://registry.npmmirror.com/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
       "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "devOptional": true,
       "license": "MIT",
@@ -531,7 +532,7 @@
     },
     "node_modules/@babel/helper-validator-identifier": {
       "version": "7.29.7",
-      "resolved": "https://registry.npmmirror.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
       "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "devOptional": true,
       "license": "MIT",
@@ -541,7 +542,7 @@
     },
     "node_modules/@babel/runtime": {
       "version": "7.29.7",
-      "resolved": "https://registry.npmmirror.com/@babel/runtime/-/runtime-7.29.7.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
       "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
       "devOptional": true,
       "license": "MIT",
@@ -550,20 +551,20 @@
       }
     },
     "node_modules/@deepseek-ai/cordis": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/cordis/-/cordis-4.0.1.tgz",
-      "integrity": "sha512-YBdskTU2Po1kru3GgcUWUbkTsPMA9LkSQDAY8rBkFJeajdgcQad3QPJZE26JyK99Xb6HaASvoXg2DSUTeN/0Nw==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/cordis/-/cordis-4.0.2.tgz",
+      "integrity": "sha512-asOnXP1TzFSFQlHb1iegDZp0z/8WD1c7YNrwJR/Tx2bzNuMXfcekE/I67Iv6SQXeLB4csxqCngzQKANP7gdw0g==",
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/cosmokit": "^1.8.2",
+        "@deepseek-ai/cosmokit": "^1.8.3",
         "@standard-schema/spec": "^1.1.0"
       },
       "bin": {
         "cordis": "bin.js"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis-plugin-include": "^1.0.6",
-        "@deepseek-ai/cordis-plugin-loader": "^1.0.2"
+        "@deepseek-ai/cordis-plugin-include": "^1.0.7",
+        "@deepseek-ai/cordis-plugin-loader": "^1.0.3"
       },
       "peerDependenciesMeta": {
         "@deepseek-ai/cordis-plugin-include": {
@@ -575,61 +576,61 @@
       }
     },
     "node_modules/@deepseek-ai/cordis-plugin-group": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/cordis-plugin-group/-/cordis-plugin-group-1.0.1.tgz",
-      "integrity": "sha512-E1NThkFB3jn3TCqa6Oc++1zQHqLejF3W2wDwv2BlL3UEmgtBXL1K1j1koc+j676RuiOXtJkUJlPcOntRGKLWBQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/cordis-plugin-group/-/cordis-plugin-group-1.0.2.tgz",
+      "integrity": "sha512-OeGiPD793Mhma9+rGIox95neuufwOFTqQ5jooFgrMK/Mn7Fp7Hkv/d7VKMXZz40iks2fZCbiFE6p9WjTVTQRdg==",
       "devOptional": true,
       "license": "MIT",
       "peer": true,
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/cordis-plugin-loader": "^1.0.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/cordis-plugin-loader": "^1.0.3"
       }
     },
     "node_modules/@deepseek-ai/cordis-plugin-hmr": {
-      "version": "1.0.16",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/cordis-plugin-hmr/-/cordis-plugin-hmr-1.0.16.tgz",
-      "integrity": "sha512-S7VHfylDg1+Y5O6fdYYZu0KFRAj/snHywcFPnX3KmQYa/qv2Q8IXi4zAt9ABq0BJYqhNoqRlbpGMfIjabgXjKA==",
+      "version": "1.0.17",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/cordis-plugin-hmr/-/cordis-plugin-hmr-1.0.17.tgz",
+      "integrity": "sha512-o1BooaJpwd+C80Tn5+B48MGqrfNZydlfRVQjmCrrULA4nCmlMqBKjDF2FmcZoNP+L2uX9m/6DdGKVtFpQRQVUQ==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
-        "@deepseek-ai/cosmokit": "^1.8.2",
-        "@deepseek-ai/schemastery": "^3.18.1",
+        "@deepseek-ai/cosmokit": "^1.8.3",
+        "@deepseek-ai/schemastery": "^3.18.2",
         "chokidar": "^4.0.3",
         "picomatch": "^4.0.3"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/cordis-plugin-timer": "^1.1.3"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/cordis-plugin-timer": "^1.1.4"
       }
     },
     "node_modules/@deepseek-ai/cordis-plugin-include": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/cordis-plugin-include/-/cordis-plugin-include-1.0.6.tgz",
-      "integrity": "sha512-i1VXrZCbv6tk/iUgedCNjrxxArbWT3IvRZGB5sdqJ3ectnihivXXQbRZ8JJ73DSmAPvlMGmrbtjFAfm10yvXRg==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/cordis-plugin-include/-/cordis-plugin-include-1.0.7.tgz",
+      "integrity": "sha512-bZ4S1YuOmwOeE97HnslQ6ggVQbaWz4GejJ8OcY4P/DIyc1Qhu/3Szt1XSw6c/pd37kRkxxJXGwt4cmCxWSBBuw==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/cosmokit": "^1.8.2",
+        "@deepseek-ai/cosmokit": "^1.8.3",
         "js-yaml": "^4.1.0"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/cordis-plugin-loader": "^1.0.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/cordis-plugin-loader": "^1.0.3"
       }
     },
     "node_modules/@deepseek-ai/cordis-plugin-loader": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/cordis-plugin-loader/-/cordis-plugin-loader-1.0.2.tgz",
-      "integrity": "sha512-RIW9hoVyhYDWdCI9BsvtZccPde1ECLC4OAxupwowGTak78vwVTVdb3HezTSOK1Y1/Ax3Ru0LA1pYOB04CnTxIQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/cordis-plugin-loader/-/cordis-plugin-loader-1.0.3.tgz",
+      "integrity": "sha512-YNcHiH7TRFrgnRbQU7qdS1spABUFFHg04QpB9DdboPEjgKLTFfeEAvr6Y7qll3/nGgqywDQdk1tYshqKO0p1WQ==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/cosmokit": "^1.8.2"
+        "@deepseek-ai/cosmokit": "^1.8.3"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
+        "@deepseek-ai/cordis": "^4.0.2",
         "node-addon-require-builtin": "^0.1.4"
       },
       "peerDependenciesMeta": {
@@ -639,90 +640,100 @@
       }
     },
     "node_modules/@deepseek-ai/cordis-plugin-timer": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/cordis-plugin-timer/-/cordis-plugin-timer-1.1.3.tgz",
-      "integrity": "sha512-IOkey1VNmJwYa5U8bksyMOnM7mtirqjjbWLr3xA8QybLMK0sMooG3a6iJwtvd8P3MFwo3FQibEg+JPixp37MEw==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/cordis-plugin-timer/-/cordis-plugin-timer-1.1.4.tgz",
+      "integrity": "sha512-GhxOiU+TF2BbNBKlV2N24zvfv2Kh7RxkFW1hjML6s+DOb+y2zomzbeC5zHIIjsc/rpRwbKpDNucPGSwkH0ChXw==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/cosmokit": "^1.8.2"
+        "@deepseek-ai/cosmokit": "^1.8.3"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1"
+        "@deepseek-ai/cordis": "^4.0.2"
       }
     },
     "node_modules/@deepseek-ai/cosmokit": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/cosmokit/-/cosmokit-1.8.2.tgz",
-      "integrity": "sha512-muBOKtSrUKU5m/xpq8ZXWL6hQ/jgd4PhU2PqH97bcxIiLEJfNwZOGQEx4t/aS/GgxRAR+ra9pMHPMtTHU4sqqA==",
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/cosmokit/-/cosmokit-1.8.3.tgz",
+      "integrity": "sha512-qBo+ronVM6Eu2WNVJXi8JcMiqZ19T9BRIpV+5qJUFPXjGH/Z0QKcQMC/IZJ7L394YTOtJgcovbk9qP0w2GsBXQ==",
       "license": "MIT"
     },
     "node_modules/@deepseek-ai/dsh": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh/-/dsh-0.1.1-rc.2.tgz",
-      "integrity": "sha512-UP1UIh6q3Gme/yXRn/QL2P8IsVlv8Shpg22TRJIZPsCRWLm4CBiA1MUvXmJAfsOEETBMLAl+xWPtFw6ICsN3wg==",
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh/-/dsh-0.1.5-rc.1.tgz",
+      "integrity": "sha512-rmNmzQCg3oIc1z8xH7izRSOuy1TNzq+/NILyfM+7e8DKOyV+yBtg47WEsqR2SiIe1ATec3L/rUa1YhIcfQ2XEg==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/cordis-plugin-hmr": "^1.0.16",
-        "@deepseek-ai/cordis-plugin-include": "^1.0.6",
-        "@deepseek-ai/cordis-plugin-loader": "^1.0.2",
-        "@deepseek-ai/cordis-plugin-timer": "^1.1.3",
-        "@deepseek-ai/dsh-agent-instructions": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-agent-tool-presentation": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-app-boot": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-base": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-agent-preset": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-cordis": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-cmdline": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-command-compact": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-command-goal": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-compaction-basic": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-compaction-tool-result-pruner": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-cordis-client-runner": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-fs-local": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-goal": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-goal-round-driver": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-headless": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-home-paths": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-jobs-local": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-launch-environment": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-mcp-client": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-persona": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-plan-mode": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-pwsh-local": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-pwsh-sandbox": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-schedule": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-projection": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-reference": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-skill": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-skill-filesystem": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-terminal": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-terminal-bash": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-time-context": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tmux-context": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-token-meter": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tool-ask-user": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tool-bash": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tool-bash-persistent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tool-cordis": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tool-fs": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tool-fs-search": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tool-goal": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tool-jobs": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tool-pwsh": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tool-pwsh-persistent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tool-ralph": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tool-skill": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tool-str-replace-editor": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tool-subagent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tool-subagent-control": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tool-todo": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tool-web": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tool-workflow": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-web-app": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-workflow-worker-thread": "^0.1.1-rc.2",
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/cordis-plugin-hmr": "^1.0.17",
+        "@deepseek-ai/cordis-plugin-include": "^1.0.7",
+        "@deepseek-ai/cordis-plugin-loader": "^1.0.3",
+        "@deepseek-ai/cordis-plugin-timer": "^1.1.4",
+        "@deepseek-ai/dsh-acp-app": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-agent-instructions": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-agent-tool-presentation": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-app-boot": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-base": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-client-ui-agent-preset": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-client-ui-cordis": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-cmdline": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-command-compact": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-command-goal": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-compaction-basic": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-compaction-tool-result-pruner": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-cordis-client-runner": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-fs-local": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-goal": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-goal-round-driver": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-headless": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-home-paths": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-hooks-claude-code": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-hooks-codex": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-http-proxy": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-jobs-local": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-launch-environment": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-mcp-client": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-persona": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-plan-mode": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-pwsh-local": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-pwsh-sandbox": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-schedule": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-sdk-app": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-sdk-minimal": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session-reference": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-skill": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-skill-filesystem": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-terminal": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-terminal-bash": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-time-context": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-tmux-context": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-token-meter": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-tool-ask-user": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-tool-bash": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-tool-bash-persistent": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-tool-cordis": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-tool-fs": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-tool-fs-search": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-tool-goal": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-tool-jobs": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-tool-present": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-tool-pwsh": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-tool-pwsh-persistent": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-tool-ralph": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-tool-skill": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-tool-str-replace-editor": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-tool-subagent": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-tool-subagent-control": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-tool-todo": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-tool-web": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-tool-workflow": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-web-app": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-webhook": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-webhook-github": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-workflow-worker-thread": "^0.1.5-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2",
         "commander": "^15.0.0",
         "js-yaml": "^4.2.0",
         "node-addon-require-builtin": "^0.1.4"
@@ -731,199 +742,352 @@
         "dsh": "lib/bin.js"
       }
     },
+    "node_modules/@deepseek-ai/dsh-acp": {
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-acp/-/dsh-acp-0.1.5-rc.1.tgz",
+      "integrity": "sha512-Ze5yCIcfz0VjBNrt3B7mfRI0WPYJd8ZckdaV3lRwO98PcVuO330y8DTuQXdBvgvFpmZCLselVW1mB9tT7240hA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@agentclientprotocol/sdk": "1.4.0",
+        "@deepseek-ai/dsh-brand": "^0.1.5-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-attachment": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-mcp-client": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session-persistence": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-token-meter": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-user-approval": "^0.1.5-rc.1"
+      },
+      "peerDependenciesMeta": {
+        "@deepseek-ai/dsh-token-meter": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-acp-app": {
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-acp-app/-/dsh-acp-app-0.1.5-rc.1.tgz",
+      "integrity": "sha512-O6+Hl//+uog9ezp+aVI0oQyNAtZ4GHf6haGxgPe7U9Kp/KUKjVYC94Lb2x45SgEimJroSxBOcR1CIQop2Tsn1g==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-acp": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-cmdline": "^0.1.5-rc.1",
+        "commander": "^15.0.0"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
     "node_modules/@deepseek-ai/dsh-agent": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-agent/-/dsh-agent-0.1.1-rc.2.tgz",
-      "integrity": "sha512-cC7lnJe7JgPFcreNXxcxLMxQd78LnpVO9ZXROjZsGRQN1zGH6i/DduI892F1am85IfzzO+XTxMwwUHmfwamb0g==",
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-agent/-/dsh-agent-0.1.5-rc.1.tgz",
+      "integrity": "sha512-obIPyTSjq1y0Yhasm3mLhK5BW6Ge0VQoRT8FBt0ooLsct2+pFAjgyd7GP3KzFaz7zaEhQJ/NNEmCaU0KOsYutg==",
       "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-scope": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-typert-protocol": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-scope": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-util-values": "^0.1.5-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-agent-default-model": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-agent-default-model/-/dsh-agent-default-model-0.1.1-rc.2.tgz",
-      "integrity": "sha512-Pv+4p20Eol7Ds/n0OS0vjtChCWfFTJAMThxugXcEcLKEJ9WAtpI4mzWfLgjmeVXnwD2yvp6HlLKDrrQV9PIkww==",
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-agent-default-model/-/dsh-agent-default-model-0.1.5-rc.1.tgz",
+      "integrity": "sha512-yEUYhogUpiUfctefVHpNZ+9WvCKjm2wbVIj1iGnCRmHtvlrB2tmAJ7OkaOhUK3AxY0WovSjf+8Y8+sGLMx980A==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
+        "@deepseek-ai/schemastery": "^3.18.2"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-settings": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-settings": "^0.1.5-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-agent-instructions": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-agent-instructions/-/dsh-agent-instructions-0.1.1-rc.2.tgz",
-      "integrity": "sha512-a3xKsOsqmlWZaGxXfIr97ULJlXSI1clZt0DCSjCaULW4Z1y67DzG8w/kRsb+/Z1pksRMrJE7faLMC/i9S5Y2Ew==",
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-agent-instructions/-/dsh-agent-instructions-0.1.5-rc.1.tgz",
+      "integrity": "sha512-HpYUZSB0RB2gZnG2chR53Ama8grr95TIBoYlLyDFvHy61zl6HOtYEsm44LQp5gNlycAyoUPxoyXExo7hVn5glQ==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
+        "@deepseek-ai/dsh-util-values": "^0.1.5-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-fs": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-home-paths": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-fs": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-home-paths": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.5-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-agent-loop": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-agent-loop/-/dsh-agent-loop-0.1.1-rc.2.tgz",
-      "integrity": "sha512-2uJZ6kjJ3IYLRGn6/NhiZgD576ABcbERB/nkReR9TEUMO2zWkz6OuKtVwLyFCFSni2T25Jv+clKQWt7D4MhU3A==",
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-agent-loop/-/dsh-agent-loop-0.1.5-rc.1.tgz",
+      "integrity": "sha512-FcpsiXMHR7M3UwZtC6CYzhmU9xhvbFuuEQisfUqW7c+G6oVhrX9kg8ytI50jXZempcdmVHZLyNeUcuDmgGtx7Q==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
+        "@deepseek-ai/dsh-brand": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-util-values": "^0.1.5-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "zod": "^4.4.3"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-scope": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-persistence": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-settings": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-scope": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session-persistence": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-settings": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.5-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-agent-presets": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-agent-presets/-/dsh-agent-presets-0.1.1-rc.2.tgz",
-      "integrity": "sha512-88r3jkrbdwTgcP3MZLIUX458Ecu8JcLmZa7PtPszwf33yFoWlZvZmgjyn5ETHV55plNQ8gKMRm9a0RwzGGmzCw==",
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-agent-presets/-/dsh-agent-presets-0.1.5-rc.1.tgz",
+      "integrity": "sha512-kUBeWCF/7g7Z73kPJHleyqZt72aDOrLCeqbwrLks1svDy6ubMUvWi9jAYrYzvSYCJg+fD7x8/13tw49NriJyxA==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1",
-        "js-yaml": "^4.1.0"
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "js-yaml": "^4.1.0",
+        "zod": "^4.4.3"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/cordis-plugin-include": "^1.0.6",
-        "@deepseek-ai/cordis-plugin-loader": "^1.0.2",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-atomic-write": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-home-paths": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-scope": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-settings": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/cordis-plugin-include": "^1.0.7",
+        "@deepseek-ai/cordis-plugin-loader": "^1.0.3",
+        "@deepseek-ai/dsh-agent": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-atomic-write": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-home-paths": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-scope": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-settings": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.5-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-agent-tool-presentation": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-agent-tool-presentation/-/dsh-agent-tool-presentation-0.1.1-rc.2.tgz",
-      "integrity": "sha512-l1C7Z+erWcfj6Ak5EQbcCAPW/0+na4iOXwGknozHgKILLCK2C9CWcrTK0LwozvUPdqh0gFUucSOhi68HQ61srg==",
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-agent-tool-presentation/-/dsh-agent-tool-presentation-0.1.5-rc.1.tgz",
+      "integrity": "sha512-Q4sjyFnws8PqrOmRtthT5ps2jToFRIxC+ogpEcoAik/ggFwfBEC8+IZ3KT2kxNzTvymCyDsxbJxFtirO6gE7SQ==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
+        "@deepseek-ai/schemastery": "^3.18.2"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-tools": "^0.1.5-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-anonymous-user-id": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-anonymous-user-id/-/dsh-anonymous-user-id-0.1.1-rc.2.tgz",
-      "integrity": "sha512-ZQBsDhI0VuFwoDnq75VT2gPJdMPmBYfWM3EBDmUkwHM0E2dmyr+iLGXxp33a7M64r79x7kN+81KOTEL5LS0E8A==",
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-anonymous-user-id/-/dsh-anonymous-user-id-0.1.5-rc.1.tgz",
+      "integrity": "sha512-+ecDwUWxv+E18+m0lhaC6/Z6EfmtqG2EhNxmycQi0u02t7CU0/ZiTZrUaWIB6365btlPy+GTBHE9C+SIlTomEA==",
       "devOptional": true,
       "license": "MIT",
       "peer": true,
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-brand": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-home-paths": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-brand": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-home-paths": "^0.1.5-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-api-gateway": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-api-gateway/-/dsh-api-gateway-0.1.1-rc.2.tgz",
-      "integrity": "sha512-i/e/Ecg1QCjMePUFHBfjRQU3NbDV0IdORwQbQD6RpiirzyvAIm4vvZgmW/FfgkO2XYJHHIVjo3i1i0YaHPcQag==",
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-api-gateway/-/dsh-api-gateway-0.1.5-rc.1.tgz",
+      "integrity": "sha512-q/R5sJt8Q6D37mAQBM7gIB6mTC88qJ1WY6gLjtcwOn0GgSRwY17ChgIZq/b6YUxAJ3ykgKTeKfvAj8pvyRX09w==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/dsh-typert-protocol": "^0.1.1-rc.2"
+        "@deepseek-ai/dsh-deque": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-timeout": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.5-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "ws": "^8.21.0"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-client-connection": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-typert-registry": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-api-remotes": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-api-remotes/-/dsh-api-remotes-0.1.1-rc.2.tgz",
-      "integrity": "sha512-mtmMxA0TZwTjy46E2DF0kmsPCXVq6RBhrwEHWXBaRzc0DLjnYqmJODrZ0X+XwXOkwFZtDxWSv/uheiIsXf8now==",
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-api-remotes/-/dsh-api-remotes-0.1.5-rc.1.tgz",
+      "integrity": "sha512-sFoGZ3jJbrKLxbxSoyUpxhbRhgrxtxutfOcTJWacCTTfJQWvyJiJtbt4aK/997Uqgv19CklIBVkDBfqMDZA4RA==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/dsh-typert-protocol": "^0.1.1-rc.2"
+        "@deepseek-ai/dsh-deque": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-util-values": "^0.1.5-rc.1"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-agent-presets": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-api-gateway": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-commands": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-cordis-host-runner": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-credentials": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-file-reference": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-goal": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-host-plugin-inventory": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-message-feedback": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-persistence": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-reference": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-settings": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-typert-registry": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-scope": "^0.1.5-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-api-session-controller": {
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-api-session-controller/-/dsh-api-session-controller-0.1.5-rc.1.tgz",
+      "integrity": "sha512-BwOU/VMFpYQo7fAp0RyeBbSlIwNg9BNI3tDatRpYHBNKBcckiN0Lv2HO3Aoe7dLRh8yqqaOeiUVBY3Mkva1aZA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-brand": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-deque": "^0.1.5-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "mime-types": "^3.0.2",
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-agent-default-model": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-agent-presets": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-api-gateway": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-attachment": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-client-connection": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-client-file-upload": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-commands": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-file-reference": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-fs": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-jobs": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-native-command": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-scope": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session-persistence": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session-projection-cache": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session-query": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session-title": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-skill": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-subagent": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-typert-registry": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-util-time": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-util-values": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-util-workspace-path": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-workspace": "^0.1.5-rc.1"
+      },
+      "peerDependenciesMeta": {
+        "@deepseek-ai/dsh-jobs": {
+          "optional": true
+        },
+        "@deepseek-ai/dsh-session-persistence": {
+          "optional": true
+        },
+        "@deepseek-ai/dsh-session-projection-cache": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-api-settings-controller": {
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-api-settings-controller/-/dsh-api-settings-controller-0.1.5-rc.1.tgz",
+      "integrity": "sha512-MeeYkdfhiVy6oHOoyHKKsuahbSinPSaOY3nIiudbLIQYrGyF9+KGFPmP7LM+KF/G9mP/Q8Dh9nZq3BUIMBj3LQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent-presets": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-credentials": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-native-command": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-settings": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.5-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-api-workspace-controller": {
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-api-workspace-controller/-/dsh-api-workspace-controller-0.1.5-rc.1.tgz",
+      "integrity": "sha512-1mzTuL850EFqBPD+JwGzC9aNpZQ7LgxZCt3TP4YBVZcbys3D5Gopbb+wIJsqMHpfwIA2eqY9m3KAJjaJepF4Sg==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-deque": "^0.1.5-rc.1",
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-api-gateway": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-client-connection": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-host-directory-picker": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-storage-domain": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-workspace": "^0.1.5-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-api-workspace-files": {
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-api-workspace-files/-/dsh-api-workspace-files-0.1.5-rc.1.tgz",
+      "integrity": "sha512-fDUHdBBMH50vHwViZoM3tdp3fgrzFB4x/NqwNRwnJfaVgg2t5exRok9gSoHmsKYaP5EkEqGXYozOCNUx9GWVYg==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-deque": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.5-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-app-boot": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-app-boot/-/dsh-app-boot-0.1.1-rc.2.tgz",
-      "integrity": "sha512-eynZWb0oNPKc4OO3HPokqFfz4b5sUEq+EjqhKE2TUWsUsOTgFO43l2Ai3LibqLu6XTpYeHCTbsRLM4Aqg0deBQ==",
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-app-boot/-/dsh-app-boot-0.1.5-rc.1.tgz",
+      "integrity": "sha512-yWxb2SbcW/Vq2mt3Q6+PTbYdxSPK4KEWADTDdWDseiIn4F78szElS+zyclc1jmr9HlcZkTuLg9mwUZhgjixJjw==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "js-yaml": "^4.2.0"
+        "@deepseek-ai/dsh-atomic-write": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-package-manifest": "^0.1.5-rc.1",
+        "js-yaml": "^4.2.0",
+        "resolve.exports": "^2.0.3"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/cordis-plugin-group": "^1.0.1",
-        "@deepseek-ai/cordis-plugin-hmr": "^1.0.16",
-        "@deepseek-ai/cordis-plugin-include": "^1.0.6",
-        "@deepseek-ai/cordis-plugin-loader": "^1.0.2",
-        "@deepseek-ai/dsh-home-paths": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-launch-environment": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/cordis-plugin-group": "^1.0.2",
+        "@deepseek-ai/cordis-plugin-hmr": "^1.0.17",
+        "@deepseek-ai/cordis-plugin-include": "^1.0.7",
+        "@deepseek-ai/cordis-plugin-loader": "^1.0.3",
+        "@deepseek-ai/dsh-home-paths": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-launch-environment": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.5-rc.1"
       },
       "peerDependenciesMeta": {
         "@deepseek-ai/cordis-plugin-hmr": {
@@ -932,1073 +1096,848 @@
       }
     },
     "node_modules/@deepseek-ai/dsh-atomic-write": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-atomic-write/-/dsh-atomic-write-0.1.1-rc.2.tgz",
-      "integrity": "sha512-QqNSF0+Ddn6qWY480dlilwEy6FLv3JKEWx1UQgoNJrxD4y54SDRzqBQB9yDXWKOoOGyC+05TN6/Px10GNIzMWA==",
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-atomic-write/-/dsh-atomic-write-0.1.5-rc.1.tgz",
+      "integrity": "sha512-5fiPu6usjlzTd9IfOyINMHqMdxsmyTI3YY3s+BqAGk5qwqedrh83gPEer9a94L8lkhX+06AC0wdsSROI5bNZsQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-attachment": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-attachment/-/dsh-attachment-0.1.1-rc.2.tgz",
-      "integrity": "sha512-rCYAt8QsawP1yfDCU7XxNwYT/XWvyFsxYrkwhLLkdfW83QVD0CQHizSkTQE7RFX74nKUD1z3sTLfnLr7xneArw==",
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-attachment/-/dsh-attachment-0.1.5-rc.1.tgz",
+      "integrity": "sha512-uTBtB/LDlYgPI6i9Ac9jaK/bV1wN8cDTZBUkec80Yg3qMzW6K74wvBv5lPmoiXQgp4q3eOmDNEmodSS2ZxxVdg==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-brand": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-brand": "^0.1.5-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-attachment-local": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-attachment-local/-/dsh-attachment-local-0.1.1-rc.2.tgz",
-      "integrity": "sha512-bU24CZc2ElJ7JPUUeWLcibRsiuXjsj9dVuUu8yx6t2vensjbqo70kzAIA4eh9q6ai4CeU1/9cRnKLcMQbgNxMQ==",
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-attachment-local/-/dsh-attachment-local-0.1.5-rc.1.tgz",
+      "integrity": "sha512-FVrfFKktYBKt9MzODf9oxdB0QOCcY2i/9cHOuxYDluS+SRP/zs3c7Rs/GsUk0Crg8Q2LQNf7CCYQ0Lr2ymGHEA==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1",
+        "@deepseek-ai/schemastery": "^3.18.2",
         "sharp": "^0.35.3"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-attachment": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-home-paths": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-attachment": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-home-paths": "^0.1.5-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-authorization": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-authorization/-/dsh-authorization-0.1.1-rc.2.tgz",
-      "integrity": "sha512-+ye7d4XzenQ4kpfY2nMIlUhoIbcprotL9fmkTBahafIPDhyyph0JzmUVhz1AGnkIqZc8TltjGzX2ssald+f+3A==",
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-authorization/-/dsh-authorization-0.1.5-rc.1.tgz",
+      "integrity": "sha512-VoG21RzrGx5AQYAgMtXYgd6ku1XNxPsQMLdnkQlfIUgzgjZx2Lju8CArfCqxCOEna2Ku4vAz+gm8PEp/Q4Paxg==",
       "devOptional": true,
       "license": "MIT",
       "peer": true,
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-credentials": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-credentials": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-base": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-base/-/dsh-base-0.1.1-rc.2.tgz",
-      "integrity": "sha512-DT1kSaseoTZ0b8pwZ5biRkqez2K8AnsLataRiCPsn3uUuxupZOjM1e8x9W+kpkWWFykWy1mbCPhzDRVJ+pLCbg==",
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-base/-/dsh-base-0.1.5-rc.1.tgz",
+      "integrity": "sha512-cfFyTpUKNnMlS6NRIG8AnvjSsr3enAyl0a1CXnD+wQ1tzoqhGY5+OKsgkVdciKw0Co5WeTSSPItU5lmjBwo4hg==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/cordis-plugin-hmr": "^1.0.16",
-        "@deepseek-ai/cordis-plugin-timer": "^1.1.3",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-agent-default-model": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-agent-instructions": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-agent-loop": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-api-gateway": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-attachment-local": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-bash-sandbox": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-command-compact": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-command-feedback": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-command-goal": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-commands": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-compaction-basic": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-compaction-tool-result-pruner": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-credentials-local": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-fs-local": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-fs-observation-policy": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-fs-sandbox": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-goal": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-goal-round-driver": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-jobs-local": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm-deepseek": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm-pi-ai": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm-retry": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-permission-presets": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-plan-mode": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-pwsh-sandbox": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-repeat-tool-reminder": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-sandbox-local": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-sandbox-policy": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-checkpoint-policy": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-persistence-jsonl": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-projection": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-query-sqlite": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-telemetry-otel": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-title": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-title-first-prompt-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-settings-file": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-shell-env": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-skill": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-skill-badge": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-skill-filesystem": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-spill-local": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-spill-policy": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-subagent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-subagent-fork-in-process": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-subagent-spawn-in-process": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-subprocess-local": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-token-meter": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tool-bash": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tool-call-timeout-policy": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tool-fs": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tool-fs-search": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tool-goal": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tool-jobs": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tool-pwsh": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tool-ralph": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tool-skill": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tool-str-replace-editor": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tool-subagent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tool-subagent-control": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tool-subagent-report": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tool-todo": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tool-web": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tool-workflow": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-typert-loader": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-typert-registry": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-user-approval": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-user-questions": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-web": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-web-search-deepseek": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-workflow-worker-thread": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis-plugin-hmr": "^1.0.17",
+        "@deepseek-ai/cordis-plugin-timer": "^1.1.4",
+        "@deepseek-ai/dsh-agent": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-agent-default-model": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-agent-instructions": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-agent-loop": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-api-gateway": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-attachment-local": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-bash-sandbox": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-command-compact": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-command-feedback": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-command-goal": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-commands": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-compaction-basic": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-compaction-tool-result-pruner": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-credentials-local": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-deepseek-llm-api-extensions": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-fs-local": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-fs-observation-policy": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-fs-sandbox": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-goal": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-goal-round-driver": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-jobs-local": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-llm-deepseek": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-llm-pi-ai": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-llm-retry": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-permission-presets": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-plan-mode": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-plugin-package-inventory-deepseek": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-pwsh-sandbox": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-repeat-tool-reminder": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-sandbox-local": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-sandbox-policy": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session-checkpoint-policy": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session-log-deepseek": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session-persistence-jsonl": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session-projection-cache": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session-query-sqlite": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session-telemetry-otel": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session-title": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session-title-first-prompt-llm": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-settings-file": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-shell-env": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-skill": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-skill-badge": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-skill-filesystem": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-spill-local": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-spill-policy": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-storage": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-storage-domain": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-storage-json": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-subagent": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-subagent-fork-in-process": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-subagent-spawn-in-process": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-subprocess-local": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-token-meter": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-tool-bash": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-tool-call-timeout-policy": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-tool-fs": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-tool-fs-search": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-tool-goal": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-tool-jobs": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-tool-present": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-tool-pwsh": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-tool-ralph": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-tool-skill": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-tool-subagent": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-tool-subagent-control": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-tool-todo": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-tool-web": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-tool-workflow": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-typert-loader": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-typert-registry": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-user-approval": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-user-questions": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-web": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-web-fetch-http": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-web-search-deepseek": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-workflow-worker-thread": "^0.1.5-rc.1"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-bash-local": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-bash-local/-/dsh-bash-local-0.1.1-rc.2.tgz",
-      "integrity": "sha512-GAjYTVsJKXkAptjO767xqt0otMufZRtj2qvOAvkx5Bfusd5R6+mMUkSbcx2K2A8WMbltyCbjwhZf4Tu4xyJAdw==",
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-bash-local/-/dsh-bash-local-0.1.5-rc.1.tgz",
+      "integrity": "sha512-1JxwFJI2cRt+/3yQ8DPxmO6jFqZSOBrLCFZ9ObumZ+AcIddsqEVyJBGoniHDmPRRqt8riEisksvkFskhSdnm2g==",
       "devOptional": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
+        "@deepseek-ai/schemastery": "^3.18.2"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-settings": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-shell": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-subprocess": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-timeout": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-settings": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-shell": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-subprocess": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-timeout": "^0.1.5-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-bash-sandbox": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-bash-sandbox/-/dsh-bash-sandbox-0.1.1-rc.2.tgz",
-      "integrity": "sha512-bagZDMZ73C1dVDBjFCn1flNZ8aOEel4dsmDJTfmagqeYPXfIJDFKPhDc3lWjc+o6jMNfmumeUJ62dwhHkjJHKA==",
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-bash-sandbox/-/dsh-bash-sandbox-0.1.5-rc.1.tgz",
+      "integrity": "sha512-mQ+/0Fo3LTIX+4k3m+P4y9e9IA6/BeNHrWW19U+Un4hBo5JtTwWhAaJN1nCdV6mG5tveXbIe2tpiv65GJdvt8w==",
       "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-bash-local": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-sandbox": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-sandbox-policy": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-shell": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-bash-local": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-sandbox": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-sandbox-policy": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-shell": "^0.1.5-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-brand": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-brand/-/dsh-brand-0.1.1-rc.2.tgz",
-      "integrity": "sha512-8vXsAXoUdzKAgvd/E9DgyT6HKmR6ZM4rtJ3fs/XoJ6n2kBk4tWil8Lv+jxCMWJeMOnTJF55gu2+NWQ3ECFPtJw==",
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-brand/-/dsh-brand-0.1.5-rc.1.tgz",
+      "integrity": "sha512-nfEsuSNghhrcvjMnjlPU55Z60K/5FjCRY4ZJtnc0SHR0PgoMl7N9I9+y4t2kDMe3rnEKlH2UgIGIZ/msGOYvpg==",
       "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2"
       }
     },
-    "node_modules/@deepseek-ai/dsh-client-connection": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-connection/-/dsh-client-connection-0.1.1-rc.2.tgz",
-      "integrity": "sha512-YX2WLA/aZdDQsien4Zo7IHTEfYVJ+4QhRXbgA6BrRUM23NSP/+V3K00dQYyQVsF3ZwocE5uyvlZvbYeg1Iz4ug==",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1",
-        "ws": "^8.21.0"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-attachment": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-commands": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-host-apiproxy": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-host-webserver": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-client-hmr": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-hmr/-/dsh-client-hmr-0.1.1-rc.2.tgz",
-      "integrity": "sha512-q2YqCvIWXfVQBh+AWLQFDF2cMu2ZabgahGKrWXHqQ5q1dY0ae9CvDV+bCMf8+EwQgz1axSOXWQ35+SSKPGwGlw==",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/cordis-plugin-loader": "^1.0.2",
-        "@deepseek-ai/dsh-client-modules": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-host-webserver": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-client-locale": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-locale/-/dsh-client-locale-0.1.1-rc.2.tgz",
-      "integrity": "sha512-AMoR4FwMPLmt6WlYd4m0PCoxXj4qqMhpElBQZSc3r3NyGCZIuleU8tCG1xphGtr/w9mA1Y0kUX7Ftdmf7yV4FQ==",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-connection": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-settings": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-settings": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-client-modules": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-modules/-/dsh-client-modules-0.1.1-rc.2.tgz",
-      "integrity": "sha512-D0vRgJJpMeTB4ExJTGHk9ay01kLxfK5zvp6bgFjYGlk9sBJgCE3qsOGBFNqD369ylJx4W2oyExAH9lOZGNk3Rw==",
-      "devOptional": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/cordis-plugin-loader": "^1.0.2",
-        "@deepseek-ai/dsh-host-webserver": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-client-runtime": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-runtime/-/dsh-client-runtime-0.1.1-rc.2.tgz",
-      "integrity": "sha512-o1FH7Rlns0Xaxh4SBOWZ1wpa0ViGw6DXWNm5NFpsBTGYD94RGdIrud3QxgrfzmQKLzu33gvS8JL/IjqbzWyYsg==",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "immer": "^10.1.1",
-        "zustand": "~4.4.7"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-attachment": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-connection": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-commands": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-host-apiproxy": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm-retry": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-projection": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-title": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-typert-protocol": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-typert-registry": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-client-ui-agent-preset": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-agent-preset/-/dsh-client-ui-agent-preset-0.1.1-rc.2.tgz",
-      "integrity": "sha512-U8iT0+jQSbIdPPF4rYYEhmFaTyewryOgL/ye3322UhuFXFapjQcPTBkchvZYYWnTJ/SGB2CpKXLQqiVSjsN2tA==",
-      "devOptional": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-connection": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-settings": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-client-ui-attachment": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-attachment/-/dsh-client-ui-attachment-0.1.1-rc.2.tgz",
-      "integrity": "sha512-c3tLJL7Qhok4NzVTE/OomBAsNSLbryT0UndqLaxx/9hcS4W7A984SD0iOF9VuZT4dgZ6dQjMse9eIe9M7Kg08Q==",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "clsx": "^2.0.0"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-attachment": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-client-ui-brand-official": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-brand-official/-/dsh-client-ui-brand-official-0.1.1-rc.2.tgz",
-      "integrity": "sha512-ORrj3w92n5tif0ecKQy/xGd6vlHPkK3XZCxT0+7JUeA1GRo4TW/wc5ljm0/6hM4FcqKf2x7ndW+OdWfZ2Rwfdg==",
-      "devOptional": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-sidebar": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-client-ui-commands": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-commands/-/dsh-client-ui-commands-0.1.1-rc.2.tgz",
-      "integrity": "sha512-k7gIeD/+zRF2jtGPi5tG2vZMUkgVnS9HYPA2yzwB0ilB1NhvL/Xbne1Y9vO4aBAakFE1Be1/1RMIKW4PMv0fkA==",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "clsx": "^2.0.0"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-input-trigger": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-commands": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-client-ui-conversation": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-conversation/-/dsh-client-ui-conversation-0.1.1-rc.2.tgz",
-      "integrity": "sha512-5PCyHw2Y7nz9geEUT23et3h2XghJm7/3iWDAKa1/4ldIfCnjfxiZ5ZNRdZ9Xxpj32tBmh2lc6yxIJwrtepIyTg==",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1",
-        "clsx": "^2.0.0"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-attachment": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-brand": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-connection": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-input-trigger": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-layout": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-settings": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-commands": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-compaction": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-goal": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm-retry": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-permission-presets": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-plan-mode": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-stats": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-settings": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-token-meter": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tool-todo": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-client-ui-cordis": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-cordis/-/dsh-client-ui-cordis-0.1.1-rc.2.tgz",
-      "integrity": "sha512-zUtgUW1N9m+rnyGxVI1uXmXxWA11JxK0/W5sI3ZiwhIzYJNvIMtkMyBjsoNVOVpgd3krwViBxFfbFpP20ew4pA==",
-      "devOptional": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-connection": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-input-trigger": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-sidebar": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-tool": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-cordis-client-runner": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-client-ui-deliverables": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-deliverables/-/dsh-client-ui-deliverables-0.1.1-rc.2.tgz",
-      "integrity": "sha512-VA6tXDGTgHUvudrbPqgvUCnZcuJOc49OTm4k2tGrazm3uUdO7W5uO/VeuAVD8eEA9afS/0IBqqs0WHc3Q8Cojw==",
-      "devOptional": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-client-connection": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-client-ui-directory-picker-browse": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-directory-picker-browse/-/dsh-client-ui-directory-picker-browse-0.1.1-rc.2.tgz",
-      "integrity": "sha512-O4fd87GB6Pt0+FgiiygbV/5+DmLI+sPHEBOWouyWqkDKZ19pgRZ541FpYNOmxf6Hjhf8wiG+Zpy3CYi9+n0+vw==",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "clsx": "^2.0.0"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-workspace": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-client-ui-directory-picker-native": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-directory-picker-native/-/dsh-client-ui-directory-picker-native-0.1.1-rc.2.tgz",
-      "integrity": "sha512-ubC7861LSIIKLR8AU/vR/V79tOffQE7bhzaKbGl1A0IPruCZCFZiyYD5J8P0RPvWPSaePXjF/P49or5bF//tdg==",
-      "devOptional": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-workspace": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-client-ui-goal": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-goal/-/dsh-client-ui-goal-0.1.1-rc.2.tgz",
-      "integrity": "sha512-nyoloPDya2sdsTSn4cFJmJBZWpr2EVgJ+oWAkwIrDGWpDTkQXaX2G44bDmMZas8dY6F2uODfLIBp/rYe4ZdPOQ==",
-      "devOptional": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-commands": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-goal": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-typert-protocol": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-client-ui-input-trigger": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-input-trigger/-/dsh-client-ui-input-trigger-0.1.1-rc.2.tgz",
-      "integrity": "sha512-jro0WgcJdi/ClpyKGWg+/0nEq9mmcda1KIoMsB+o9lLqebDUce/enxdEP0UtIEpQVOJ6EMMDY5Bsn+WtrdJNhg==",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "clsx": "^2.0.0"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-file-reference": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-client-ui-jobs": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-jobs/-/dsh-client-ui-jobs-0.1.1-rc.2.tgz",
-      "integrity": "sha512-G2yJqYpvfEvqSSJ8Rl61gSfoCcX2v3yGEidKzN5InbS0mcewMqLUfn8RihV2fDKu6UG3nggDGN6aahg0csq93Q==",
-      "devOptional": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-client-ui-layout": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-layout/-/dsh-client-ui-layout-0.1.1-rc.2.tgz",
-      "integrity": "sha512-y7xSQyQYGuahLyJcSXpB+JbH1F5lGEc3L9K8cjLy5vd/L9N6gLFLWyeGdlGxxM4jxRt1+rAHDDZ/zl7b8GC5zQ==",
-      "devOptional": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-theme": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-client-ui-message-feedback": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-message-feedback/-/dsh-client-ui-message-feedback-0.1.1-rc.2.tgz",
-      "integrity": "sha512-ABh9GhtUmwUXtBMQg/rMrTgyEXrCIuv7gK2UGJ2waurhblSrw2br7EYqTcIsZbVdFIec9+sHHVCmowqJf3lGog==",
-      "devOptional": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-connection": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-message-feedback": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-typert-protocol": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-client-ui-model-selection": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-model-selection/-/dsh-client-ui-model-selection-0.1.1-rc.2.tgz",
-      "integrity": "sha512-CEFpGeEL6gtz0jTRWEpHcEH1cBIwzY9023vWmgyjjcFDOcaKv3G324n+IXweHDttbWGSKdtxfpi4FMOu14W3Og==",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "clsx": "^2.1.1"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-connection": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-commands": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-input-trigger": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-client-ui-permission-presets": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-permission-presets/-/dsh-client-ui-permission-presets-0.1.1-rc.2.tgz",
-      "integrity": "sha512-dR+7VNod6b1OU3NF8eeAC8if1K+Aj8Z80gj/ly5sBcfV2ezRuhWMwiazFrQfFum5k/EDuoKTL5lOt3pciWEu5w==",
-      "devOptional": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-connection": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-commands": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-input-trigger": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-settings": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-permission-presets": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-client-ui-plan": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-plan/-/dsh-client-ui-plan-0.1.1-rc.2.tgz",
-      "integrity": "sha512-1kMI5AgyX3LPdXNEr75CaLwC40SIpYUCxWkyVO0xcoZ5VIXuB/E9jmBXTkEXS5US6IzSHWvam5Pm9PahPwX/dA==",
-      "devOptional": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-plan-mode": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-client-ui-reference": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-reference/-/dsh-client-ui-reference-0.1.1-rc.2.tgz",
-      "integrity": "sha512-45Fsle7tGJsIjODdFFESK5PvO0Uk505UgRAy8vKUz36VGUl4v5WpofW562hFSaDBkUztbJQ6/UpCeEQnWs4bjw==",
-      "devOptional": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-input-trigger": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-file-reference": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-reference": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-typert-protocol": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-client-ui-renderer": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-renderer/-/dsh-client-ui-renderer-0.1.1-rc.2.tgz",
-      "integrity": "sha512-yCpJWKrA4DLd9lwHuUUIdId8H9Vcoq6xtQoNh3UxOYy4KDeoKbcMsRpOOShlnkxdJYGKOoRk3GpRaDw5RPlrwA==",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "use-sync-external-store": "1.2.0"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-client-ui-settings": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-settings/-/dsh-client-ui-settings-0.1.1-rc.2.tgz",
-      "integrity": "sha512-WqEQkyjW467leTJoA31BgqM+nALI3JnrvN1IXDhJuKd8E9nXhTLJcRgDrovEUkh2cjbHF8g8gQJ5Qafg9PzJiQ==",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-connection": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-settings": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-client-ui-settings-general": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-settings-general/-/dsh-client-ui-settings-general-0.1.1-rc.2.tgz",
-      "integrity": "sha512-0hXnCb+nKBdlNPgblzhckUQNVrUsfhwDWsexYWs2wFoSWcfALfwjwgN9ZMwS5dj9LLvl/rWib8w9a4miuhFENw==",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1",
-        "clsx": "^2.0.0"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-connection": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-settings": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-sidebar": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-settings": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-client-ui-settings-models": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-settings-models/-/dsh-client-ui-settings-models-0.1.1-rc.2.tgz",
-      "integrity": "sha512-LfGTsbJpCNG0nhT9nBzUucVxnJ5tlY78i5JmlUEb3fwEFUM2cq9pmhv5sXWFdn3LOAnGr0QcyTm+08iBubc6zQ==",
-      "devOptional": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-connection": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-settings": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-client-ui-settings-plugin-inventory": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-settings-plugin-inventory/-/dsh-client-ui-settings-plugin-inventory-0.1.1-rc.2.tgz",
-      "integrity": "sha512-HSxcn/UbifCGsVSYPxd2dHlURTOqRQ0a907rmQ5TMdPCabEauD+yc0m910XcL+3rRlyTsfW/Vy6AjpNK8cAeJQ==",
-      "devOptional": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-settings": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-client-ui-settings-plugins": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-settings-plugins/-/dsh-client-ui-settings-plugins-0.1.1-rc.2.tgz",
-      "integrity": "sha512-NspsecIb4YdvE54jmaGBW/MjFyuu/MwUjQeM/I9iAgMOpLO+jOsoCOT4M8Su1Nfy1bxokgks9XcBJOcNGjN4Vg==",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "clsx": "^2.0.0"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-connection": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-settings": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-client-ui-sidebar": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-sidebar/-/dsh-client-ui-sidebar-0.1.1-rc.2.tgz",
-      "integrity": "sha512-UCilyaNPwMO54JYtpCW5leLL+ecwtoRd4sHNVNG94aPQAqZOrqH+hqrBBsuolDJ9d0cKG9K5Mtew0fPz/hByZA==",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "clsx": "^2.0.0"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-layout": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-client-ui-skill": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-skill/-/dsh-client-ui-skill-0.1.1-rc.2.tgz",
-      "integrity": "sha512-LMpSKA/QIqsv6uGawiMUOY0wgdCzoohBm2Dg7+DGvMmbxdHiUkp0N6HM1SbgO35sS/KP3qBmyDmDrvHrye2EDA==",
-      "devOptional": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-connection": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-input-trigger": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-tool": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-client-ui-subagent": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-subagent/-/dsh-client-ui-subagent-0.1.1-rc.2.tgz",
-      "integrity": "sha512-YvlWV2GpDVKR/0Ay4rn9whgPx1o0cLBV1TsOzGAp1yQbm2nKjJ3fUJgwcq2Tf6LAZLpJqGxmg8ji0upmkLBjUg==",
-      "devOptional": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-input-trigger": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-subagent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-token-meter": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-client-ui-theme": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-theme/-/dsh-client-ui-theme-0.1.1-rc.2.tgz",
-      "integrity": "sha512-gRKI92D+EZtOy7UBkRfNvyL4e/3HikZ7exQSfgGpLEJ278/aXMvStNbL5ZgWVC41+MSZsBUk3dZAfbXNjelz2g==",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1",
-        "clsx": "^2.0.0"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-connection": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-settings": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-host-webserver": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-settings": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-client-ui-tool": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-tool/-/dsh-client-ui-tool-0.1.1-rc.2.tgz",
-      "integrity": "sha512-JLLkipHwhpjJsUTECuS7jMq8z1YD9CVYS5ZRZvIYvOd0OxgvBB/ga/CJ5MIIBQhCj8/gLvseAOiqV3wm2OF2Hw==",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "clsx": "^2.0.0"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-connection": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-client-ui-trajectory": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-trajectory/-/dsh-client-ui-trajectory-0.1.1-rc.2.tgz",
-      "integrity": "sha512-8w8klclVCsqqVM6shVWe0vXtfs6pfEfviKHXPLtX70J+yW042wrRkOqcNh61W14QR+OCfq75TIJZbNPDiIf+2Q==",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "@tanstack/react-virtual": "^3.14.9",
-        "diff": "^9.0.0"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-compaction": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-client-ui-trajectory/node_modules/@tanstack/react-virtual": {
-      "version": "3.14.10",
-      "resolved": "https://registry.npmmirror.com/@tanstack/react-virtual/-/react-virtual-3.14.10.tgz",
-      "integrity": "sha512-SRyoUbdFMRHuYXMijV5H4ZarQWpXkj3iANq8OFre+pybeVap8ZJjZ3Nz9bVjx4d8PfobVUQUdKyyyHYk3E+djw==",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "@tanstack/virtual-core": "3.17.8"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/tannerlinsley"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-client-ui-trajectory/node_modules/react": {
-      "version": "19.2.8",
-      "resolved": "https://registry.npmmirror.com/react/-/react-19.2.8.tgz",
-      "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
-      "devOptional": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-client-ui-trajectory/node_modules/react-dom": {
-      "version": "19.2.8",
-      "resolved": "https://registry.npmmirror.com/react-dom/-/react-dom-19.2.8.tgz",
-      "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
-      "devOptional": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "scheduler": "^0.27.0"
-      },
-      "peerDependencies": {
-        "react": "^19.2.8"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-client-ui-user-questions": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-user-questions/-/dsh-client-ui-user-questions-0.1.1-rc.2.tgz",
-      "integrity": "sha512-rIyokmmWzOvT5W4zBRlPEs84PtcUXKleGW3oABHaAyIidCcWylT868xzXtUiPBh19Wkr734sZT3rYppoC9fqmQ==",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "clsx": "^2.0.0"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-client-ui-workflow-run": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-workflow-run/-/dsh-client-ui-workflow-run-0.1.1-rc.2.tgz",
-      "integrity": "sha512-XuAZStSyy834UdX3jcobv4ZleLXcuwGsn9BVk4/SSi6GKOG1wzsVgxJFi7IhaKGURxuCpheUQKe8+TuE1ScePQ==",
-      "devOptional": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tool-workflow": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-workflow": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-client-ui-workspace": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-workspace/-/dsh-client-ui-workspace-0.1.1-rc.2.tgz",
-      "integrity": "sha512-k/jB5ke2e+oNyNKzu4/PBlriwCHKVg5bY3kn7Co3MtWZdqbJ42hfwZkRNMnn+nmziQXCVXWRzuiHZt0xNTAveA==",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "clsx": "^2.0.0"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-client-connection": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-sidebar": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-cmdline": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-cmdline/-/dsh-cmdline-0.1.1-rc.2.tgz",
-      "integrity": "sha512-0/dEVUm7Xy0aBo0DBqC5F3kxC5ahzKcmHOF+Q6E1lBqTwN2xytGYTh0TSfj+6rS31jDqxeIvWxy35bLl83n/Sg==",
-      "devOptional": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/cordis-plugin-loader": "^1.0.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-code-runtime": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-code-runtime/-/dsh-code-runtime-0.1.1-rc.2.tgz",
-      "integrity": "sha512-SgFresqH5UABzRQZ7tOfqzOLMHF7089VeH+mfcwNQH5peOavgEKrAGOYz/9RnISH0XmMrj/x177t8gfO8Uvo/w==",
-      "devOptional": true,
-      "license": "MIT",
-      "peer": true,
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-code-runtime-worker-thread": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-code-runtime-worker-thread/-/dsh-code-runtime-worker-thread-0.1.1-rc.2.tgz",
-      "integrity": "sha512-wE+6x4yGsyg4kntVQFOcb5PiAg2Wb3gs1UNY7SHWC7WOcWCAbREZRfqaoAAxO7AZuqlFhBou7wWc6dZqtGENkw==",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-code-runtime": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-timeout": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-command-compact": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-command-compact/-/dsh-command-compact-0.1.1-rc.2.tgz",
-      "integrity": "sha512-rLNBnq5jo9nm4Etw5PrVtcYlFDTM8IQt8w5aL+7CQiEpC6OevP7QzvGrIbJ2VTG2GX9yN6fJosPd0Ky18EQuYQ==",
-      "devOptional": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-commands": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-compaction": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-command-feedback": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-command-feedback/-/dsh-command-feedback-0.1.1-rc.2.tgz",
-      "integrity": "sha512-0i0EDLFP0h1UpeWq1KrrUXKJFBK7aoCFfzcWnrrD9Lj36I09XfjNDJIm4kcYNTkbOFb4o3MWNw01FKC5rNJjXA==",
-      "devOptional": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-anonymous-user-id": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-commands": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-telemetry": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-command-goal": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-command-goal/-/dsh-command-goal-0.1.1-rc.2.tgz",
-      "integrity": "sha512-AfiBUOd2QjM2PW73nwQJtSDUri8RtEB6l3XVlznUrfY3VFu5tF7GcFUXffTxgtroWrvaqETs/vQJc/zsn8tGwQ==",
-      "devOptional": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-commands": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-goal": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-commands": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-commands/-/dsh-commands-0.1.1-rc.2.tgz",
-      "integrity": "sha512-BOIe4Sht9rmMv1a6b3GWjWBbeWr7PtHlAy41vgpaymvUUuzOapOIA648ZMGCI/crRIt72Umev2FHtSwCNSbYZg==",
+    "node_modules/@deepseek-ai/dsh-chunked-list": {
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-chunked-list/-/dsh-chunked-list-0.1.5-rc.1.tgz",
+      "integrity": "sha512-3c/pYWSE++OWdilO8kG7mY9UyhHnwfV0qYQN+Bxwt2YdjqRQZ/6UkwvzNQIAoDqUEWJYwcQUQoLHTrgrrpIxNw==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "zod": "^4.4.3"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-attachment": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-brand": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-scope": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-typert-protocol": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2"
       }
     },
-    "node_modules/@deepseek-ai/dsh-compaction": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-compaction/-/dsh-compaction-0.1.1-rc.2.tgz",
-      "integrity": "sha512-LV5GAIx7GO8DCRivnN2bmLmuucsYDG+ifG18BaXBqsVKdrzmaIu5o+CBxQAI2bX1N6mfBenLxmvCnROkyumLTg==",
+    "node_modules/@deepseek-ai/dsh-client-connection": {
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-connection/-/dsh-client-connection-0.1.5-rc.1.tgz",
+      "integrity": "sha512-mBHCF/WT5kAn4fHJDe0mL5TcVUEIRWGUAwPzr32xitQrIAM6jh5G+pPVJLDtTk+ZbHGkGusN0+nQh2gCJpGHjQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-credentials": "^0.1.5-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-file-upload": {
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-file-upload/-/dsh-client-file-upload-0.1.5-rc.1.tgz",
+      "integrity": "sha512-qjH4KGnr97GiBU9Pwr2jIOuZUAeI2QJ1em/e/QHFehu74RGIkvajojVn0d/xGxPqs3JCt/dvVR4OfctqzmVulA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-brand": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.5-rc.1",
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-scope": "^0.1.5-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-hmr": {
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-hmr/-/dsh-client-hmr-0.1.5-rc.1.tgz",
+      "integrity": "sha512-RKymfSAI21aZ35elHZHMztwwuVTvqn4UY/eeAyDrfPfErPWPwIScKd935u+vAhM4HuBZnIL3E/Sl4MYvws4NZw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-locale": {
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-locale/-/dsh-client-locale-0.1.5-rc.1.tgz",
+      "integrity": "sha512-DNzkyudBnGEPPaqRTsBnrr8nast/ZOPSAO21pS1MldK277Wj7Po4bCURKg1cS9QT30Fs4NMeJdIvyV/xNWoMSw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-modules": {
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-modules/-/dsh-client-modules-0.1.5-rc.1.tgz",
+      "integrity": "sha512-PE+c+LDUBnk1IfVu4caIKMj2XwLx/tzu0p9gY1jGQa1cNxzKfPgftKHDwvqWMbJQowtLb+RiR2Tc+24nFylVyQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-resources": {
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-resources/-/dsh-client-resources-0.1.5-rc.1.tgz",
+      "integrity": "sha512-Q0g/4KWavf10yiYXWHjbrgHr5pejqySTAwXtouD6TrHvtgGAKtqWIa6s5t5y+YW3RqxabzAqmjCTqZrq+/RbWA==",
+      "devOptional": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-agent-preset": {
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-agent-preset/-/dsh-client-ui-agent-preset-0.1.5-rc.1.tgz",
+      "integrity": "sha512-0W0ZrOewwgsUWgqd+Zz4hF6Vwn0xe/JNy6nf80BdjvV8RCms4o8hW1+c6dO0z6O42WLLlF4K7t1Hs/lkPN1YEA==",
+      "devOptional": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-approval": {
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-approval/-/dsh-client-ui-approval-0.1.5-rc.1.tgz",
+      "integrity": "sha512-zba9ZtNmkfypU+wOkKGh5I3GmJMAH6rMj5FEsMs9/GG5x0Z8BlybHDELZIBVV4UoJfuZYvDFI/zemVMVRaGsVw==",
+      "devOptional": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-attachment": {
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-attachment/-/dsh-client-ui-attachment-0.1.5-rc.1.tgz",
+      "integrity": "sha512-JmHfLBhXDfbo7+l1L92ACye3DSBtaF8bZ7EiQuTajwUHmtBtK/jKv9PKKXJnnHQNFwSrdcR2Sc2FxGW7WJHgQA==",
+      "devOptional": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-brand-official": {
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-brand-official/-/dsh-client-ui-brand-official-0.1.5-rc.1.tgz",
+      "integrity": "sha512-scbXvZiVH+Uag1R/twD3r/sqEhrU+EMKae78F2399JUjkAVZDdJLv4R6PlSJbIKy16OKt2cYgsRxEkUxs+1a7w==",
+      "devOptional": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-chat": {
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-chat/-/dsh-client-ui-chat-0.1.5-rc.1.tgz",
+      "integrity": "sha512-mi0KY13+w9uqXIrp8ZObHC0mGNOhSn2rx4sSobetYN+u4GW1xFvONBsPJYTCqvgnAWFEjAUtqHXmH/Tvmhe0wg==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-commands": {
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-commands/-/dsh-client-ui-commands-0.1.5-rc.1.tgz",
+      "integrity": "sha512-XU01bKi8Dlupq1E3l/dkUQueHRTm3hqbcTDbK/gbfVMUZXlUN9zNFxEvtXzQzBOrPMFs+gBH3nyza12ViuyOrg==",
+      "devOptional": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-conversation": {
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-conversation/-/dsh-client-ui-conversation-0.1.5-rc.1.tgz",
+      "integrity": "sha512-/A+lvO6mc+uTJWJerFyhZeBV+Ez9Sid8+wx7NbIrrg/mdt191IdHqHI9v2sGiIQ/1d+nI3S0YjhOxMH4hGka5A==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-cordis": {
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-cordis/-/dsh-client-ui-cordis-0.1.5-rc.1.tgz",
+      "integrity": "sha512-+lhe7NilUE/Shy02UqBGFku+CCk97L/Jxbyv+LFVVQw+hbGUh2bSgCuNfRLfyQzaRwMxDATlqVM0T0cHkXU5RA==",
+      "devOptional": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-deliverables": {
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-deliverables/-/dsh-client-ui-deliverables-0.1.5-rc.1.tgz",
+      "integrity": "sha512-cT995A3OoY07GhpenbBRC/9z/WQFf5uFv5VMNZSnmrG/+X9huaOu7fZvWV1wiwWWgmhxVWxNFbyYyeq8VJerRA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.5-rc.1"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-directory-picker-browse": {
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-directory-picker-browse/-/dsh-client-ui-directory-picker-browse-0.1.5-rc.1.tgz",
+      "integrity": "sha512-ssNVwTfj2kob4e/9zLISU4QVz7MOw7MWjP5+oqWCmpMVMd3wJBeRNqqOTx+ZaqijfMft8QNJIlyoJmgvYDdK+A==",
+      "devOptional": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-directory-picker-native": {
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-directory-picker-native/-/dsh-client-ui-directory-picker-native-0.1.5-rc.1.tgz",
+      "integrity": "sha512-YK5uUJFZAnXmve0d/nrqF1V+duAxil8615Vx4TPc8b4BsXZ4uloCqHGAfQTkXVdIA3x9gLc9CRp2ZhUDLR7Wtw==",
+      "devOptional": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-goal": {
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-goal/-/dsh-client-ui-goal-0.1.5-rc.1.tgz",
+      "integrity": "sha512-xM+bIv4gkQIMzOx2vtZRBT5P0rFoxEaOA0FhYuSmItmDUu/tECCbduarRyvBe5KKyjDL8ONCMY9hS8GwJHvjUA==",
+      "devOptional": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-input-trigger": {
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-input-trigger/-/dsh-client-ui-input-trigger-0.1.5-rc.1.tgz",
+      "integrity": "sha512-y/Y6HPwZf146ZHJW5G1O4eD4vKWYVi+xFFY50tdsHRMSPpoiQnnlIAbG12OQknsKslc4SDdA7FHNLxzGankPRA==",
+      "devOptional": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-jobs": {
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-jobs/-/dsh-client-ui-jobs-0.1.5-rc.1.tgz",
+      "integrity": "sha512-PVMSsYyexvebr45PCo2Va2VtfGIpUPkS3umH+WsI/pc1JoYw7REW5lqUy639N4tGDh3WTFhU9bczpAf1Aj8T1g==",
+      "devOptional": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-layout": {
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-layout/-/dsh-client-ui-layout-0.1.5-rc.1.tgz",
+      "integrity": "sha512-XbaJSLhZM5rSbcpAy9IyoYgC6nmEppUptzU3H50/cbFqoDCDvXrcflx04UlifRI5tb5ofZtNOvDqqCsJ6kwcIg==",
+      "devOptional": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-message-feedback": {
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-message-feedback/-/dsh-client-ui-message-feedback-0.1.5-rc.1.tgz",
+      "integrity": "sha512-jOpjPC9O+/XqhBjI7Z6u5c7nj/vAV2S84jH592ruG4qZF/rr4EkMs+KZy3Bm7nRxOIpNaJM0D8sGFAgfoAgqvQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-model-selection": {
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-model-selection/-/dsh-client-ui-model-selection-0.1.5-rc.1.tgz",
+      "integrity": "sha512-fl59qM9HcNplIXC+MqSgujsaUt3vZYOQpJWO1Y2vihkrg6fHjZoY2TOw42b53fr9NGH/dUImQ0iXll4X4F9Hpw==",
+      "devOptional": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-open-in-app": {
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-open-in-app/-/dsh-client-ui-open-in-app-0.1.5-rc.1.tgz",
+      "integrity": "sha512-wzsG3tR/FrkZ/mr+2jwbOVbRNKVLabTcz+XAnJqAeYCAymQmxCCNrAaOUUiaWwGfbrWbAOGp2XnANqs4MjDqug==",
+      "devOptional": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-permission-presets": {
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-permission-presets/-/dsh-client-ui-permission-presets-0.1.5-rc.1.tgz",
+      "integrity": "sha512-Dr0orTetf84oJ2+53HohNvxXmZ4vNMT5ZiLaMhJslWvE2DkqMMq5u7ceVTx3/+MBQvJBKX9V6Atas3Qw64bp8g==",
+      "devOptional": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-plan": {
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-plan/-/dsh-client-ui-plan-0.1.5-rc.1.tgz",
+      "integrity": "sha512-B/yYlTP/8QIF0cXCyFRatZ71wlDe+9HiUGCly3AhGgyuYO1xqXuJAhRtsLei0U4hzbar3SL2DF109pO1XlAB+Q==",
+      "devOptional": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-reference": {
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-reference/-/dsh-client-ui-reference-0.1.5-rc.1.tgz",
+      "integrity": "sha512-08Iu4RBC3lO6YtlZWihIL0kF9+oQA/J6qQJp5oN+qHuRbjJUcfQ41JLplTiEP3PUWwVeMEpsT69+zWdPsDTUPw==",
+      "devOptional": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-renderer": {
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-renderer/-/dsh-client-ui-renderer-0.1.5-rc.1.tgz",
+      "integrity": "sha512-v3NlhGgcYDUtskwjylVuKJ+FMiuJgYdWg/bIjth+obj7cF2SBJR4A0/9XfCKQvh2xbF/puRLZ7DG3KRl8+BKBQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-schedule": {
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-schedule/-/dsh-client-ui-schedule-0.1.5-rc.1.tgz",
+      "integrity": "sha512-k5bhs50oxNNQDQW10aK2z1o07ZjejDwjFqMqYqn8nMaqpG3b/14v063Vfr0woimwpSuSTtO1oBPDZyPGLYguhg==",
+      "devOptional": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-session": {
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-session/-/dsh-client-ui-session-0.1.5-rc.1.tgz",
+      "integrity": "sha512-qrAKy9soxmTmStjs6mnxHx992iTKzn1uBu1p5UL1wHPYJKus6cTHjBD8HlaYMYE4IzB9AFezUjDfOOjwgyxlUQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-settings": {
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-settings/-/dsh-client-ui-settings-0.1.5-rc.1.tgz",
+      "integrity": "sha512-5O+HJrGuyJL0rNf7ulLI7CbdVozYfKDrAYKXoykAzZZ11EgSEaOrNfRobBhUKMsmXyfbKec7qce9rtG+HOgiuA==",
+      "devOptional": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-settings-general": {
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-settings-general/-/dsh-client-ui-settings-general-0.1.5-rc.1.tgz",
+      "integrity": "sha512-oGzUbFGr27KnteXU7/82K5sI/MRB9b+B1sFiQTpUEix318uNfE6q3/o0mhpBcbQoSmpP0D++Bgn12vlgklvsog==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-settings-models": {
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-settings-models/-/dsh-client-ui-settings-models-0.1.5-rc.1.tgz",
+      "integrity": "sha512-qCzSHZLZoV5NLgzVGj+h/OAqEOUF9NaFxyD3bdZSpy1xL9ZTmBitpjdmllqiBiIbxRx4AxCiYfOQ38ZGMlyD4Q==",
+      "devOptional": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-settings-plugin-inventory": {
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-settings-plugin-inventory/-/dsh-client-ui-settings-plugin-inventory-0.1.5-rc.1.tgz",
+      "integrity": "sha512-8dvV1zZBG0yx2/DPj3MWtFom8jaJONkCwu0n98peEvGtqzu1vJJZQEfMAD6kxSi/jq5Ws0pt60byPa5PAtW2vA==",
+      "devOptional": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-settings-plugins": {
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-settings-plugins/-/dsh-client-ui-settings-plugins-0.1.5-rc.1.tgz",
+      "integrity": "sha512-DEE4oGtDd0O0jCuo3Jrpt1FF5RIA49P6TfObJbhugOzdt2X1vdsoEqZZDAO4yuu6f2QedgM1mGP3IMCP9J57Qg==",
+      "devOptional": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-sidebar": {
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-sidebar/-/dsh-client-ui-sidebar-0.1.5-rc.1.tgz",
+      "integrity": "sha512-AG8NSL/dzQaq9NmnVpVQIXuNghR3Gr6QbAQvx7Qm49JG+JbJGBurWcYXLgH6OX+hxE2w3y0DezJ2LxLq6ZZs0A==",
+      "devOptional": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-sidebar-documentpreview": {
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-sidebar-documentpreview/-/dsh-client-ui-sidebar-documentpreview-0.1.5-rc.1.tgz",
+      "integrity": "sha512-EnxzXokzQDP/ZkhtQuzHqwFYzB6EZFESRzGhuUTREyZihdM7q4Z1zcRObOw8Btr7WSuiZH/il4RGwDN16XTvMg==",
+      "devOptional": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-sidebar-files": {
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-sidebar-files/-/dsh-client-ui-sidebar-files-0.1.5-rc.1.tgz",
+      "integrity": "sha512-QnR84tTkCpk59j403bIhGjdLFounfNrRcWQKRcFU01bGkaMdhIaU6AsEGv5pTw2DbCTP4blCeTGr806olIjzIQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-sidebar-right": {
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-sidebar-right/-/dsh-client-ui-sidebar-right-0.1.5-rc.1.tgz",
+      "integrity": "sha512-JFKsoWRdfX4r++DL2CbuDAgZ6Di1L3siSjcl5z6ilieFfcsN9eUHyOcZN+2WKOQtmpw374ZwrN5Z/i+coO/mCA==",
+      "devOptional": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-skill": {
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-skill/-/dsh-client-ui-skill-0.1.5-rc.1.tgz",
+      "integrity": "sha512-Y6BeDPWD1/waLUiJgnI1T1uz3zzTUypvva7Tr9Sykf50JROIffRVwPCQnZQn61A5k+fbDCFMaaabHpzFdYPNAQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-subagent": {
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-subagent/-/dsh-client-ui-subagent-0.1.5-rc.1.tgz",
+      "integrity": "sha512-FViVXMZSnxod6FBAkXOGb+YEMRNPfi+Aauyh+my5EWbvSKEnXTKBYEtoiSN9Y2laS8ZonJgNI4p5Bthb7MVpYA==",
+      "devOptional": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-theme": {
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-theme/-/dsh-client-ui-theme-0.1.5-rc.1.tgz",
+      "integrity": "sha512-Q4A4dgpF9WVKN/wo+3LlFHJOp7UMFdFzEITB5WhiwsKADYpU/n6sE8FkWIeFo0g1eqJY9bHAseqQYOAdZ227/g==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-tool": {
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-tool/-/dsh-client-ui-tool-0.1.5-rc.1.tgz",
+      "integrity": "sha512-3TOV/T2r7sCxHXaXh+HHvRxh5oMv8ONg9yHTWVsCBKiMO2ZMWBmb4Eqns7+C0c6mNH9FXRR4vSzaUci+v57XDQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-trajectory": {
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-trajectory/-/dsh-client-ui-trajectory-0.1.5-rc.1.tgz",
+      "integrity": "sha512-j5rZXHuu+0v8kBVC65s5dBKSh/qFzA0B577d0zL4D7f1iP1zQ3OGnRYKRlcsZ+WCA4b3nIAI3StJdnKx65+xNA==",
+      "devOptional": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-user-questions": {
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-user-questions/-/dsh-client-ui-user-questions-0.1.5-rc.1.tgz",
+      "integrity": "sha512-NpIjEdE97VKDG2vGye8GY6VLUbY0CzJCGIAir+UZ24WfHtlGxhoKheBvoeijjiEEKoQwM1o2xlDUBGxK8DlfjQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-workflow-run": {
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-workflow-run/-/dsh-client-ui-workflow-run-0.1.5-rc.1.tgz",
+      "integrity": "sha512-IqAfHrQMbnfrYFz6fuK6z9POtJUiWiIUnZ3WxTxSxbVqi386G0+HoEu22rzqglgeSMH9VdXpsoczXE5jphcw4A==",
+      "devOptional": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-workspace": {
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-workspace/-/dsh-client-ui-workspace-0.1.5-rc.1.tgz",
+      "integrity": "sha512-ESKP4+0zJa5KB86HzKl573Zk3EUwyuzyXc0y1Bj/J7aWsFLj4LYkud7iVl0Pag5P2cM7LpB/0Pm/d45E9tec8w==",
+      "devOptional": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-cmdline": {
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-cmdline/-/dsh-cmdline-0.1.5-rc.1.tgz",
+      "integrity": "sha512-hZFWY6blJCp8WFbyP9ETLMtBhp6jNcBSaxaFxtOO3MTVFgbUGE/2/zdTSu389j9B/eNXhEoiaIsk9BT0VtD4lg==",
+      "devOptional": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/cordis-plugin-loader": "^1.0.3"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-code-runtime": {
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-code-runtime/-/dsh-code-runtime-0.1.5-rc.1.tgz",
+      "integrity": "sha512-DfqzMEQW42lVQjjQ6FCEmtzAuYGle1grxqrRPqdXhkDYe4aTSLJLEcqn7/BYZSI64/G1XQYvdS+jkYxbymbv3A==",
       "devOptional": true,
       "license": "MIT",
       "peer": true,
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-brand": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-commands": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2"
       }
     },
-    "node_modules/@deepseek-ai/dsh-compaction-basic": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-compaction-basic/-/dsh-compaction-basic-0.1.1-rc.2.tgz",
-      "integrity": "sha512-qNg4JqWlZ5NvlFmaVZtJ+RuvJUtYFgdS7xXlhhBGSHbMZi4sHgB63Mo+9Y0Rl8glLSxLjo2reMMPlECN+duUuw==",
+    "node_modules/@deepseek-ai/dsh-code-runtime-worker-thread": {
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-code-runtime-worker-thread/-/dsh-code-runtime-worker-thread-0.1.5-rc.1.tgz",
+      "integrity": "sha512-UvrZCSLFD15bwrN2r+MMVxgWSLzwz0R2zm4FbA3yUHDtQXpNsGZeGq6uLVOTc5yKsrFGkxCA/0gIaBPo2dze3w==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
+        "@deepseek-ai/dsh-util-values": "^0.1.5-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-commands": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-compaction": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-compaction-tool-result-pruner": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-token-meter": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-code-runtime": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-timeout": "^0.1.5-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-command-compact": {
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-command-compact/-/dsh-command-compact-0.1.5-rc.1.tgz",
+      "integrity": "sha512-VzZ2dltTYijSL5lMWiOxrIcO0sd/kW/df2mQFJtlDygn9qP6KmXkJYjy78iF9lCnu2tkeUwL9ypd16ZdS4/MKA==",
+      "devOptional": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-commands": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-compaction": "^0.1.5-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-command-feedback": {
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-command-feedback/-/dsh-command-feedback-0.1.5-rc.1.tgz",
+      "integrity": "sha512-LqDBHmjfI3oF5uwG2te5Xwa64zbV3aD0EsVa7/V7nMoWSuORlbdBa9YN0EBXpsxmjOwbik8BKaPZPIAdoLRNsQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-anonymous-user-id": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-commands": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.5-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-command-goal": {
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-command-goal/-/dsh-command-goal-0.1.5-rc.1.tgz",
+      "integrity": "sha512-qmfPA2fOf53Vgda1btYhJ1ryQpcwiGxtYukyhQKwmwOt/wa1b+Xkcvq58qQOAOtm5fSbWWpKGRhbFxikxlHl3g==",
+      "devOptional": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-commands": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-goal": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-commands": {
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-commands/-/dsh-commands-0.1.5-rc.1.tgz",
+      "integrity": "sha512-OMk0uVNbr2RdsItcIigp/2boGulqjei1uoQH3/DZYHB+aWWRXEYa6rk6vW3t82lnkd/6nvyQFV8eccQWZ2PQXQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-util-crypto": "^0.1.5-rc.1",
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-attachment": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-brand": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-scope": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.5-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-compaction": {
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-compaction/-/dsh-compaction-0.1.5-rc.1.tgz",
+      "integrity": "sha512-DF1BcWNwA997vrR94yfxVxSvXCVejgv8/ytxNkxvliKK79wFr6DMPAdv9ludapE5PXVO62PLgjV4CE2lxW53fA==",
+      "devOptional": true,
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-brand": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-commands": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-compaction-basic": {
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-compaction-basic/-/dsh-compaction-basic-0.1.5-rc.1.tgz",
+      "integrity": "sha512-Zhl+GOZdNuPmInk6Oko1IkfDMpGSoE2VLFkhfhqjP7mxC3t/OxWmP1fXkvNKiHGHPXrGUx9NLRE1T0AK3zSAGg==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-util-values": "^0.1.5-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-commands": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-compaction": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-compaction-tool-result-pruner": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-token-meter": "^0.1.5-rc.1"
       },
       "peerDependenciesMeta": {
         "@deepseek-ai/dsh-compaction-tool-result-pruner": {
@@ -2007,667 +1946,728 @@
       }
     },
     "node_modules/@deepseek-ai/dsh-compaction-tool-result-pruner": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-compaction-tool-result-pruner/-/dsh-compaction-tool-result-pruner-0.1.1-rc.2.tgz",
-      "integrity": "sha512-HUS95EsuveR8fuzaZW0qSv90mVWbv6aj7W9zfWPbr5BmLJsmomQlw6jFX3GodN1Iv8qWtrzFkMuxDHk4ZTHcAA==",
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-compaction-tool-result-pruner/-/dsh-compaction-tool-result-pruner-0.1.5-rc.1.tgz",
+      "integrity": "sha512-s9TmPMUenf8fDQxm2C0nwKasLMqCYx+ZSn5gXN/GFnSTW2YrPPD/o7KnvlhhFGeuBoE2s+hUXgg5Ro4cbPmzlA==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
+        "@deepseek-ai/dsh-util-values": "^0.1.5-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-compaction": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-token-meter": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-compaction": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-token-meter": "^0.1.5-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-cordis-client-runner": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-cordis-client-runner/-/dsh-cordis-client-runner-0.1.1-rc.2.tgz",
-      "integrity": "sha512-4/DNA4fCSa1nIb52mbRT3TV8wpsnDzjMRJfPbffk8+Fv/bj50jaeQY5yMgUXsUYWX98/RlekXTK4u4LdjtyHKQ==",
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-cordis-client-runner/-/dsh-cordis-client-runner-0.1.5-rc.1.tgz",
+      "integrity": "sha512-kd/5/0wWzTbhuigTfymPg8f659Q+HyymVapE+EdYImJDUgbKDPon9i4DmS1wiiwTYgjHPo8VR7QhZ231vJaw8A==",
       "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/cordis-plugin-loader": "^1.0.2",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-connection": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-modules": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-theme": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-cordis-host-runner": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-cordis-host-runner/-/dsh-cordis-host-runner-0.1.1-rc.2.tgz",
-      "integrity": "sha512-+AQGegPy+gdtcjTTPxDDYwAFUn6BB1J/MFFbmpPr+WIqJoDyVsuCDe8Rr8mCJmxs12CmTZXXSOE03LW203W8fA==",
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-cordis-host-runner/-/dsh-cordis-host-runner-0.1.5-rc.1.tgz",
+      "integrity": "sha512-f9wflxVAwH6YRQl/CJE8xC18iKAslokEGGRXtWst/ymiOlhTaQC4Iv7CAlrTF5c7er+OUeIODs22GTGHtglz1A==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1",
+        "@deepseek-ai/dsh-util-values": "^0.1.5-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2",
         "zod": "^4.4.3"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-brand": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-scope": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-typert-protocol": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-brand": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-scope": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.5-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-credentials": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-credentials/-/dsh-credentials-0.1.1-rc.2.tgz",
-      "integrity": "sha512-aeVBaH07rox7NuSNbSqbz8g0eNb2IIhNbrZngj/VxUsr/TR9TXOq7lm1CL6SBUDlstGw3vNWeXyhim/DmA5iSQ==",
-      "devOptional": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-brand": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-credentials-local": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-credentials-local/-/dsh-credentials-local-0.1.1-rc.2.tgz",
-      "integrity": "sha512-xlDyX9BrfT579qv6ilh4EsqtMs4A4oYsuCYHvK8UWQ6YRflxC4GiXDU44iNfosQo5BQwzJzUlBmwHy9id3e71g==",
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-credentials/-/dsh-credentials-0.1.5-rc.1.tgz",
+      "integrity": "sha512-+pcIimUNe2OQWZVwJFTbKEMUQA/6JAx+EMPodzgJgZzDPwsnYE8OClS2aXY9PW8T6DdaKAX+MVWptTsoVVEmBA==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1",
+        "@deepseek-ai/dsh-brand": "^0.1.5-rc.1"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.5-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-credentials-local": {
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-credentials-local/-/dsh-credentials-local-0.1.5-rc.1.tgz",
+      "integrity": "sha512-S5C3+ItHsJ4WlSQEvY4qqHB/txxe7NnaQXEbsjVDZUwUci5Ia3TaEvH0yz6Oi6ovG2oPrYulzorg6G1ayjPRZg==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2",
         "chokidar": "^4.0.3",
         "yaml": "^2.9.0"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-atomic-write": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-credentials": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-home-paths": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-launch-environment": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-atomic-write": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-credentials": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-home-paths": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-launch-environment": "^0.1.5-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-deepseek-llm-api-extensions": {
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-deepseek-llm-api-extensions/-/dsh-deepseek-llm-api-extensions-0.1.5-rc.1.tgz",
+      "integrity": "sha512-xnWdajsbw8vLLoWWw/t3URyFZho5NhFCVfcKumLUU7/6g8RXpYSfdPE1ouMufg/++ESSYEAFtITRaPuZ80jiDg==",
+      "devOptional": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-deque": {
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-deque/-/dsh-deque-0.1.5-rc.1.tgz",
+      "integrity": "sha512-lg+nPOuVz1OfqFnp7FmawYx76DjCrFXgLKG82m7xIHeTqJqUpQlQnTalL20VzTqZCGTsnsvQtrQLzLXTPykXTg==",
+      "devOptional": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-file-reference": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-file-reference/-/dsh-file-reference-0.1.1-rc.2.tgz",
-      "integrity": "sha512-8Pd4SNHhV6OlbwfV5K4qmFb709I0Z68qgaUQJ7zM4BTjClNe1/dktQnETtWPfqbPTx/2sNKXM1rz4WXuROrIfQ==",
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-file-reference/-/dsh-file-reference-0.1.5-rc.1.tgz",
+      "integrity": "sha512-XjgSLZOiAK3khVpACpqk+/G5j9noPO14+tf5p70S7N5PFFNT2oav4ojB+OGo+gs1bNWrDlij6vR0ePxV2rzfSA==",
       "devOptional": true,
       "license": "MIT",
-      "dependencies": {
-        "zod": "^4.4.3"
-      },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-typert-protocol": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.5-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-file-reference-local": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-file-reference-local/-/dsh-file-reference-local-0.1.1-rc.2.tgz",
-      "integrity": "sha512-aFOn9vsRfjWJYJyBLLD/kItD/KxAzxLNpKTUlxy8mSBMPUM5HEpUkAopgOg265OsjfvKdAVSt+eY1snrURXNgA==",
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-file-reference-local/-/dsh-file-reference-local-0.1.5-rc.1.tgz",
+      "integrity": "sha512-Ig/UBqBsCA675680DZ8xk5OELb8ERU4mJ8uTjIuTsUyQliNGcP49I23DywoiNIzLX/zzAigeYkZ77bZLFu7vLg==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
+        "@deepseek-ai/schemastery": "^3.18.2"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-file-reference": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-file-reference": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.5-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-fs": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-fs/-/dsh-fs-0.1.1-rc.2.tgz",
-      "integrity": "sha512-8j+6MffvCHATLQrhAVfc9rKyunKu/O7mjjJzmdsUSdID7V4iUYMwqPamhlAyI+tfohZu/vcforKzCRIZGmCYug==",
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-fs/-/dsh-fs-0.1.5-rc.1.tgz",
+      "integrity": "sha512-F+loGiwsT09YpRONuFv0+bevEdfmbKBFjxxM8JkDOXpgwk1JXdGNSy7Kp4vXXVh3GcmYkd8VA7iB7NuVp51ytQ==",
       "devOptional": true,
       "license": "MIT",
       "peer": true,
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-brand": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-sandbox": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-brand": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-sandbox": "^0.1.5-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-fs-local": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-fs-local/-/dsh-fs-local-0.1.1-rc.2.tgz",
-      "integrity": "sha512-jvn1MsAMqCmt5SjRNkPjmpc+RIWrZQrBVtf/OpmKr2PaBEGqSbCkPApWDE9iSMhcuQg6k5evScOXwAsduzKOLA==",
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-fs-local/-/dsh-fs-local-0.1.5-rc.1.tgz",
+      "integrity": "sha512-Qyqs9l+ZENq4PL7EwBpisvXcqJvCxGTrD/zH0Zj+S0eZee1kXrQjkY0gjW6dxAosGlLL7hZu0kdaD7TPxtKVcA==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1",
+        "@deepseek-ai/schemastery": "^3.18.2",
         "koffi": "^3.1.0"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-fs": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-fs": "^0.1.5-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-fs-observation-policy": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-fs-observation-policy/-/dsh-fs-observation-policy-0.1.1-rc.2.tgz",
-      "integrity": "sha512-rlq7yu4xavkKK1Oa1/aNCOeUW7t/3OXJJOfOcZXuUgJn5f8G0AbpTDpp2CeuL1cHlKpbunGhEkKQ2N/dv7ZR9w==",
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-fs-observation-policy/-/dsh-fs-observation-policy-0.1.5-rc.1.tgz",
+      "integrity": "sha512-TGu/2UrZS8KWr6x3sKLce7u0KoGrq5l+RK7ITd79n2WNzSCcAdzN5tsxUEo8JgfHij5S0QRgID0Q8DOx/6iQew==",
       "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-fs": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-fs": "^0.1.5-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-fs-sandbox": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-fs-sandbox/-/dsh-fs-sandbox-0.1.1-rc.2.tgz",
-      "integrity": "sha512-PI65uLZ3ARkfVV/PXvACS1HEXggoOaXgYQzXQFdLOfm7AiHOdZWZccUAXBetpZhcNYIOKsVoLnfZkXcHByqecQ==",
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-fs-sandbox/-/dsh-fs-sandbox-0.1.5-rc.1.tgz",
+      "integrity": "sha512-np+3EdQ86w609DwyaEUFGEHjSQ5i2NFypQxcM9sB+zX6DVSUR9sA2W/fmnStFJdsSzvgXYTCnJiBhlKnAXPf0g==",
       "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-fs": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-fs-local": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-sandbox": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-sandbox-policy": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-fs": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-fs-local": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-sandbox": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-sandbox-policy": "^0.1.5-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-goal": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-goal/-/dsh-goal-0.1.1-rc.2.tgz",
-      "integrity": "sha512-lSHTh4vfS6eRb9to/y+bjRf2+0QkNpY3tHJ29HMTewR9fJYZsEVVu4Hc+GPhPEjF7RpiD35/sKx+akijtDasyg==",
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-goal/-/dsh-goal-0.1.5-rc.1.tgz",
+      "integrity": "sha512-RF+cHqV0O7xkoqkhIst6NhMAwqXXAjTf7Z+H7FLHtZBvFAawU8zC7n7/tmS4P7rZYV+XYFYCDdNoI0GwPReCYA==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1",
+        "@deepseek-ai/schemastery": "^3.18.2",
         "zod": "^4.4.3"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-brand": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-scope": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-projection": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-typert-protocol": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-brand": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-scope": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.5-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-goal-round-driver": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-goal-round-driver/-/dsh-goal-round-driver-0.1.1-rc.2.tgz",
-      "integrity": "sha512-pWipAFKx0l+ai/gJvNQNNk+ukHkb5Rb85llAhJVwyk7YfXLC2G8lIfnG7ln58M3vfUKuLxQLE/GL1Qbr7FQuyQ==",
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-goal-round-driver/-/dsh-goal-round-driver-0.1.5-rc.1.tgz",
+      "integrity": "sha512-t564V58sl4N6V4CBbgOvJGlGFCUt6NtnDVZaebE8bDZOedRd7DtoXyxtuTZOBk4skF+416oQJdA24ybtefH2Ow==",
       "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-goal": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-goal": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-headless": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-headless/-/dsh-headless-0.1.1-rc.2.tgz",
-      "integrity": "sha512-Pk50xwmUUehOxNe8DJ2/tThj7Aw1MmJQeUkfAQh9miF7Tm+WOOxiOOei/H4wjH9cf+FuqtbLDw6jrHmGotfhjw==",
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-headless/-/dsh-headless-0.1.5-rc.1.tgz",
+      "integrity": "sha512-J1XWUYuPPxxzZC0cUgznJ7yuDG/lhuXXAwOsfkTq6BADb083GzXJL6ppKolDBOhbgLmmLj/7Zq+Ss7aswyEhBA==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/dsh-cmdline": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-code-runtime-worker-thread": "^0.1.1-rc.2",
-        "@deepseek-ai/schemastery": "^3.18.1",
+        "@deepseek-ai/dsh-brand": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-cmdline": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-code-runtime-worker-thread": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-util-values": "^0.1.5-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2",
         "commander": "^15.0.0"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/cordis-plugin-loader": "^1.0.2",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-agent-default-model": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/cordis-plugin-loader": "^1.0.3",
+        "@deepseek-ai/dsh-agent": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-agent-default-model": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-home-paths": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-home-paths/-/dsh-home-paths-0.1.1-rc.2.tgz",
-      "integrity": "sha512-lGsP7sbnu20AiRAb+gxYiKx9oa9r1D/8Fr6BwWHXpaPx6ZE4Qg0+ybh5SZVfGQ+XhLcQisu3nwWemEjtTJGiig==",
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-home-paths/-/dsh-home-paths-0.1.5-rc.1.tgz",
+      "integrity": "sha512-CxMi9qHY/zIkzo+UsA+/8UbTagRo6HL07iy32iTYV7gVmXTRt66ViNMDcwXHIlqiQ1A6y7cc0GYTVk88XcyL7A==",
       "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2"
       }
     },
-    "node_modules/@deepseek-ai/dsh-host-apiproxy": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-host-apiproxy/-/dsh-host-apiproxy-0.1.1-rc.2.tgz",
-      "integrity": "sha512-dplRnGGXXsQYFQ1KMHymAM0iaxuE9Z153JHYcGEgOwXNkS3HA20gSi3yMt6fz+zi/cMHYXvY1JQhS54BTc761A==",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-agent-default-model": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-attachment": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-brand": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-commands": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-credentials": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-goal": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-host-directory-picker": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-jobs": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-native-command": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-persistence": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-projection": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-projection-cache": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-query": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-title": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-settings": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-skill": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-subagent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-user-approval": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-user-questions": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-workspace": "^0.1.1-rc.2",
-        "@deepseek-ai/schemastery": "^3.18.1",
-        "fflate": "^0.8.2",
-        "zod": "^4.4.3"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent-presets": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-cordis-host-runner": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-host-directory-picker": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-host-directory-picker/-/dsh-host-directory-picker-0.1.1-rc.2.tgz",
-      "integrity": "sha512-m3puwS+bvJQ1eASdpEEwlQqKa9znhBSgtoSSI0GZN5VMynZVl7E31HMltENz3QC2Nd+C3bh7vNjrJFtumUDsLQ==",
-      "devOptional": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-host-directory-picker-auto": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-host-directory-picker-auto/-/dsh-host-directory-picker-auto-0.1.1-rc.2.tgz",
-      "integrity": "sha512-YW79cegRtVJ3zeVEvYPCpyfIGZV8l5iXUfdm2DI2lwUZsbQ0ZH09AeeLyy6fREmbtuy99l9MExKG1KYWl9No4Q==",
-      "devOptional": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/cordis-plugin-loader": "^1.0.2",
-        "@deepseek-ai/dsh-client-ui-directory-picker-browse": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-directory-picker-native": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-host-directory-picker-browse": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-host-directory-picker-native": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-host-webserver": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-host-directory-picker-browse": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-host-directory-picker-browse/-/dsh-host-directory-picker-browse-0.1.1-rc.2.tgz",
-      "integrity": "sha512-iLIXqO2fWDsItbtiNPE2Yv2KK0u5A4W5xDbNgd9jpLvzB9vg0NLv4wG9zI4azQ0zf0XgmfPt7BK7UpMM8iStKA==",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "@deepseek-ai/dsh-host-directory-picker": "^0.1.1-rc.2",
-        "@deepseek-ai/schemastery": "^3.18.1"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-host-directory-picker-native": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-host-directory-picker-native/-/dsh-host-directory-picker-native-0.1.1-rc.2.tgz",
-      "integrity": "sha512-EvCe+NWYCMvJM1FCZCqrT9ggwcQjCGfnI+9t9F1ZIXbjmnhTD1X9K9xt0Ber61lO7ZN20h98Hls8gkzWbHt42A==",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "@deepseek-ai/dsh-host-directory-picker": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-native-command": "^0.1.1-rc.2",
-        "koffi": "^3.1.0"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-host-frontend-static": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-host-frontend-static/-/dsh-host-frontend-static-0.1.1-rc.2.tgz",
-      "integrity": "sha512-KmdcBiprbRPuCK2d5e6VmXbXmT6fwd6nwGtqU6iOxh/Tl3/1V3c/lg7dvJu1LeOmyw8epXFbzgEQNw5ATJtaBA==",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-host-webserver": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-host-plugin-inventory": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-host-plugin-inventory/-/dsh-host-plugin-inventory-0.1.1-rc.2.tgz",
-      "integrity": "sha512-Hud9ezW0bexWfhX7C+c5rdUDX1xzbEGDzj1lGQyj/QxdrxHYHjGrJq3tLRyvN6K4FSmEdG2IBKdQGCOLVrIthA==",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "zod": "^4.4.3"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/cordis-plugin-loader": "^1.0.2",
-        "@deepseek-ai/dsh-brand": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-typert-protocol": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-host-webserver": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-host-webserver/-/dsh-host-webserver-0.1.1-rc.2.tgz",
-      "integrity": "sha512-t9MrjC65QHiiWhG9V8UZxgfE/aWYhJHHrIM0kbTvtXxg4tLGIKo/upHp7iiag65F3HTkVLrH/DUyPMi4v2ZA7g==",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-invariants": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-invariants/-/dsh-invariants-0.1.1-rc.2.tgz",
-      "integrity": "sha512-l+1Om/EDFyMjhgSuEx2WDLLA2fia/+ga9mBTCoT/MMslsnWaK5G0/lWwbwlTBSaJ6OfmYc3DuBgox8DbgIGHRQ==",
+    "node_modules/@deepseek-ai/dsh-hook-protocol": {
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-hook-protocol/-/dsh-hook-protocol-0.1.5-rc.1.tgz",
+      "integrity": "sha512-rkroa/Fq+ErLAaFm5Z9Er01RFq1W0zbzmuDkmg4EeKUjTA3/SlQW0UldbeNIP/amxiqRJdDSYGwGKDXvRnYabQ==",
       "devOptional": true,
       "license": "MIT",
       "peer": true,
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-shell": "^0.1.5-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-hooks-claude-code": {
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-hooks-claude-code/-/dsh-hooks-claude-code-0.1.5-rc.1.tgz",
+      "integrity": "sha512-2WaWwkPSjRG3OVhO/nxfxc1qZQb2g7YPSOhqsmJsgnumtcdTuDCuQbS0VRQpkAJrBMbW20/hitpl1U2FgHLdmA==",
+      "devOptional": true,
+      "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
+        "@deepseek-ai/schemastery": "^3.18.2"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-hook-protocol": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-subagent": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.5-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-hooks-codex": {
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-hooks-codex/-/dsh-hooks-codex-0.1.5-rc.1.tgz",
+      "integrity": "sha512-NfILKE0cluKGogalOCjVM/l5FMBtSH0mUWhGNVI9mPqQ7flVWbi205XOvznmbENyw9Jnak1W3X/AeT1E0PXC3Q==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-hook-protocol": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.5-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-host-directory-picker": {
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-host-directory-picker/-/dsh-host-directory-picker-0.1.5-rc.1.tgz",
+      "integrity": "sha512-zKbIv4vnWMLV0BVo7LrAjsphbgIB77Se0iOGV3bnF1d9RKHxnkLfyZ6Vt6Y/MKqtKR9UMi1q2z/qls153VOWBw==",
+      "devOptional": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-host-directory-picker-auto": {
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-host-directory-picker-auto/-/dsh-host-directory-picker-auto-0.1.5-rc.1.tgz",
+      "integrity": "sha512-GYkEPJo2+3DrZfsJY+nYHIeFYp8kQ0YfCo4Ul1NJ4ALwN/bg4IboLoesMtNsc5W/BaGNV0Y46ivCBjFx33ibeg==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-launch-environment": "^0.1.5-rc.1"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/cordis-plugin-loader": "^1.0.3",
+        "@deepseek-ai/dsh-client-ui-directory-picker-browse": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-client-ui-directory-picker-native": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-host-directory-picker-browse": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-host-directory-picker-native": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-host-webserver": "^0.1.5-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-host-directory-picker-browse": {
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-host-directory-picker-browse/-/dsh-host-directory-picker-browse-0.1.5-rc.1.tgz",
+      "integrity": "sha512-dmB+OK+NFkVjtIguRwgdPMTE7j4/wSotBBM+hvTgAeLF0QR3J2elipiQAhwgQwTtWh5ktLblfzV+/R7yinaIhQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-host-directory-picker": "^0.1.5-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-host-directory-picker-native": {
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-host-directory-picker-native/-/dsh-host-directory-picker-native-0.1.5-rc.1.tgz",
+      "integrity": "sha512-gbR/CkVRs9rVEMTPwCdhXCeJQtVe2/ph/R7CSZr6AWY9GUXDahbw2V1a2GU/FmySO6hfWD2MBx5+fCUuWs59WQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-host-directory-picker": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-native-command": "^0.1.5-rc.1",
+        "koffi": "^3.1.0"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-host-frontend-static": {
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-host-frontend-static/-/dsh-host-frontend-static-0.1.5-rc.1.tgz",
+      "integrity": "sha512-4ryTu2EPqM2w1h1Z7kLzYAm2paC4MjuwJmWwz6qwBsI5OeZNYt4Q8Ew1C8F8vsFR/jcwho4ZCkdhLcEunLF5fQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-client-connection": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-host-webserver": "^0.1.5-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-host-open-in-app": {
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-host-open-in-app/-/dsh-host-open-in-app-0.1.5-rc.1.tgz",
+      "integrity": "sha512-gfyH+UfR3t8hPpHACN5csFz1r+13efNUC9dpa/HriY2LnnVvcN1Kj9CW7hOAe/NfawFF/adYxb4kqo0wgzWxYA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-launch-environment": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-native-command": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-subprocess": "^0.1.5-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-host-plugin-inventory": {
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-host-plugin-inventory/-/dsh-host-plugin-inventory-0.1.5-rc.1.tgz",
+      "integrity": "sha512-xCOJ1nTW2s5etl18QhBBGpcOxiDfGxofe+4pd90/ZX+vW1vAhaHqyTYSRucOQVGyJb9zvdWCg7R3GcBYn6pUrQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/cordis-plugin-loader": "^1.0.3",
+        "@deepseek-ai/dsh-agent-presets": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-brand": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.5-rc.1"
+      },
+      "peerDependenciesMeta": {
+        "@deepseek-ai/dsh-agent-presets": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-host-webserver": {
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-host-webserver/-/dsh-host-webserver-0.1.5-rc.1.tgz",
+      "integrity": "sha512-5kOu9kb0AuRN60/zwPTRcki801ozgnWAFwS1QtQ4ZNgCYIbAiU8gwJHY1//qEpUOuHS+26k+Tqq5/WCJmLGE6Q==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "compression": "^1.8.1",
+        "negotiator": "^1.0.0"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-http-proxy": {
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-http-proxy/-/dsh-http-proxy-0.1.5-rc.1.tgz",
+      "integrity": "sha512-uzqFRi5d6k5ZiV4Q7CxkPUKGZrURN7VBdKAS0LNuBCUApI//vA72blWC+vn2Lz0BKKb8GDrBTuD2ZwCdXIObYg==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici": "^8.10.0"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-invariants": {
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-invariants/-/dsh-invariants-0.1.5-rc.1.tgz",
+      "integrity": "sha512-iXhJJ3r34NHFEWiuc5pxXlU19hPfNclvH9Ll0X7CzQ39Oh/4UlfO3DBlLpBU7T9fE/y7/UkuI1aRt+dNeiVQsQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-jobs": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-jobs/-/dsh-jobs-0.1.1-rc.2.tgz",
-      "integrity": "sha512-SXvDJMvcUrGrlzIyE7j8/lI4Pj1nDe/UOR8C05Zagp+/0R8p46n6KylySvZdPAFENV5t8WX3Fw3eOaS4No0+wQ==",
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-jobs/-/dsh-jobs-0.1.5-rc.1.tgz",
+      "integrity": "sha512-0AWlZLcIpwdtV9A9fVeJ7b9jpXX0494fPL594gE/Kp1q9jHYyerIulrMHZa17kpu9W59cb1AJNPQy2xN6VDX7g==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-brand": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-brand": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-jobs-local": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-jobs-local/-/dsh-jobs-local-0.1.1-rc.2.tgz",
-      "integrity": "sha512-26lg7mi9RKnu8IP8SWLbY+uZenbqF2AkAZvgZaLDlw1z58NtBsbgKgh6FNC8JXEyknAwYc6auQQKF+nLTlEjCw==",
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-jobs-local/-/dsh-jobs-local-0.1.5-rc.1.tgz",
+      "integrity": "sha512-19sCxqUKduNO8E3YICSzOfajpBLPXbK/3p40GlxR6bGcOhxqhyH3TPdQS6UQjwNa5bUXHiW9GyB1xUWUUFGAJA==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
+        "@deepseek-ai/schemastery": "^3.18.2"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-jobs": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-scope": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-timeout": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-jobs": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-scope": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-timeout": "^0.1.5-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-launch-environment": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-launch-environment/-/dsh-launch-environment-0.1.1-rc.2.tgz",
-      "integrity": "sha512-LIjPUPwaZ2cIiz98Oqxn9TDKXhWlp+0EGmUhk4RerBAkqRVtDl0B/leK1pSZLLIR+qcr+VAwLGJagY8Xm9XWvw==",
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-launch-environment/-/dsh-launch-environment-0.1.5-rc.1.tgz",
+      "integrity": "sha512-F2vKsFL491FYjlPLzM2/TtuCt88LrV5SAk+r4zNlt9gvbQ+ZEdeVD4uFRwFc8TpYfdM/yL3qioGEpTuU26TxTQ==",
       "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-llm": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-llm/-/dsh-llm-0.1.1-rc.2.tgz",
-      "integrity": "sha512-ASJfjIdZbIXvLwi3rGo+eZb/GxMVV/WO5/XVD3B96mT8EIzrlw3+nMR6/CvmJVzcycKQ2XN0wj7jD6TasPRySA==",
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-llm/-/dsh-llm-0.1.5-rc.1.tgz",
+      "integrity": "sha512-KPKJFTNLjURphuF4NlS8DRK94CUYL/dKB8Hzg/22jtxAFO2paX3ifL0vhdPq9xPbcyplaF7LYlf0+3+pXFTnTg==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
+        "@deepseek-ai/dsh-brand": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-timeout": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-util-crypto": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-util-values": "^0.1.5-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "zod": "^4.4.3"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-attachment": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-brand": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-timeout": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-llm-deepseek": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-llm-deepseek/-/dsh-llm-deepseek-0.1.1-rc.2.tgz",
-      "integrity": "sha512-GH9AukC2kozv6Q8/9DDhACHSe7fpTG7o0iWGUEN/m7/qajCJ8abySOFi3N7otdVmolR6Mvz2GZDTn2HdHqkWWg==",
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-llm-deepseek/-/dsh-llm-deepseek-0.1.5-rc.1.tgz",
+      "integrity": "sha512-PwqB/Amrtc4nF+ndH6UNIOAH+X2QREwV3R3NaBxY/n0j+hfAl3BUmafj/9UvKlFwStYLLxsyS4um7Vy+XQXhNg==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1",
+        "@deepseek-ai/dsh-brand": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-util-values": "^0.1.5-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2",
         "eventsource-parser": "^3.1.0"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-anonymous-user-id": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-atomic-write": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-attachment": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-brand": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-credentials": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-home-paths": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-launch-environment": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-settings": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-timeout": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-anonymous-user-id": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-atomic-write": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-attachment": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-credentials": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-deepseek-llm-api-extensions": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-fs": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-home-paths": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-launch-environment": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-settings": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-timeout": "^0.1.5-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-llm-pi-ai": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-llm-pi-ai/-/dsh-llm-pi-ai-0.1.1-rc.2.tgz",
-      "integrity": "sha512-/02zlUjTHlJkme5+eM6VFtuiK6TacI5rxwIWMaxItp/s8rz91grzWir+qxRsPrz6XIrmKXagyvi3m/tuRCtk5A==",
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-llm-pi-ai/-/dsh-llm-pi-ai-0.1.5-rc.1.tgz",
+      "integrity": "sha512-5OiNHkkVFDucqXY1KT9QQB7EAulbKDDpqrrK7WTJbLzjVUs98ZetAOf1UOZ15JqA1hABX2+fCoXyitPK9yuuvA==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1",
-        "@earendil-works/pi-ai": "^0.82.1"
+        "@deepseek-ai/dsh-brand": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-util-values": "^0.1.5-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "@earendil-works/pi-ai": "^0.85.1"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-attachment": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-authorization": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-credentials": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-launch-environment": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-settings": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-timeout": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-attachment": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-authorization": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-credentials": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-fs": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-launch-environment": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-settings": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-timeout": "^0.1.5-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-llm-retry": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-llm-retry/-/dsh-llm-retry-0.1.1-rc.2.tgz",
-      "integrity": "sha512-a13Fpmn8HFy8LCjl6gljaNPxcVjO/R+/uMPDl0QLjwQcHWVyGW38ZA8jP5iRuFgdyNNXpyxLWuZXi/0VOH00tA==",
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-llm-retry/-/dsh-llm-retry-0.1.5-rc.1.tgz",
+      "integrity": "sha512-WcA5KOmv8aC5F8s60riyaVBSNKBpCrSByzpNbATpNKmU6MHKHSpmYOfOO8vUJQY+cdC3qCOcWwtOd56VpoMPGw==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "zod": "^4.4.3"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-brand": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-timeout": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-brand": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-timeout": "^0.1.5-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-mcp-client": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-mcp-client/-/dsh-mcp-client-0.1.1-rc.2.tgz",
-      "integrity": "sha512-oxNes59UTkXuTmOqQr6+GhZW7u2JtqSYiI5eZyBQ6K+yjPEQESa3/rYnRI+gHGAtx8EFgn6hsdOS5uoEwtFuXg==",
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-mcp-client/-/dsh-mcp-client-0.1.5-rc.1.tgz",
+      "integrity": "sha512-vaxO+lGLsj4B5okcJ3uwrAUoyq9EFqpt6m0rUY9jYlSQHc7RfMkKJ0wpegt8GXUw/WJ0a89dvqI8ojMzi6Jlig==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1",
+        "@deepseek-ai/schemastery": "^3.18.2",
         "@modelcontextprotocol/sdk": "^1.12.0",
         "zod": "^4.4.3"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-attachment": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-subprocess": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-timeout": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-attachment": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-scope": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-subprocess": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-timeout": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.5-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-message-feedback": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-message-feedback/-/dsh-message-feedback-0.1.1-rc.2.tgz",
-      "integrity": "sha512-GzxDiNvyUVs/bbbm+Hr3MfuU3wM8ErRF5z9XadnSGPYZvipZDAMrvrS5v6JgOUaZt6ApBpEMJ4xVgIel1VnGYQ==",
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-message-feedback/-/dsh-message-feedback-0.1.5-rc.1.tgz",
+      "integrity": "sha512-PztvCosgvzuEOLIwtQ1gVrH7Mz/IUXY9Kj/x63hMpQcnJBmgu7Td5fZljtiAkKexVn2PRFFktyo7MRdN6b08VA==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1",
+        "@deepseek-ai/schemastery": "^3.18.2",
         "zod": "^4.4.3"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-brand": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-persistence": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-storage-domain": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-typert-protocol": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-brand": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-command-feedback": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session-persistence": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.5-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-native-command": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-native-command/-/dsh-native-command-0.1.1-rc.2.tgz",
-      "integrity": "sha512-GIknPrwU7vZOUQ2o/ES7Z0uUhUrZGp/yigKP+RXEu41VI9tcybiXQAA8CEdDFmNQ11R2wfYQhr3WO5vy35akWg==",
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-native-command/-/dsh-native-command-0.1.5-rc.1.tgz",
+      "integrity": "sha512-mQxUZ6eY2FGD3nD/IdoC0PgYpAyip/iOvlHpdoIhV9ehbAd0+YwXw8lzsgrO/bq/KGnff2+LjXSkJvyBcPAabA==",
       "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-output-retention": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-output-retention/-/dsh-output-retention-0.1.1-rc.2.tgz",
-      "integrity": "sha512-tCni+bTEp/FWokfz3fqn4p6SzHn6pkY6H3HkS9UY5PHrztUE1ESUQUp41kIVtwUhRmJU7yissqjxe6kLDB6t2Q==",
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-output-retention/-/dsh-output-retention-0.1.5-rc.1.tgz",
+      "integrity": "sha512-bXRq3nGtrsIGOlNNFHLp3gx+59Njl9jnbK30vqiga01y82QzBepfXROWSJGj0Cea0mjxb1tyv0KDRvsHbvTiow==",
       "devOptional": true,
       "license": "MIT",
       "peer": true,
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-package-manifest": {
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-package-manifest/-/dsh-package-manifest-0.1.5-rc.1.tgz",
+      "integrity": "sha512-BWbXpw5AaCJXrGrbvo+CQYBkiS2ilX3hF3a+dQ4N1OqMALFSMNmUV03aT5yT8WUQEngR6ixvOUUgJvHUK0MiiQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-permission-presets": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-permission-presets/-/dsh-permission-presets-0.1.1-rc.2.tgz",
-      "integrity": "sha512-k9hdF0lXV6dmVNBeWTmJpk0okaaH3hnvpQVRfUja8mlpJgPr482QMReuQsGJkY8ztzSE+JtzZndPSXjRrvLzSw==",
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-permission-presets/-/dsh-permission-presets-0.1.5-rc.1.tgz",
+      "integrity": "sha512-A0xrvtH0AgcH/QycrKHIGEeE98xS0ana8q4wmIYKs/AjuZICR0N/qT4qb1GnPRxcuz/7Z8rHjD/fhou/gFRTpw==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1",
+        "@deepseek-ai/schemastery": "^3.18.2",
         "zod": "^4.4.3"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-commands": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-sandbox": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-sandbox-policy": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-projection": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-settings": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-shell": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-user-approval": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-commands": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-sandbox": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-sandbox-policy": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-settings": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-shell": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-user-approval": "^0.1.5-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-persona": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-persona/-/dsh-persona-0.1.1-rc.2.tgz",
-      "integrity": "sha512-3pQjr8qSCVmGtExX9WzGNF9tNHKAFjtDyX6g/2HY3Br/hzANfQY13F/HqdjxufB3K0Rsu4CNkq78TyweXVUZew==",
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-persona/-/dsh-persona-0.1.5-rc.1.tgz",
+      "integrity": "sha512-IgZ5aCD7Y9bS82WStxTW3InVhajfy5e5mCAMTJMa3Zu2sSCBJ1N9lPKgAmMR8c9YGXl03t7YVuM07fjRYfvmMw==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
+        "@deepseek-ai/schemastery": "^3.18.2"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.5-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-plan-mode": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-plan-mode/-/dsh-plan-mode-0.1.1-rc.2.tgz",
-      "integrity": "sha512-jIQ71skseprYkwcIkZfS5jtClF6Z5oDC8JIwMN5ukGRDkkoKTT+uLWnw3AgArAOBi0CIy8j5Khy7GP7v+02F5g==",
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-plan-mode/-/dsh-plan-mode-0.1.5-rc.1.tgz",
+      "integrity": "sha512-E1ajaP9NdbIGZK1i+q1QlhPkDSqIEm1Jsiilp3MGQOCM0nxN78IjfbQo8dpgRZMJ9y/N9zXYJtLpGjLksNkv0A==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "zod": "^4.4.3"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-commands": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-projection": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-user-questions": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-commands": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-user-questions": "^0.1.5-rc.1"
       },
       "peerDependenciesMeta": {
         "@deepseek-ai/dsh-commands": {
@@ -2675,297 +2675,524 @@
         }
       }
     },
-    "node_modules/@deepseek-ai/dsh-pwsh-local": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-pwsh-local/-/dsh-pwsh-local-0.1.1-rc.2.tgz",
-      "integrity": "sha512-MtX+IN0dN60n9F8A07ugz4+GptSaoj2Jyub1vkUFkgpdiph9lDAh+PVVG4EKrusu5YG8eXDCDDnb3S1UNtrNiw==",
+    "node_modules/@deepseek-ai/dsh-plugin-package-inventory-deepseek": {
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-plugin-package-inventory-deepseek/-/dsh-plugin-package-inventory-deepseek-0.1.5-rc.1.tgz",
+      "integrity": "sha512-6W0vYHshQBw9RLGayAMx+PwoIiCWPSZ3hOrgiuWoeecwFYdHgLvInP2Cht0tCGcidUDLojmooPJ8XxefZ4I8Dw==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
+        "@deepseek-ai/dsh-brand": "^0.1.5-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-settings": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-shell": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-subprocess": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-timeout": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/cordis-plugin-loader": "^1.0.3",
+        "@deepseek-ai/dsh-agent": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-agent-presets": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-deepseek-llm-api-extensions": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.1"
+      },
+      "peerDependenciesMeta": {
+        "@deepseek-ai/dsh-agent-presets": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-pwsh-local": {
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-pwsh-local/-/dsh-pwsh-local-0.1.5-rc.1.tgz",
+      "integrity": "sha512-VjTb+R44iPZ2czxD2VN+5YzCpU3WsOtdaKiwNzfswmam73KcjMWuJP1XH6hHLFD3QOjhSr1AaaMYijHYWIEvKQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-settings": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-shell": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-subprocess": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-timeout": "^0.1.5-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-pwsh-sandbox": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-pwsh-sandbox/-/dsh-pwsh-sandbox-0.1.1-rc.2.tgz",
-      "integrity": "sha512-hBUTg5p8TTQifZrfstbimVlBFyUOb7JhNkWKc+n6UpTzoFRSkPAvrjGeXKDmFI6jXpL4nXzLJoaIssfYnRg7bw==",
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-pwsh-sandbox/-/dsh-pwsh-sandbox-0.1.5-rc.1.tgz",
+      "integrity": "sha512-QRD6PfcQuaRwUTn9EMIx15l1erRqk0erUamcAB3sxPyZOMWIFP7w2cp44Va8RGGDEUb9ZB1vRUH6cF4FAKSZRw==",
       "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-pwsh-local": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-sandbox": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-sandbox-policy": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-shell": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-pwsh-local": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-sandbox": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-sandbox-policy": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-shell": "^0.1.5-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-repeat-tool-reminder": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-repeat-tool-reminder/-/dsh-repeat-tool-reminder-0.1.1-rc.2.tgz",
-      "integrity": "sha512-alDGjPdN1o7BVnBy2h4WZa+Zgb6yT76fyAQ7T7wN6K9jbnenSuvCjQyhoehhSFZUEl8ldRqaafFhS9ErGpVmDg==",
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-repeat-tool-reminder/-/dsh-repeat-tool-reminder-0.1.5-rc.1.tgz",
+      "integrity": "sha512-dFdo4icZLP8MvDpGTWTt9/xjVwwoJuzp5jUeBUBxyiK0uSfcdAv+bWW3ghDWeyfRUhpkJIThLb1VmkpfBk9paw==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
+        "@deepseek-ai/schemastery": "^3.18.2"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.5-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-sandbox": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-sandbox/-/dsh-sandbox-0.1.1-rc.2.tgz",
-      "integrity": "sha512-rnO2RqZ+ycpwrXrXlMcrhWAICdui3ZVTjNQ8eZrOPE18hAbX3tw0nLFq26sBjMSnBfDQHNZ4VaFpt0p8qhkPWQ==",
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-sandbox/-/dsh-sandbox-0.1.5-rc.1.tgz",
+      "integrity": "sha512-xT+oTsSE7tRZVqqcj2qDZJARoK6A+Dmhf3CWPqlaFG/83Zh41kwcW2YWE4sA+vCt2pI2iqLYRw1SftSGawOtVQ==",
       "devOptional": true,
       "license": "MIT",
       "peer": true,
+      "dependencies": {
+        "@deepseek-ai/dsh-util-values": "^0.1.5-rc.1"
+      },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-sandbox-local": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-sandbox-local/-/dsh-sandbox-local-0.1.1-rc.2.tgz",
-      "integrity": "sha512-Sn1RTGRFLA3fB+thcBwyyfDRdpgXJ7/6qBz/piFh+emJ4IfGFlBEUz7H2QfuwOGAmzlOmncxf2brcM5SfAgJ2A==",
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-sandbox-local/-/dsh-sandbox-local-0.1.5-rc.1.tgz",
+      "integrity": "sha512-cO8edQeX6sdOzbYuCzyadc6o7QFM2upNuEqb32+VXXDl3qCaNb68NBZxaZaBCfC2/aofcvCL+b6rRE5bcauXRA==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/dsh-sandbox-windows-acl": "^0.1.1-rc.2",
-        "@deepseek-ai/node-addon-landlock-run": "^0.1.1",
-        "@deepseek-ai/schemastery": "^3.18.1"
+        "@deepseek-ai/dsh-sandbox-windows-acl": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-util-values": "^0.1.5-rc.1",
+        "@deepseek-ai/node-addon-system": "^0.1.2",
+        "@deepseek-ai/schemastery": "^3.18.2"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-sandbox": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-sandbox": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-sandbox-policy": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-sandbox-policy/-/dsh-sandbox-policy-0.1.1-rc.2.tgz",
-      "integrity": "sha512-cpoIUxCzpZJDTMXVt9gS+qgWEDAWf6rIe715uY1NF0ROoiEXPlmToLsHLF+4pXTW3wWWzpGVswO0bPYEKrQr3g==",
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-sandbox-policy/-/dsh-sandbox-policy-0.1.5-rc.1.tgz",
+      "integrity": "sha512-jLeny81NVsAiEWW8+MqmtkXJfu8CSFDPiuR8W4I/bZ7TNHrPTN7jPuk1/JlphkU4bq1N1a3iLvsDyHK+56ZLVA==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "zod": "^4.4.3"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-sandbox": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-sandbox": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.5-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-sandbox-windows-acl": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-sandbox-windows-acl/-/dsh-sandbox-windows-acl-0.1.1-rc.2.tgz",
-      "integrity": "sha512-DJ5jI8uzJA2VJiIgkUrqNDo1oKMJMaQ1Z8F7kFpxEkI3IMRSfMyqTur740ERBkX3pVc5uDLx6HNeEBx/JR43SQ==",
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-sandbox-windows-acl/-/dsh-sandbox-windows-acl-0.1.5-rc.1.tgz",
+      "integrity": "sha512-gziY3YdGfq4W03W+qeEKF0oH/3U6XNU0YoUnU4PeBIJFqg1NPamxoX7CdoFXuJgLkYN97IFf2ihQMLfzWvhwhQ==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
+        "@deepseek-ai/dsh-win32-process": "^0.1.5-rc.1",
         "koffi": "^3.1.0"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-schedule": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-schedule/-/dsh-schedule-0.1.1-rc.2.tgz",
-      "integrity": "sha512-I/uuXlZv6gc71SdXoV5sGQhh95nNjhy0zJWfhttfapNvuQYxZEzQU0vTAOsQB5FtdZ/xvDZm86z01/E8+usLAA==",
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-schedule/-/dsh-schedule-0.1.5-rc.1.tgz",
+      "integrity": "sha512-3Kp/2G1yw7aolCQNvZocpN1kSj2dRUHQ/HpYhEmMInBT1OZT4nm+x7UXnxLcskc7R+HIKbd7KpV8YNwkn1K/Eg==",
       "devOptional": true,
       "license": "MIT",
+      "dependencies": {
+        "zod": "^4.4.3"
+      },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-brand": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-persistence": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-brand": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session-persistence": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.5-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-scope": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-scope/-/dsh-scope-0.1.1-rc.2.tgz",
-      "integrity": "sha512-Xy3ejL6dwVSluZL7XOWy76ya4pCw1uHwxodDK4O9XiQUiUV4FBXnt0aNJUtMeAFN0c1YujxxCmRniMvuuNn1Nw==",
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-scope/-/dsh-scope-0.1.5-rc.1.tgz",
+      "integrity": "sha512-HU6AGzCCWSQUS9KoDBAPkyQqgUVp+iI9P5Zn0qzLJv3IOdt6cYvxgjt/rORryuQUR9AUj7CGFO3OYw833H7HWA==",
+      "devOptional": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.5-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-sdk-app": {
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-sdk-app/-/dsh-sdk-app-0.1.5-rc.1.tgz",
+      "integrity": "sha512-0slsRRDEkq5fxDYF0P9tHtZtzjyvg/dB30w6AhvqEX13MRiNdirUQNSsS62yCuCgRzTx0YDg+oQJUwPAw07tOg==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-cmdline": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-sdk-jsonrpc-server": "^0.1.5-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "commander": "^15.0.0"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-sdk-jsonrpc-server": {
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-sdk-jsonrpc-server/-/dsh-sdk-jsonrpc-server-0.1.5-rc.1.tgz",
+      "integrity": "sha512-pg80s3S6EBJOmQb+wT4M10+jgxJw/6ebf8Mr0+FChwCR2HTraKQRo40LmPqgVMCZTj753VZODu8SIQbpUwzhoQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-brand": "^0.1.5-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-attachment": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-llm-deepseek": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-scope": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-sdk-protocol": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-subagent": "^0.1.5-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-sdk-minimal": {
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-sdk-minimal/-/dsh-sdk-minimal-0.1.5-rc.1.tgz",
+      "integrity": "sha512-jWH+1cmiS7LMrpF3OAQqoTSWxC45sxvNHshOBikYqaoUf4sBpSUiTaxy52ZWCB1/tcxB/ZYr1fBDDvTGsg9JfQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/cordis-plugin-timer": "^1.1.4",
+        "@deepseek-ai/dsh-agent": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-agent-loop": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-deepseek-llm-api-extensions": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-jobs-local": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-llm-deepseek": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-llm-retry": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-plugin-package-inventory-deepseek": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-sandbox-local": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-sandbox-policy": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-scope": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-sdk-app": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-sdk-jsonrpc-server": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session-log-deepseek": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session-persistence-jsonl": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session-title": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-subprocess-local": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-terminal": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-terminal-bash": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-tool-bash-persistent": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-tool-pwsh-persistent": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.5-rc.1"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-sdk-protocol": {
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-sdk-protocol/-/dsh-sdk-protocol-0.1.5-rc.1.tgz",
+      "integrity": "sha512-xTleAtWust5wpcjv3HQnFLB0KJIBFthwWerriVtXUz4JUw2b08m7S0JNveKIVDstulNxBvHqgXThtpz7nI9Pow==",
       "devOptional": true,
       "license": "MIT",
       "peer": true,
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-subagent": "^0.1.5-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-session": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-session/-/dsh-session-0.1.1-rc.2.tgz",
-      "integrity": "sha512-4/cv6X9HPhm47eyRhCu/WZwzrtJKegk5J+0xaxcZ9i8S0smdxP57tqy8a0jkSshLQn7BzMFxneQrlYExrLrDhQ==",
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session/-/dsh-session-0.1.5-rc.1.tgz",
+      "integrity": "sha512-0YBBrzkCbVEJolS/OpD0DZMSozmYxUTZopiG76MXInjOFBW9J4ca1a8WUjJjqelP1nJTmWGKXp92HcvNEny0Dg==",
       "devOptional": true,
       "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-brand": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-util-values": "^0.1.5-rc.1"
+      },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-brand": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-scope": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-typert-protocol": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-scope": "^0.1.5-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-session-checkpoint-policy": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-session-checkpoint-policy/-/dsh-session-checkpoint-policy-0.1.1-rc.2.tgz",
-      "integrity": "sha512-VmnQBKuWEHD78CtK1W5Auhz9VayTiNQTpbsNFex4uD/9h0XglFxVN7G3/XVUDOp8VHxReV/Mh8F1RS9s/2yoxg==",
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-checkpoint-policy/-/dsh-session-checkpoint-policy-0.1.5-rc.1.tgz",
+      "integrity": "sha512-q0DXnkvEBmgEnyHYmKGOrkPUOnyEQV/LDMiP6Cnx8xEgdDztALa0koUuRr0Z+3+vlWUKsbXuKkkn3D2yXMW8tA==",
       "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-persistence": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session-persistence": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.5-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-session-format": {
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-format/-/dsh-session-format-0.1.5-rc.1.tgz",
+      "integrity": "sha512-i90c0z2F4k+46CBOuWW/0b2UPnHpDqhS0PictwxWrh7Em7OSwyCTN2dz9cwraCXubg4APTiBCLeOslxvTCKzmQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-util-values": "^0.1.5-rc.1"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-session-format-catalog": {
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-format-catalog/-/dsh-session-format-catalog-0.1.5-rc.1.tgz",
+      "integrity": "sha512-5MT9Z56QjpcgJ+b9UFfVR3Rd9ylaJtKAFFkXp6uFm4ATsK5hTdtrVHgj2rsvqlEVnNAO2gcrnvVd/9diFotv6A==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-session-format": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session-format-v0-to-v1": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session-format-v1-to-v2": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session-format-v2-to-v3": "^0.1.5-rc.1"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-session-format-v0-to-v1": {
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-format-v0-to-v1/-/dsh-session-format-v0-to-v1-0.1.5-rc.1.tgz",
+      "integrity": "sha512-zKayd3l7YETy0agKB5Mg0gdDKkeaHUOmDYblVhS346Wl5G3ZTuurvgwXMNglfwvy7O0uNfOS/SvnU0eWQ4sV1w==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-session-format": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-util-values": "^0.1.5-rc.1"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-session-format-v1-to-v2": {
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-format-v1-to-v2/-/dsh-session-format-v1-to-v2-0.1.5-rc.1.tgz",
+      "integrity": "sha512-wwgTHoeItoITykmlhWFhN8BM87NP58p/OMBrm9UEDd6Z0Y5T+8/ijoVFhPbWIQFMyWdTLF/3JMsS+RxcKwRESg==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session-format": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session-format-v0-to-v1": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-util-values": "^0.1.5-rc.1"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-session-format-v2-to-v3": {
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-format-v2-to-v3/-/dsh-session-format-v2-to-v3-0.1.5-rc.1.tgz",
+      "integrity": "sha512-BH41t2xsAxk2ibigx8WcZZknwxT19IrN1gOm//Qoj0K0qFJ4lWWgj6kJcNyIhdFvTbXOAoaF7KTYEM10Nmzs+w==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-session-format": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session-format-v0-to-v1": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session-format-v1-to-v2": "^0.1.5-rc.1"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-session-log-deepseek": {
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-log-deepseek/-/dsh-session-log-deepseek-0.1.5-rc.1.tgz",
+      "integrity": "sha512-Q2eNVnLsigVRenf+qQxLHWF38GWiRFGWkHAacwwXCZOQUYBNFXnrSGXAGF8gW1tUQAkCKPTsx6LohMW7GDgfAg==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-brand": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-util-values": "^0.1.5-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-deepseek-llm-api-extensions": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-session-log-export": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-session-log-export/-/dsh-session-log-export-0.1.1-rc.2.tgz",
-      "integrity": "sha512-IQ0itJ5VsmvTkBZYNnwNIj7h2qaw7dlHrnKt7toUiAc5gC12tFwKouMFdBS5VtOSsxTuQLdnVNPa81XOy24opg==",
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-log-export/-/dsh-session-log-export-0.1.5-rc.1.tgz",
+      "integrity": "sha512-/SGAggREmyYmVu4F3daNqXE1rFcaeuvOONUwh5dRXf+xMtY/5E1wtwI0K0aJ53+1r6+Azzd9X4xc5EqToV4YiA==",
       "devOptional": true,
       "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-brand": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session-format": "^0.1.5-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "fflate": "^0.8.2"
+      },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-commands": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-commands": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session-persistence": "^0.1.5-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-session-persistence": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-session-persistence/-/dsh-session-persistence-0.1.1-rc.2.tgz",
-      "integrity": "sha512-dxdYxRfmK5jWtiFFabqRNb/jGGjkXyF2djI7O8IIKmDVjhQiv170zpvhbAhRUuqClEdseCtbQpLBrRm2blzt3g==",
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-persistence/-/dsh-session-persistence-0.1.5-rc.1.tgz",
+      "integrity": "sha512-ZOFdFdsX5w4lWln1CO2ZzdnibEIOoPu58rlafw4xsLaPoR5mnceVnIuGIYr8qqaB7iv2f9ZLNaGtyHT/Wgpv0Q==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@deepseek-ai/dsh-util-values": "^0.1.5-rc.1"
+      },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-brand": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-timeout": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-brand": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-timeout": "^0.1.5-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-session-persistence-jsonl": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-session-persistence-jsonl/-/dsh-session-persistence-jsonl-0.1.1-rc.2.tgz",
-      "integrity": "sha512-1H+boST8tlc8fu5VVClcCRFGI18dH1EOAzfC+HsQZ+GiC7jhPN112oJWyzxKot1P07bmKdKev3un4VR2Chr/aw==",
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-persistence-jsonl/-/dsh-session-persistence-jsonl-0.1.5-rc.1.tgz",
+      "integrity": "sha512-/OzAiGuAS6UoiJoQSkoPekFVGB7lNYQp5maN7ZckzQ8oYf1xS5pQPFKptIrgYwd6pZRb2lDlFZhZtBvL0KGHOg==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session-format": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session-format-catalog": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session-format-v2-to-v3": "^0.1.5-rc.1",
+        "@deepseek-ai/node-addon-system": "^0.1.2",
+        "@deepseek-ai/schemastery": "^3.18.2",
         "koffi": "^3.1.0"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-persistence": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session-persistence": "^0.1.5-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-session-projection": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-session-projection/-/dsh-session-projection-0.1.1-rc.2.tgz",
-      "integrity": "sha512-SNaOrjRS4RMXocna6uL33TeS/uhcQ7jDJtJZ1HyDPL06mXUdAgje2MVt8OZCh6dH95xIiqpQQm+KjzeiQnhYSQ==",
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-projection/-/dsh-session-projection-0.1.5-rc.1.tgz",
+      "integrity": "sha512-dwDS3ite9I1oOAPneA87ieHBd+szFNrTeMNF4XHRxexMbBWxNZUv62h714UMNlk2niGKsAKE56PzwlnWHmGwGg==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "zod": "^4.4.3"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-session-projection-cache": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-session-projection-cache/-/dsh-session-projection-cache-0.1.1-rc.2.tgz",
-      "integrity": "sha512-UvCRpIb+LoQI/nCLof17xc2P2KuZoucU3VuzfAukfsF3dYZAy5OP7jrCRdVZIvjRfvFUd7G+awdS9sWbnjcolg==",
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-projection-cache/-/dsh-session-projection-cache-0.1.5-rc.1.tgz",
+      "integrity": "sha512-455PbLGmBNQcOFX1s/yYd3fkRCy13TbQMcVouyhTCzo9KrbiDPg2jPVTkTpQgoo8X9RaAm/hbST781rNqja87g==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1",
+        "@deepseek-ai/dsh-util-values": "^0.1.5-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2",
         "zod": "^4.4.3"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-persistence": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-projection": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-storage-domain": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-storage-domain": "^0.1.5-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-session-query": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-session-query/-/dsh-session-query-0.1.1-rc.2.tgz",
-      "integrity": "sha512-QxQFRg/KnrZnYiO7fNtTJVTakuGs9ZFRkGGgYuNPzSz1pRqiohGNE/JZzBtq+HMv38RRTRZrM4aIOUV8OgqoXQ==",
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-query/-/dsh-session-query-0.1.5-rc.1.tgz",
+      "integrity": "sha512-4FdRNYdUb7uXV9NGSJJtyV+qT0ex3DlidXyWsOPj+8DXo90I24mveLvK72w8IuXDXS2hpO7tJVYoRk8LkxCtIg==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-brand": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-persistence": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-title": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-brand": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session-persistence": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session-projection-cache": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session-title": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-tool-todo": "^0.1.5-rc.1"
       },
       "peerDependenciesMeta": {
         "@deepseek-ai/dsh-session-persistence": {
+          "optional": true
+        },
+        "@deepseek-ai/dsh-session-projection": {
+          "optional": true
+        },
+        "@deepseek-ai/dsh-session-projection-cache": {
           "optional": true
         }
       }
     },
     "node_modules/@deepseek-ai/dsh-session-query-sqlite": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-session-query-sqlite/-/dsh-session-query-sqlite-0.1.1-rc.2.tgz",
-      "integrity": "sha512-gZ9q3v+NdQC5jaArBMQfpX36wLXXvhtEfKK3zu3jOd9HopYxgNKnm/mUX8Ma9P42gR3Q+m5SGU42pow5vy34Cw==",
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-query-sqlite/-/dsh-session-query-sqlite-0.1.5-rc.1.tgz",
+      "integrity": "sha512-WU9L78sMN0smbRndw59COnkG63/r1d3HfRXnGLMcGiJWTJNsMQLniZq1t6SvChtPPsGN4Djr0jGwSULRI20Sbg==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
+        "@deepseek-ai/schemastery": "^3.18.2"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-persistence": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-query": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session-persistence": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session-query": "^0.1.5-rc.1"
       },
       "peerDependenciesMeta": {
         "@deepseek-ai/dsh-session-persistence": {
@@ -2974,66 +3201,78 @@
       }
     },
     "node_modules/@deepseek-ai/dsh-session-reference": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-session-reference/-/dsh-session-reference-0.1.1-rc.2.tgz",
-      "integrity": "sha512-c9mz19ndxjVxSnXEhmJwGDjyKG4oNmu4Sfneix8OUJ+mAr3jIgb/QZZ8rYEc8Bi+Dd1z7Wr90IeWOBF0nolU3A==",
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-reference/-/dsh-session-reference-0.1.5-rc.1.tgz",
+      "integrity": "sha512-rbHLt6qm75wqxzUpp3jw9twcEsWVTAZnSa8uNcqtIAeHbPhlgDKqNxvxOeoQPPmlNFr5y//FCQ4S27B1cqxw4A==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1",
+        "@deepseek-ai/dsh-brand": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-util-values": "^0.1.5-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2",
         "zod": "^4.4.3"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-compaction": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-output-retention": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-query": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-typert-protocol": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-compaction": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-output-retention": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session-projection-cache": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session-query": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session-title": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-spill": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.5-rc.1"
+      },
+      "peerDependenciesMeta": {
+        "@deepseek-ai/dsh-session-projection-cache": {
+          "optional": true
+        },
+        "@deepseek-ai/dsh-spill": {
+          "optional": true
+        }
       }
     },
     "node_modules/@deepseek-ai/dsh-session-stats": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-session-stats/-/dsh-session-stats-0.1.1-rc.2.tgz",
-      "integrity": "sha512-SKGUZicnHHU8+zCswoluBCHSbTkA5ARQjl7YNxN6qY01ud/azpPdbcVaKO2MUy60Q1myx3W0Xk93VzF7sMt6cA==",
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-stats/-/dsh-session-stats-0.1.5-rc.1.tgz",
+      "integrity": "sha512-xq0iu4FRCw6Jgy6VFVwK/ND3R8gNWZ754GXkRfF59OYnWJ9N07JqYw0iCKzg3nUcd3kMYrPCDTPZW1jMUtn1eA==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "zod": "^4.4.3"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-projection": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.5-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-session-telemetry": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-session-telemetry/-/dsh-session-telemetry-0.1.1-rc.2.tgz",
-      "integrity": "sha512-yYNUtpxykp10m6YVCcfmxtfiRZeNr9g+Mg5/37oO6W5Fs9A6L3vfCM4Ppn47lwLbQetejsR1QClV4P4I//c01g==",
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-telemetry/-/dsh-session-telemetry-0.1.5-rc.1.tgz",
+      "integrity": "sha512-051BiuVwm55jvoXuobz1FSA9p1hmpvcJUiBylpvU5rS7u+Jd+iLTkti80954FfSs3bNoTCBRb/mEHmXjl+9YaQ==",
       "devOptional": true,
       "license": "MIT",
       "peer": true,
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-session-telemetry-otel": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-session-telemetry-otel/-/dsh-session-telemetry-otel-0.1.1-rc.2.tgz",
-      "integrity": "sha512-a+kmjEWvRZTMW/oGzoF0LwlsEOdtr4zCv0PeFPG5+wA3XGqn+uukgh5LnXJt4htApxPfWVj1qBz5GFRgg6MkNQ==",
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-telemetry-otel/-/dsh-session-telemetry-otel-0.1.5-rc.1.tgz",
+      "integrity": "sha512-UQfr47iXoMkOQXZqn56p5Pd7rXghPzxpuZJwSydhlNHqIzvYC17tf8TvbNA4FCc63uXv5ISSdcli6smZLHbtfA==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1",
+        "@deepseek-ai/schemastery": "^3.18.2",
         "@opentelemetry/api": "^1.9.1",
         "@opentelemetry/api-logs": "^0.220.0",
         "@opentelemetry/exporter-logs-otlp-http": "^0.220.0",
@@ -3042,186 +3281,203 @@
         "@opentelemetry/sdk-logs": "^0.220.0"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-anonymous-user-id": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-command-feedback": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-telemetry": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-anonymous-user-id": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-command-feedback": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-message-feedback": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session-telemetry": "^0.1.5-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-session-title": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-session-title/-/dsh-session-title-0.1.1-rc.2.tgz",
-      "integrity": "sha512-qHv+9nE6J/piHsWwckmbJBS1sJjunCWsv00arhsgjW1XMLCHxG6QOB+U48P4EBZjve798Tz8AQIlWZy+9T8XmA==",
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-title/-/dsh-session-title-0.1.5-rc.1.tgz",
+      "integrity": "sha512-Gz1qZ9rXiNzogz9StL4+oV3PilLvK6kCgtXSYJZeLIr7quliwDObCmP68+B4vncLPUeBpEaN5ozyE2ymFuzNPg==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1",
+        "@deepseek-ai/dsh-util-values": "^0.1.5-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2",
         "zod": "^4.4.3"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-brand": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-projection": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-brand": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.5-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-session-title-first-prompt-llm": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-session-title-first-prompt-llm/-/dsh-session-title-first-prompt-llm-0.1.1-rc.2.tgz",
-      "integrity": "sha512-HWgRO5C+xFOq8dEKwotJ+jNj9SLo222EIlZuTCV3kdEjblLkSJES8jmXsahzLsIEqXfwdplHfgpG+365XE8NWQ==",
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-title-first-prompt-llm/-/dsh-session-title-first-prompt-llm-0.1.5-rc.1.tgz",
+      "integrity": "sha512-bEF/hyR7eBvBG/EDnERFajo3+phtyGbhpHdm5DRcMzv0EC+JMPVn/vVeOXYzYRvJ95trTntsoVBczL51YdFlkg==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
+        "@deepseek-ai/schemastery": "^3.18.2"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-title": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-title-llm": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session-title": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session-title-llm": "^0.1.5-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-session-title-llm": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-session-title-llm/-/dsh-session-title-llm-0.1.1-rc.2.tgz",
-      "integrity": "sha512-UTdH4h5zuMsNDSEAa3xp6YsfVbLRCCkm/0uBt8wKhu7+rWh7OCgvAgvvwaIKEGST8/8NWC6ogdT2GFNCX4WizQ==",
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-title-llm/-/dsh-session-title-llm-0.1.5-rc.1.tgz",
+      "integrity": "sha512-csGnyYOFr7ubBZQ38sKgfQYujdWNP9n0FJdfgAM1y62lYKMWtjzuPJfKQGar7VsW2E/fBGeyIuLmUP5sEJc/0w==",
       "devOptional": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
+        "@deepseek-ai/dsh-util-values": "^0.1.5-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-title": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-timeout": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session-title": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-timeout": "^0.1.5-rc.1"
       }
     },
-    "node_modules/@deepseek-ai/dsh-settings": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-settings/-/dsh-settings-0.1.1-rc.2.tgz",
-      "integrity": "sha512-iGdKEt91Im3gE7xA9CzRfTJsPcFcxDeDOCLhAjzbpjEv7TAjx/EoYP7lPtiy+QmOjKSKy206SEtAKol9PXWbOw==",
-      "devOptional": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-brand": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/schemastery": "^3.18.1"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-settings-file": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-settings-file/-/dsh-settings-file-0.1.1-rc.2.tgz",
-      "integrity": "sha512-6EKER/KLEOwmTkB0AMb/Or/UVkeaqxisZ4WKo+tgsYyJYDTBTDOZjVRz+nedK7vLj1AH8JiEKvmAf6FMxkZvrw==",
+    "node_modules/@deepseek-ai/dsh-session-turn-outline": {
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-turn-outline/-/dsh-session-turn-outline-0.1.5-rc.1.tgz",
+      "integrity": "sha512-vH6KMszzMCQHJOpVkYOhBqwAN94zFP33ByUbAWag2BT6YDmEXh3pE1lKd7glyGfuPJE6W0cDUUuWLIr5cWLkyA==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1",
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.5-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-settings": {
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-settings/-/dsh-settings-0.1.5-rc.1.tgz",
+      "integrity": "sha512-9t6JlHwnMu7qTHpMVVRLyzfi7yWKlDozmh7Xbjjd5mmzY+dSdKTPsoRGSdGgTLvBMQBi0X2O8Kj2moDp30XKGg==",
+      "devOptional": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@deepseek-ai/dsh-util-values": "^0.1.5-rc.1"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-brand": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-settings-file": {
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-settings-file/-/dsh-settings-file-0.1.5-rc.1.tgz",
+      "integrity": "sha512-y/9cLMidbEq53N4IFYVUgnim9Zfk0UYVTAPkzegOlHCyLQY2mK86u+GU4fXw1mMoO7JH5JjS6SiBTA8ZX4h0DQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-util-values": "^0.1.5-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2",
         "chokidar": "^4.0.3",
         "yaml": "^2.9.0"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-atomic-write": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-home-paths": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-settings": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-atomic-write": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-home-paths": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-settings": "^0.1.5-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-shell": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-shell/-/dsh-shell-0.1.1-rc.2.tgz",
-      "integrity": "sha512-gEqPUxKOpOV66wvM4o8Z5FEuWmsEvYzD9OQy3cyo/kjzlx+2+KUWi22cl/YWtBs/zUtRJbdG5UqMnh8GUeO8Hg==",
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-shell/-/dsh-shell-0.1.5-rc.1.tgz",
+      "integrity": "sha512-8V7iGmfsXDFMyftwQXemh1QLqcUysvy+bYWXr620/1B/sMn3oU8dhXvT8i4uD6VkMy2rds3XScUQ3XBl7ByMLA==",
       "devOptional": true,
       "license": "MIT",
       "peer": true,
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-sandbox": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-settings": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-subprocess": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-sandbox": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-settings": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-subprocess": "^0.1.5-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-shell-env": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-shell-env/-/dsh-shell-env-0.1.1-rc.2.tgz",
-      "integrity": "sha512-dDKKqsxsbklUpxX5ornd/SKJ2yfr/SOHOWDgeJkYvx3SMSXq8EvhCK/VEvHswXQ25rRLFWM4/Mr3htk1hn/GPA==",
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-shell-env/-/dsh-shell-env-0.1.5-rc.1.tgz",
+      "integrity": "sha512-OO4AmGqqHUWRPK1PSroO/TJG3rNwoAgIMx56S3aiM7v4cUtNmUtMQ71lv9kOezcW+2VlHxfup5jhzpYIQAIiSw==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
+        "@deepseek-ai/schemastery": "^3.18.2"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-home-paths": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-persistence": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-shell": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-home-paths": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-shell": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.5-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-skill": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-skill/-/dsh-skill-0.1.1-rc.2.tgz",
-      "integrity": "sha512-FACjlOqdsWX+0RtSs3RWrdY0QQEpPJrBfvxUbWSh7E8UyCM8dKdIbsQnuXIjsAgC7GgYp7lyFDSCMovQ3ARp8g==",
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-skill/-/dsh-skill-0.1.5-rc.1.tgz",
+      "integrity": "sha512-SmlIL6lak8nf+Ioiad0N/iImx/S8NO23ile95rsnfJLOPCxSTjNunyjtSkE6ioyAS8UQaIb4gkVo+LvLYKI0NA==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
+        "@deepseek-ai/dsh-util-values": "^0.1.5-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-scope": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-scope": "^0.1.5-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-skill-badge": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-skill-badge/-/dsh-skill-badge-0.1.1-rc.2.tgz",
-      "integrity": "sha512-1JL4KdWk8pApJAVGlX7SS7p/MIhFKSq7GgA32qHIKWZBnL0qkwtaDdGbk2mam00NVcfGnpTPBXjwL1kOboPn8Q==",
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-skill-badge/-/dsh-skill-badge-0.1.5-rc.1.tgz",
+      "integrity": "sha512-DAEEzizxOPH13HlHDzxT4WiNzCFtbMAfGxTWKpftG5ybfRlb/DBZZu7Bg6vgm/ZXiWcpvlCo7kg0hie0DBjKsg==",
       "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-skill": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-skill": "^0.1.5-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-skill-filesystem": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-skill-filesystem/-/dsh-skill-filesystem-0.1.1-rc.2.tgz",
-      "integrity": "sha512-eyQGv4046c392kIvOCom+gvJpiFbkWsf/VqB7dCQXTZrdXEx99P8oOm3jsagnllcLKYyZVVETs75pPgznye/iw==",
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-skill-filesystem/-/dsh-skill-filesystem-0.1.5-rc.1.tgz",
+      "integrity": "sha512-E8l6NITQ47uVNzfhPz9OLUzxZX3Q0M8K6Vqol5Q8Xjl2IKE9VKMKDErFVkf+IWzZclhMimcbZmqAeUrjbTOmFA==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1",
+        "@deepseek-ai/schemastery": "^3.18.2",
         "chokidar": "^5.0.0",
         "yaml": "^2.4.2"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-fs": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-home-paths": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-skill": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-fs": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-home-paths": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-skill": "^0.1.5-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-skill-filesystem/node_modules/chokidar": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmmirror.com/chokidar/-/chokidar-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
       "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
       "devOptional": true,
       "license": "MIT",
@@ -3237,7 +3493,7 @@
     },
     "node_modules/@deepseek-ai/dsh-skill-filesystem/node_modules/readdirp": {
       "version": "5.1.1",
-      "resolved": "https://registry.npmmirror.com/readdirp/-/readdirp-5.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.1.1.tgz",
       "integrity": "sha512-Kko+Y5XQ6fM+Ce3dq3m9YGxnacYZYl9cA1wZjaF3Vbry2L3i1qVg8+CAgNPsXRArPMUMCaOR7oa9Nqntc43JKA==",
       "devOptional": true,
       "license": "MIT",
@@ -3250,122 +3506,124 @@
       }
     },
     "node_modules/@deepseek-ai/dsh-spill": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-spill/-/dsh-spill-0.1.1-rc.2.tgz",
-      "integrity": "sha512-iayBN51zRj0+ER6KKJM6UlN1dfKXe5eDJeSwYmH+j3wLbCBQTD7Axnhmo9t68JBRrg+eczg2epFMR5RrXrisUQ==",
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-spill/-/dsh-spill-0.1.5-rc.1.tgz",
+      "integrity": "sha512-Dl4ukHqXazACAkxuctFSl3HyjOLLCS1y8Yr8XiD4OQVkoNdJZWjpFwxZemrlEwodQRy4arcbWA0xUOBpGSMkhA==",
       "devOptional": true,
       "license": "MIT",
       "peer": true,
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-brand": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-brand": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-spill-local": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-spill-local/-/dsh-spill-local-0.1.1-rc.2.tgz",
-      "integrity": "sha512-I2t9BRjFw33Ya7c/nSZEwZeDSOCk06fDnGvTmXZoaP+Y4mWRBKStfRk4DvBsUQJW+/ov/E5OEvhNhzhZcUnXgw==",
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-spill-local/-/dsh-spill-local-0.1.5-rc.1.tgz",
+      "integrity": "sha512-rsXRuJLhhfyulMqZjYNHT0cOEsKzkwvumfmXQRvkb6LwHi9dHAtu4l7yVVX8F+OpywPKPVJhP+VkU2E5DfKkTw==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
+        "@deepseek-ai/schemastery": "^3.18.2"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-spill": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-spill": "^0.1.5-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-spill-policy": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-spill-policy/-/dsh-spill-policy-0.1.1-rc.2.tgz",
-      "integrity": "sha512-ulkAuhjIm9sOzNdZ7TDqXyvk601Wn3mN/d1QkBBNmCnxt8yQY/nS4ixGtqCVWCu/tdzQOlVw55qKrcNvsQAJ0A==",
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-spill-policy/-/dsh-spill-policy-0.1.5-rc.1.tgz",
+      "integrity": "sha512-ABtC3dSUs2GWEypkJERbqb6lNqIe3I9qlPd91uG9BrdK2AT5yxhcNHv7PpNWEjhpVZ6dyM4T6ReMcKkKxFKPYg==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
+        "@deepseek-ai/schemastery": "^3.18.2"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-output-retention": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-spill": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-output-retention": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-spill": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.5-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-storage": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-storage/-/dsh-storage-0.1.1-rc.2.tgz",
-      "integrity": "sha512-ptJ1ss8spF+Y2VXjsMV37Qh1+hviYWZylDvXtfEBXjLbPi/BP3dktT4B6OMIAD1rRN+0A4HdTqJBgLk7Gp1rig==",
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-storage/-/dsh-storage-0.1.5-rc.1.tgz",
+      "integrity": "sha512-ng3Xjt6klE35kGH4yBzNfDL1XRVhlw1rC8YQ4aqv8yAMJqeIA1T2eyizyKBl6ewgpu4pzwyANWEHymWLbVQarw==",
       "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-storage-domain": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-storage-domain/-/dsh-storage-domain-0.1.1-rc.2.tgz",
-      "integrity": "sha512-9/3OuaZpxf9NZWhrARpgZ7UBa03pPaTIiDBw+SfESfwVk42NNLVCQgvnEbrWoNwdtzmv0aYCEV23sKwwlQ0LBA==",
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-storage-domain/-/dsh-storage-domain-0.1.5-rc.1.tgz",
+      "integrity": "sha512-pRubmMAyvllAgmKeS20asIwJHywXL79NyUVXC643pz70IJau8iRTTEbJ6sbN/w4DHsVo5ljm0/PZx4TJ72eAgg==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1",
+        "@deepseek-ai/schemastery": "^3.18.2",
         "zod": "^4.4.3"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-storage": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-storage": "^0.1.5-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-storage-json": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-storage-json/-/dsh-storage-json-0.1.1-rc.2.tgz",
-      "integrity": "sha512-UNq6yn/iCh6T1TJ+4XN1Gofam3oqqNgENxAcnajRaD8KIsryVstS7Nke+j3vLdu6MDiGjCsilxyZYtqduE+Dog==",
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-storage-json/-/dsh-storage-json-0.1.5-rc.1.tgz",
+      "integrity": "sha512-yPPJmlJRVkgTgbNy5by/0jZFxlixJdIZFp3Dn6o6xF790eYnhGqNUH94v6zuBTnPDgJiCkiwnoo5KK5FEMBkNA==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
+        "@deepseek-ai/schemastery": "^3.18.2"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-storage": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-storage": "^0.1.5-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-subagent": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-subagent/-/dsh-subagent-0.1.1-rc.2.tgz",
-      "integrity": "sha512-CNa0WuFCR69TMnBKYQInz49/olDSaVHiYkDTyTuDh7YW7Y80/f/HjQe5G0fQaqZMLla3IUSXCIPl5EssWmjcQw==",
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-subagent/-/dsh-subagent-0.1.5-rc.1.tgz",
+      "integrity": "sha512-3XQxzPkKtjhKcn2TgC1myS4qqT5s+Ya0pSLcp0dP36eS9qGLYkg/F7nM48H/xRsNKari+CIcTkVKn9xvuEz6rg==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
+        "@deepseek-ai/dsh-brand": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-chunked-list": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-util-values": "^0.1.5-rc.1",
         "zod": "^4.4.3"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-agent-presets": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-brand": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-jobs": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-sandbox": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-sandbox-policy": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-scope": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-persistence": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-projection": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-projection-cache": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-user-approval": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-agent-presets": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-attachment": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-jobs": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-sandbox": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-sandbox-policy": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-scope": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session-persistence": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session-projection-cache": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session-query": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-user-approval": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-util-time": "^0.1.5-rc.1"
       },
       "peerDependenciesMeta": {
         "@deepseek-ai/dsh-agent-presets": {
@@ -3389,888 +3647,1047 @@
         "@deepseek-ai/dsh-session-projection-cache": {
           "optional": true
         },
+        "@deepseek-ai/dsh-session-query": {
+          "optional": true
+        },
         "@deepseek-ai/dsh-user-approval": {
           "optional": true
         }
       }
     },
     "node_modules/@deepseek-ai/dsh-subagent-fork-in-process": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-subagent-fork-in-process/-/dsh-subagent-fork-in-process-0.1.1-rc.2.tgz",
-      "integrity": "sha512-m5qWHamlJqpwJEUZIZHfKEERhCmsR74B93jGo9ues2pMB7yYjk297oRLQXmaJrQi9FD6zmFntgpwXStK20mbWQ==",
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-subagent-fork-in-process/-/dsh-subagent-fork-in-process-0.1.5-rc.1.tgz",
+      "integrity": "sha512-yPuv9snuphUgimZyguvPZRsF7XJ2IKNYpv+JzW1jrxy7lP+DJhxAHdHidwdNYfDKyt+SivRKAo9vqtpRM0m55Q==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
+        "@deepseek-ai/schemastery": "^3.18.2"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-subagent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-subagent-in-process-driver": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-subagent": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-subagent-in-process-driver": "^0.1.5-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-subagent-in-process-driver": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-subagent-in-process-driver/-/dsh-subagent-in-process-driver-0.1.1-rc.2.tgz",
-      "integrity": "sha512-+GCNjPnRJOB4fv6pc4b9qQZvzoluH9neOLCrKEpJsoNn1c2XCQMaylc8G+WEziIbvzDvHcpKJJWm50XlKuDfMg==",
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-subagent-in-process-driver/-/dsh-subagent-in-process-driver-0.1.5-rc.1.tgz",
+      "integrity": "sha512-seEjs92TDU/0A3Sk31KPUWT872q7DR+mNCrl0T6Pss37Gv8uhSG9qdorRGJAhf1Y4ACIB+zV334kGfwBgs0xTg==",
       "devOptional": true,
       "license": "MIT",
       "peer": true,
+      "dependencies": {
+        "@deepseek-ai/dsh-brand": "^0.1.5-rc.1"
+      },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-subagent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-subagent": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.5-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-subagent-spawn-in-process": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-subagent-spawn-in-process/-/dsh-subagent-spawn-in-process-0.1.1-rc.2.tgz",
-      "integrity": "sha512-Xxe9GzhOK4gIfNUG/Wgx3vsCx7aGZTt268943aRO0wlKQ7Jcku5rH84KfJ+IP2ZY0954KRm4+GQLOKJc/1SSjw==",
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-subagent-spawn-in-process/-/dsh-subagent-spawn-in-process-0.1.5-rc.1.tgz",
+      "integrity": "sha512-vUf+ZdB8stqJUQZlwsZBN3nUJemlnyPiiJC44dF1Lwimx08F8LcXA+tiJ0b78H5p1StXS6BmicFKjrkvc9ZeRQ==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
+        "@deepseek-ai/schemastery": "^3.18.2"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-subagent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-subagent-in-process-driver": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-subagent": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-subagent-in-process-driver": "^0.1.5-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-subprocess": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-subprocess/-/dsh-subprocess-0.1.1-rc.2.tgz",
-      "integrity": "sha512-YXEBaUfdkCJm4Wj/w08imS+1TMd3K4Rjr/xD5tuJR1I4/EnBCseP6AOlwjcrDP5PPWfOZghrK8H01sk6cqiK8Q==",
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-subprocess/-/dsh-subprocess-0.1.5-rc.1.tgz",
+      "integrity": "sha512-kAUwSkEn2NqDiX9J8f1CltDhaxBQau8KD1yBQ2cWJ91KdQV6cwi6F7sA6xKD7Ak46Au/YAwwNX+d7cYaKyr0iQ==",
       "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-http-proxy": "^0.1.5-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-subprocess-local": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-subprocess-local/-/dsh-subprocess-local-0.1.1-rc.2.tgz",
-      "integrity": "sha512-I4pyzpohZEVRQQbuEpMP0t8oKsf+XIlRo64aJVKGXI2eMcg9f9gbfhKQNYNqRGbegQL1HYpSLU6Rzyibldgwaw==",
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-subprocess-local/-/dsh-subprocess-local-0.1.5-rc.1.tgz",
+      "integrity": "sha512-TKcqaIf1fJzjraXhwmSAQAqkPMvIjS0Y7b9fC4n7+G8eQpb3gaF/eJXn6Tx4OgFSDV5R/NLUqHaU/ogxTjdWhQ==",
       "devOptional": true,
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
+        "@deepseek-ai/dsh-win32-process": "^0.1.5-rc.1",
         "koffi": "^3.1.0",
         "node-pty": "1.2.0-beta.15"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-subprocess": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-timeout": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-subprocess": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-timeout": "^0.1.5-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-system-prompt": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-system-prompt/-/dsh-system-prompt-0.1.1-rc.2.tgz",
-      "integrity": "sha512-on4hjAlYI5uX9q7Sf95YkMMBVe6heywtA/H50ksrIMUub8U2B98hO9iQpHhjwIO1F1vu+5pLcPvRr6yUGGmtXQ==",
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-system-prompt/-/dsh-system-prompt-0.1.5-rc.1.tgz",
+      "integrity": "sha512-RAdO9biQoga1vAVTQY9J7THexiOE1FOd1Nli021MQt+Zf73c83BSd2DwXb0WDilLaMeSxZPaIRRqoXpJlpmLIA==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
+        "@deepseek-ai/schemastery": "^3.18.2"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-scope": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-scope": "^0.1.5-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-terminal": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-terminal/-/dsh-terminal-0.1.1-rc.2.tgz",
-      "integrity": "sha512-NOsajXg4cX09coiLtCMgSqXAw90uptqyA9Njv6MVAOLgh6ctpjsolL3VIIWapSJ6AngsCTqVXW7sxexwpl0yUw==",
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-terminal/-/dsh-terminal-0.1.5-rc.1.tgz",
+      "integrity": "sha512-fXsCGJMpefn0uauU1+E+/BWX77Z/Rk+hOxpm5ftNb1YcA6+bttArTQn6KdgFEq3SDXcZwvhUkITffK5wq7nvvA==",
       "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-brand": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-brand": "^0.1.5-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-terminal-bash": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-terminal-bash/-/dsh-terminal-bash-0.1.1-rc.2.tgz",
-      "integrity": "sha512-ltR4K6OBe/7I04w4gCGgbxIv8/qVYHO13vAvwfwmrDM5jePbrEPMu5/xpwPbR28C0kOb7dQy2Z1+FwtVGxviqg==",
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-terminal-bash/-/dsh-terminal-bash-0.1.5-rc.1.tgz",
+      "integrity": "sha512-CeIg1/5jjvtOmtkCyV+V0Qr9piKxDI5UT7jvoL4KdDVZ3R5nTUujaoaFPNhW65cCDR7kd5bEL8SES7JvE8ERJA==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/dsh-pwsh-local": "^0.1.1-rc.2",
-        "@deepseek-ai/schemastery": "^3.18.1"
+        "@deepseek-ai/dsh-pwsh-local": "^0.1.5-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "@xterm/headless": "^6.0.0"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-sandbox": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-sandbox-policy": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-subprocess": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-terminal": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-sandbox": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-sandbox-policy": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-subprocess": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-terminal": "^0.1.5-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-time-context": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-time-context/-/dsh-time-context-0.1.1-rc.2.tgz",
-      "integrity": "sha512-4Q1sCr06SfJ7jkhrvfdg8ZSFp5Ohtl4E9nH19nUbIjcGK8F5yA2h68HPEglztDo54vxI5HZSblLIjdGKZkY+FQ==",
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-time-context/-/dsh-time-context-0.1.5-rc.1.tgz",
+      "integrity": "sha512-ebhaIxwcUBWzA3TPu811uICzyu2hyWjkh3msppYcilBt6fidgc5l2jVIMZdnDsejpdjDzba/eqwFY5JuexKzxQ==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
+        "@deepseek-ai/dsh-util-values": "^0.1.5-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "zod": "^4.4.3"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.5-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-timeout": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-timeout/-/dsh-timeout-0.1.1-rc.2.tgz",
-      "integrity": "sha512-RrouVgU3G5gXr9zHhpThkMG6YKdcRJzXXdPm1dq3ioBxbvxlfMSfNY4tN8lWMJxLyGtvWkPra0HQX+YWxvdOOA==",
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-timeout/-/dsh-timeout-0.1.5-rc.1.tgz",
+      "integrity": "sha512-BcV4y/uCIm82VlIwuGsbLjAZXOxRBmjwusi637MV25hJhhGuWaKoMqAa0D/Lcfqu8hU+g3vgGJdpQvhHnG8sgQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-tmux-context": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-tmux-context/-/dsh-tmux-context-0.1.1-rc.2.tgz",
-      "integrity": "sha512-gsOY/pbm9gdO2sKlqWymv4UxGocm3/4hU+84eTD/Wi6Vnt0QOPDSHEO/SjZ/sdIxiTxoKQLz4mqy0LYmc7DNDA==",
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tmux-context/-/dsh-tmux-context-0.1.5-rc.1.tgz",
+      "integrity": "sha512-b5k6jS8AuW0avt0nRX2IrP38wt8sPL+vhYIE7f2kbdMfH9qcNgBegRh2DtcBLhtaf2E6fxQDQsvA6smOJeVYEA==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "zod": "^4.4.3"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-shell": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-shell": "^0.1.5-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-token-meter": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-token-meter/-/dsh-token-meter-0.1.1-rc.2.tgz",
-      "integrity": "sha512-XHSgvMga4h73LHzuG8gztocs74+6NYg7ciHdu2aM2PYC59/rPfxq4Kz9Hq6TTvYa4a/sDgCij/T0tZBNvQixDQ==",
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-token-meter/-/dsh-token-meter-0.1.5-rc.1.tgz",
+      "integrity": "sha512-Tp4rUwug/u3mV21ri++dN5kCXUecyiVTCeLs8OE/61HiPIUejr5deR54pZEwV+MPPymVOXrmR0V1dBSV0T7Jlw==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1",
+        "@deepseek-ai/dsh-util-values": "^0.1.5-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2",
         "zod": "^4.4.3"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-compaction": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-projection": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-compaction": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-llm-retry": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.5-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-tool-ask-user": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-tool-ask-user/-/dsh-tool-ask-user-0.1.1-rc.2.tgz",
-      "integrity": "sha512-6zSUxSducAdrSJ9J172rzJrqv0I/LbZQZa2ri3k0shYzM2reOi1tf+xWDxVFafUscxeyBpnpmNfXXBuZPt0HZw==",
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-ask-user/-/dsh-tool-ask-user-0.1.5-rc.1.tgz",
+      "integrity": "sha512-O98eATje45lNWJjIwzEjMULeDT5NnZr1LV3GMNd4PZJih9jfflKpuHnVMvRmyrhk6KRdO4tmsPRSs+Bij7wVUg==",
       "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-user-questions": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-user-questions": "^0.1.5-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-tool-bash": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-tool-bash/-/dsh-tool-bash-0.1.1-rc.2.tgz",
-      "integrity": "sha512-YNmrKmBanj5EQn1zejjbo4UUFtg2/h3s9y0lY3vBu+dezNz4HdUlSkSZACbNUAZywyLomdhlt4rJdtdnrqyS7Q==",
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-bash/-/dsh-tool-bash-0.1.5-rc.1.tgz",
+      "integrity": "sha512-BfZ4R40I7AJFcjHgMkzh3unrp5S7mZT+szUUz4tkbMrAkgHfOdkIHhQ/BTgxWBuFzD18OfAMJ/RnegrBCFVKWw==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
+        "@deepseek-ai/schemastery": "^3.18.2"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-jobs": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-sandbox": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-sandbox-policy": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-shell": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-shell-env": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-user-approval": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-jobs": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-sandbox": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-sandbox-policy": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-shell": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-shell-env": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-user-approval": "^0.1.5-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-tool-bash-persistent": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-tool-bash-persistent/-/dsh-tool-bash-persistent-0.1.1-rc.2.tgz",
-      "integrity": "sha512-pPI2ln6OdlCW6Kks5VWsFm7sC5NEkZetKOJ8TUrsXkbCM32wWLEaMPVsN9p5XcG/ao99p+Nh0Rdx7PYn4lfg0g==",
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-bash-persistent/-/dsh-tool-bash-persistent-0.1.5-rc.1.tgz",
+      "integrity": "sha512-o1mu982ix8Re+84oxs1ZwFObwsEuvLymQlPb/qEJcRm82/Ui3rI0SByPbBHxiHrFp4PLB4WsWCzdKNfIuF8XKQ==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
+        "@deepseek-ai/schemastery": "^3.18.2"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-terminal": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-timeout": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-terminal": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-timeout": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.5-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-tool-call-timeout-policy": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-tool-call-timeout-policy/-/dsh-tool-call-timeout-policy-0.1.1-rc.2.tgz",
-      "integrity": "sha512-vPYSRvYV9mDSNRl3BU4M76cIA4oigBD16eS/TxFjAj6fpkdc4JgLA9nsvl515/1DJLEIYnp3HQF3iCsptEdurw==",
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-call-timeout-policy/-/dsh-tool-call-timeout-policy-0.1.5-rc.1.tgz",
+      "integrity": "sha512-rx7nmu2fRWVXbprb950gXpoBxtTLCaJDSShXF73TURZtAjehr7PwMypwWdp4y0YBLfGpmFRjLy09/BK08RFnzw==",
       "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-timeout": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-timeout": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.5-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-tool-cordis": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-tool-cordis/-/dsh-tool-cordis-0.1.1-rc.2.tgz",
-      "integrity": "sha512-cBgfa+0Al94/ur+jaWk2uHZ2ChFw3Mf9nmgaFcToFxkBDAcSCpeKjXK27aw/g2EIz3MvPMzOJo9MLDF3WkUEZg==",
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-cordis/-/dsh-tool-cordis-0.1.5-rc.1.tgz",
+      "integrity": "sha512-dGX+Q/7ggnoLRtofTUXmdTRgvpiWWl53ghpPZgj6lNAh91hjKSmAwxq8vV3fXARZif9OKDJVJ7k0YBaYswOLYg==",
       "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-cordis-host-runner": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-scope": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-cordis-host-runner": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-scope": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.5-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-tool-fs": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-tool-fs/-/dsh-tool-fs-0.1.1-rc.2.tgz",
-      "integrity": "sha512-llX8AWbaI3CGme/a2eeTSfy5atk8u3iJeOFzmZV/KZ0v0hMhKZIK1xQInWwC9OmSDJ/StStJe0hDPVLWbB7hVg==",
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-fs/-/dsh-tool-fs-0.1.5-rc.1.tgz",
+      "integrity": "sha512-BWLWJCJxCECFHmS8gHbnyNJlSTG+KVbVMz73Qduoo+ABeDvWj6cFVXTewAUA9jFEIS3xzJcNilsV1g5DGaEnPw==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1",
+        "@deepseek-ai/schemastery": "^3.18.2",
         "diff": "^9.0.0"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-attachment": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-fs": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-sandbox": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-sandbox-policy": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-user-approval": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-attachment": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-fs": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-sandbox": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-sandbox-policy": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-user-approval": "^0.1.5-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-tool-fs-search": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-tool-fs-search/-/dsh-tool-fs-search-0.1.1-rc.2.tgz",
-      "integrity": "sha512-gHu+6Cs9zs1EYd5KSEJxAsw29sz8pGaj+wJb1cwbK39gzK0AUQ10RlBYuxee6SXgMMnD/vFJZFjxRtCAdo1CCA==",
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-fs-search/-/dsh-tool-fs-search-0.1.5-rc.1.tgz",
+      "integrity": "sha512-002xxeL5UD2QmssUbiI1mfVsP5hpPAmSM+RNPzlJoQ6OF5RwYjmbMeBhQ4mMlp170cyTLeOa6N6WRx+LnhQQcA==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1",
+        "@deepseek-ai/schemastery": "^3.18.2",
         "@vscode/ripgrep": "^1.18.0"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-output-retention": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-spill": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-subprocess": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-timeout": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-output-retention": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-spill": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-subprocess": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-timeout": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.5-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-tool-goal": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-tool-goal/-/dsh-tool-goal-0.1.1-rc.2.tgz",
-      "integrity": "sha512-kTECpE732uwlxRJr/jBZb1BqaxZzrA7Rv4KuM3eolvhoTJ5zjyiR2YHmDmCSfuI6zmA/BEfWss7D0mLbVtJEZA==",
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-goal/-/dsh-tool-goal-0.1.5-rc.1.tgz",
+      "integrity": "sha512-5NCniCOoCeXYXMZNPCmGlrOYIGjnGddTJVOCXNqqAcwxtOxHAoEHTtphaohIa/4Vy7mmRIHgO1KUii443ky1Bw==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
+        "@deepseek-ai/schemastery": "^3.18.2"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-goal": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-goal": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.5-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-tool-jobs": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-tool-jobs/-/dsh-tool-jobs-0.1.1-rc.2.tgz",
-      "integrity": "sha512-wCU7mo2uoQcAtz7de4ZXP2es9lALsmz6XzC+KAlS2e7/yTBi9a5LL2vdSr6XhExVAuhu/6f9eM/w4EQBOxtKlw==",
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-jobs/-/dsh-tool-jobs-0.1.5-rc.1.tgz",
+      "integrity": "sha512-SIgxnjQHl6KE+kpt7VjYCI3aw5DCeztCKGxuJzpLdqJkSoVtewp1Ofz0/Pg1R4DIIaGR8unRyqpZH8qf8uIpzA==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
+        "@deepseek-ai/schemastery": "^3.18.2"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-jobs": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-output-retention": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-jobs": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-output-retention": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.5-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-tool-present": {
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-present/-/dsh-tool-present-0.1.5-rc.1.tgz",
+      "integrity": "sha512-sfYwTyynqM5ev2TnPXX1WKAwlhFa9msptC//qCxZTsCRCeWoaKwwPj+js0P1nGGV9gIy6QJoDh0uYOPMNlb/Jg==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-fs": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.5-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-tool-pwsh": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-tool-pwsh/-/dsh-tool-pwsh-0.1.1-rc.2.tgz",
-      "integrity": "sha512-Gr0F4VWCIIR25qWVv4mMEJnewXILHLCkZwrLfbHA2OOI7DNvvdB5wjJxhuo+ZQa8/3KJ/byQGtEBqCY9mb10Zg==",
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-pwsh/-/dsh-tool-pwsh-0.1.5-rc.1.tgz",
+      "integrity": "sha512-UmWePfsJIUfFVj2UFyh8wacqxSXYrABGoBHXWjYFlfqpXt7rfJL31rOl8N1+uYypAVCxe4O2IquuJxfYAVhBLA==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
+        "@deepseek-ai/schemastery": "^3.18.2"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-jobs": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-sandbox": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-sandbox-policy": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-shell": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-shell-env": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-user-approval": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-jobs": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-sandbox": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-sandbox-policy": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-shell": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-shell-env": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-user-approval": "^0.1.5-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-tool-pwsh-persistent": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-tool-pwsh-persistent/-/dsh-tool-pwsh-persistent-0.1.1-rc.2.tgz",
-      "integrity": "sha512-h/CgOw+pZQDl+upWeFdUF1wzgZQ4NgTSMAmlOe60QRObEP8rEYggELP3QQiJbgXs34N5E6Ovf4W/ADtnFJVsEw==",
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-pwsh-persistent/-/dsh-tool-pwsh-persistent-0.1.5-rc.1.tgz",
+      "integrity": "sha512-oQdHTNNsEwdmKTUw7Ve8EkYCVs5hWb3yUxRQJt0E5qPfoTWPzmAUfYQxyZnJW4iKs9TARFKsnA0KjeOAaE4HQw==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
+        "@deepseek-ai/schemastery": "^3.18.2"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-terminal": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-timeout": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-terminal": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-timeout": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.5-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-tool-ralph": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-tool-ralph/-/dsh-tool-ralph-0.1.1-rc.2.tgz",
-      "integrity": "sha512-SGOMIJPufjz+eia6p8lRIZ9ybflk/6m1E+MAm6zg4QeCnXcGr2z3fkA8+/CTViosj9wh8NfXJYMFweRpbigkDA==",
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-ralph/-/dsh-tool-ralph-0.1.5-rc.1.tgz",
+      "integrity": "sha512-WwLx1/AXydG76/OmLPJheCOlrGXerGyJ6DTbBu+i5/v1/KqHsmg2XbBSBQNaSS1oZcpslPA04+cCOKtL6Sl1rQ==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
+        "@deepseek-ai/schemastery": "^3.18.2"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-subagent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-workflow": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-subagent": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-workflow": "^0.1.5-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-tool-skill": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-tool-skill/-/dsh-tool-skill-0.1.1-rc.2.tgz",
-      "integrity": "sha512-ADOjLELlf6QgrJDFdieNDN42pInPHL39ZU/+v+MXxkhE6poM+kcZmn/eCxbfSvMBFQm9E58Zvg60c0hrsi5BCg==",
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-skill/-/dsh-tool-skill-0.1.5-rc.1.tgz",
+      "integrity": "sha512-f/ulddbkhWXphLce3vlnie8bT9P0LuasehqG+qjsBEiZvGpCS23M3IJoh2j90sUgLhAgW5OSQ0qaut3cTgfAsg==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
+        "@deepseek-ai/schemastery": "^3.18.2"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-skill": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-skill": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.5-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-tool-str-replace-editor": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-tool-str-replace-editor/-/dsh-tool-str-replace-editor-0.1.1-rc.2.tgz",
-      "integrity": "sha512-Pzyjfr3T9VSUKyAmxoejp4GVvwup9gmj2Kx6WmoUEMK17NPZrhRXgMXbzFu2JnRjxRp2p1FSs4JDb2734xMQzA==",
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-str-replace-editor/-/dsh-tool-str-replace-editor-0.1.5-rc.1.tgz",
+      "integrity": "sha512-t0wme2aOdW7xhyxeH2T+fuR3CyA2lYVioqtrsMNnq9IqUGgoEqEl+pZMgOA9kx1NIxMRyn25vweJlgbm6NaxOw==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
+        "@deepseek-ai/schemastery": "^3.18.2"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-fs": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-sandbox": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-sandbox-policy": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-fs": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-sandbox": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-sandbox-policy": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.5-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-tool-subagent": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-tool-subagent/-/dsh-tool-subagent-0.1.1-rc.2.tgz",
-      "integrity": "sha512-26TuzAuxy8x/jDuWJdvCSRQ/ojm7++5FQ6CRLCdZcgU/3Iw2ZY9TKqAIz48cFHOv/wS3+ru0rX3fF1etv6a11Q==",
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-subagent/-/dsh-tool-subagent-0.1.5-rc.1.tgz",
+      "integrity": "sha512-29xQqqjzmMP2A0qxlQpYdbH4Eg3G+FWGpCeRDW7oFq62K4jbOlv7iba8DbG35+Av+TpnXJvMM8j/6BkyLw+dkg==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-jobs": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-subagent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-tool-subagent-control": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-tool-subagent-control/-/dsh-tool-subagent-control-0.1.1-rc.2.tgz",
-      "integrity": "sha512-I1enWV1Pm045l5usFwpJtbzJEpic/XdPdWOg+l0it4ia1jUq9l5jPZeQ85Z2x4UbyxtXFOMDGvSL+9kMi0LzLQ==",
-      "devOptional": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-subagent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-tool-subagent-report": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-tool-subagent-report/-/dsh-tool-subagent-report-0.1.1-rc.2.tgz",
-      "integrity": "sha512-nxy8Y4PhhaasMewLb/Cj+gU/CthtXgtrPuR2NZmYr49xWYXBu8A2IoWFwf6Y7HkbZRSPg6LPsQJEpftjnIYc2g==",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-subagent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-tool-todo": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-tool-todo/-/dsh-tool-todo-0.1.1-rc.2.tgz",
-      "integrity": "sha512-YKP77X/fiKxva/ZzcqkDy6WhNUWYA9oTrAPLAVf3GP+ubIu+r4/cPxu6f2+/8rXLYSi47HXAHajeqQbw2UNXnQ==",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1",
+        "@deepseek-ai/schemastery": "^3.18.2",
         "zod": "^4.4.3"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-projection": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-jobs": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-scope": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-settings": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-subagent": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.5-rc.1"
       }
     },
-    "node_modules/@deepseek-ai/dsh-tool-web": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-tool-web/-/dsh-tool-web-0.1.1-rc.2.tgz",
-      "integrity": "sha512-oV54OJFYYseJCT77F8lr9ZU/f/x8ZbPTmgQpYPC/O24Hw5uqUHEADkukC2ajrltZSTd0+OVqxHFwpWH4gjDoHQ==",
+    "node_modules/@deepseek-ai/dsh-tool-subagent-control": {
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-subagent-control/-/dsh-tool-subagent-control-0.1.5-rc.1.tgz",
+      "integrity": "sha512-vEztxH6ctHdDJFYQjxaOuecV9a9ia0R1eW4DPP5nuQdr1KeJeOl76d6h9KFPdk9gkqZjJwpkJzdH1rAYjkMDhw==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1",
+        "@deepseek-ai/dsh-brand": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-util-values": "^0.1.5-rc.1"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-subagent": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.5-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-tool-todo": {
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-todo/-/dsh-tool-todo-0.1.5-rc.1.tgz",
+      "integrity": "sha512-JfVRK72J26j/ouEmzhvcHnVqfFa0jJAPGtrGS9QV1gyTXCVvjlZi1vf4Qihf08d9Kj4LLFybXaxGlh4KEnZkcg==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.5-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-tool-web": {
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-web/-/dsh-tool-web-0.1.5-rc.1.tgz",
+      "integrity": "sha512-yWU58XcvtKdTT8Rn9f+dkN6IIFUbPd7iIuv9l4PmRMmC9MFT4eZjXABPo1yByVFsW1jjDJlm/XZVyNTnhGBBbw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-util-values": "^0.1.5-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2",
         "@joplin/turndown-plugin-gfm": "^1.0.67",
         "turndown": "^7.2.4"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-web": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-web": "^0.1.5-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-tool-workflow": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-tool-workflow/-/dsh-tool-workflow-0.1.1-rc.2.tgz",
-      "integrity": "sha512-tOLaym8/eyHOATADljSbUYBizaYZTqMKp8p+r2SwiWqIjnRral67BwoO5boX+3t+m2Z45+mvrEnHCu1deYLuaA==",
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-workflow/-/dsh-tool-workflow-0.1.5-rc.1.tgz",
+      "integrity": "sha512-gO7kRxRMabznM4UCMrpG8/YHLP/L5K4ocTMb+EiL9OcwvTSWNORNM2Zz5DAPb/aidJDGY5khSV9G2JGabqA9eA==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
+        "@deepseek-ai/schemastery": "^3.18.2"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-workflow": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-workflow": "^0.1.5-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-tools": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-tools/-/dsh-tools-0.1.1-rc.2.tgz",
-      "integrity": "sha512-0GGL4D55MwYDepzZMOI3L0ycu5b2qr96GL0Y7snwhAnpK2Di61rbX3fJE+PB3ZrovGX0csIRdt9n3iJZDVtDrw==",
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tools/-/dsh-tools-0.1.5-rc.1.tgz",
+      "integrity": "sha512-I5AUxKTqUrC0nvRO4UcpU+f65P+nKs5BUrS2nqZehhFZ2rVxhUAJ7YdORcY6pVkBTB15nPr5gK0WPgwyfS217w==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
+        "@deepseek-ai/dsh-brand": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-util-values": "^0.1.5-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-code-runtime": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-scope": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-user-approval": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-code-runtime": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-scope": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-user-approval": "^0.1.5-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-typert-loader": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-typert-loader/-/dsh-typert-loader-0.1.1-rc.2.tgz",
-      "integrity": "sha512-YTShO0kcBBwXDx8J1Xgn0z4l9nNBqBbpHh2wFAN+PXPORXn0p0F4RY5z2YUVLKLJaL8XRjNKdl43hHK/ttomqw==",
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-typert-loader/-/dsh-typert-loader-0.1.5-rc.1.tgz",
+      "integrity": "sha512-5kTyT/ZIg8+LUpffO70zTvxPtcpiQPUqGNZCWLG9WrQZzHmOytgIdlGwlFg5Wc6T4JkyA7lXsm5BOn1jI1eJdA==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
+        "@deepseek-ai/schemastery": "^3.18.2"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/cordis-plugin-loader": "^1.0.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-typert-registry": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/cordis-plugin-loader": "^1.0.3",
+        "@deepseek-ai/dsh-typert-registry": "^0.1.5-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-typert-protocol": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-typert-protocol/-/dsh-typert-protocol-0.1.1-rc.2.tgz",
-      "integrity": "sha512-lxBssDc5Pz1qBE5kuIyaArA7AvIPq9rpaVclylodiSzVJe95e2xruBg73tflyjtd8y00toet+DLgQ6tSSsq6Kw==",
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-typert-protocol/-/dsh-typert-protocol-0.1.5-rc.1.tgz",
+      "integrity": "sha512-HBxnSnvjiYPlir6An+/W+66dTRQnwpbNUbtOH6e5LHuV4CcHL5yrimTbMI04olJM9w2U9FyfwDOzmW6uqWjAew==",
       "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-typert-registry": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-typert-registry/-/dsh-typert-registry-0.1.1-rc.2.tgz",
-      "integrity": "sha512-ATZu3i7UId+ktsWW3pUFm5Hi1fVsRXFmByATVPp2RlxH1zjxXnauVW6k70ZwU/4FOsphRzo65SXOlAXA+natYg==",
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-typert-registry/-/dsh-typert-registry-0.1.5-rc.1.tgz",
+      "integrity": "sha512-h+lmV9FnNxtlZmY3vH9B4Sj49jt/I7mCPhGG2ffrA+K4twlOjB9TB2Eq9PMoHzWOoHoGoi5QeXDt0mH9fuj1lQ==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/dsh-typert-protocol": "^0.1.1-rc.2",
         "zod": "^4.4.3"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-user-approval": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-user-approval/-/dsh-user-approval-0.1.1-rc.2.tgz",
-      "integrity": "sha512-SdsO4Rs+NeJFoertkVilXBACREOLfkKPJJznYKqDhJxeRo38RJ56dtj0Xd0/6rERmsQiMck4Bwdrzg1ubUqPNA==",
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-user-approval/-/dsh-user-approval-0.1.5-rc.1.tgz",
+      "integrity": "sha512-fSxEBvHQnozIh5HV31t2BNodYzyv7iE2srna7p5k0Y/3R9c6DdoZyQZ9momcN9gloraq8HK5+cvrYHzgc4LYPQ==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
+        "@deepseek-ai/schemastery": "^3.18.2"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-brand": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-scope": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-brand": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-scope": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.5-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-user-questions": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-user-questions/-/dsh-user-questions-0.1.1-rc.2.tgz",
-      "integrity": "sha512-9lYoB7qCFE+Vvgwjny3MnRfS7QUefOspj4KpE3b30DAAJfxwrU4hRtLCHOKxyurF01qrkoEBBpXn4H5ilXYTKg==",
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-user-questions/-/dsh-user-questions-0.1.5-rc.1.tgz",
+      "integrity": "sha512-IqbMrL7qortyJGJs/H+iBbxiSke8x1csKxGDJmMmycvKOHo6RIwG5008JkZlEpmm9SU9aaJF1UzDfaGHJl10Tw==",
       "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-scope": "^0.1.5-rc.1"
       }
     },
-    "node_modules/@deepseek-ai/dsh-web": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-web/-/dsh-web-0.1.1-rc.2.tgz",
-      "integrity": "sha512-Rtikc8RUlfx6m9+hYvKB3JlAD34PrI2UFHEu1h8UMb7pM/ulIRpjBF7TPlg537WRK4ufCysqCJm0RheNMoYCcQ==",
+    "node_modules/@deepseek-ai/dsh-util-crypto": {
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-util-crypto/-/dsh-util-crypto-0.1.5-rc.1.tgz",
+      "integrity": "sha512-8ZosLrwbXdsWRlZ/0Yu85GMhKbFHqGD+ayiFzABXGb3sxfG6nbQQWKtv1sRr77wJ6wYvM2R9rPOg+EDWkGocqQ==",
       "devOptional": true,
       "license": "MIT",
-      "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
-      },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2"
       }
     },
-    "node_modules/@deepseek-ai/dsh-web-app": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-web-app/-/dsh-web-app-0.1.1-rc.2.tgz",
-      "integrity": "sha512-1zGHY7qwBVlVJrzIWu+86SuBZXaVUxe2JRfffsuRvKXq2QcR/K4CoJJfZ43cDoWKu9xPvvxz7w2ezV+EdXgg1A==",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "@deepseek-ai/dsh-agent-presets": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-app-boot": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-connection": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-hmr": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-modules": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-agent-preset": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-attachment": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-brand-official": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-commands": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-cordis": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-deliverables": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-directory-picker-browse": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-directory-picker-native": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-goal": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-input-trigger": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-jobs": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-layout": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-message-feedback": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-model-selection": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-permission-presets": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-plan": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-reference": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-renderer": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-settings": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-settings-general": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-settings-models": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-settings-plugin-inventory": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-settings-plugins": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-sidebar": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-skill": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-subagent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-theme": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-tool": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-trajectory": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-user-questions": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-workflow-run": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-ui-workspace": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-cmdline": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-code-runtime-worker-thread": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-cordis-client-runner": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-cordis-host-runner": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-file-reference": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-file-reference-local": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-host-apiproxy": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-host-directory-picker-auto": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-host-directory-picker-browse": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-host-directory-picker-native": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-host-frontend-static": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-host-plugin-inventory": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-host-webserver": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-launch-environment": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-message-feedback": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-log-export": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-projection-cache": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-reference": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-stats": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-storage": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-storage-domain": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-storage-json": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-subprocess": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-web-frontend": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-workspace": "^0.1.1-rc.2",
-        "@deepseek-ai/schemastery": "^3.18.1",
-        "commander": "^15.0.0",
-        "open": "^11.0.0"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/cordis-plugin-loader": "^1.0.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-shell-env": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-web-frontend": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-web-frontend/-/dsh-web-frontend-0.1.1-rc.2.tgz",
-      "integrity": "sha512-1cjf39g6RW7cgtvwhIF6MSnp5sk3KYRkmRhZM4GETWLXCrTfMD0WCJr3yME1uvJsYPTk28XmKXwwMUPrO3kksQ==",
-      "devOptional": true,
-      "license": "MIT"
-    },
-    "node_modules/@deepseek-ai/dsh-web-search-deepseek": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-web-search-deepseek/-/dsh-web-search-deepseek-0.1.1-rc.2.tgz",
-      "integrity": "sha512-g8wl7k0Htd0MI5CCh0XHK768P5u05ge0JRThMSgNYQvuKJ+gY4uVwzPXJb7eZ7xNWgXt8ERLXIOMVRylaJX1XQ==",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-credentials": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-launch-environment": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-settings": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-web": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-workflow": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-workflow/-/dsh-workflow-0.1.1-rc.2.tgz",
-      "integrity": "sha512-YHUGOBfHGXVr9RRAdCvKZ/1SeeKx4jRumSBMNJo1ETbVqEK+ov2kV61pHFfLu1h+heCsEbOsEJeVXvgYC8EBhw==",
+    "node_modules/@deepseek-ai/dsh-util-time": {
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-util-time/-/dsh-util-time-0.1.5-rc.1.tgz",
+      "integrity": "sha512-HXfJqKymuFv052hHzpHNvrHAcgMbx1BG0o9PiEGkqel9k0fXRBmhWGqrROebZxe5gpIotlVhq7QAXd36p/dyzA==",
       "devOptional": true,
       "license": "MIT",
       "peer": true,
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-brand": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-util-values": {
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-util-values/-/dsh-util-values-0.1.5-rc.1.tgz",
+      "integrity": "sha512-iHH62b+Mc0ueLHn1OQGLOC6+WMqjyK2+wxCkaiQGoGHBAyRGQBnBWiFAOGxp2xIElCXsc1mU1nrkN8D6jppYQg==",
+      "devOptional": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-util-workspace-path": {
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-util-workspace-path/-/dsh-util-workspace-path-0.1.5-rc.1.tgz",
+      "integrity": "sha512-yGU2meCr+8Ru+4WbMtKLlROxtuj9zGjJ6N6bJs20kRxIT0JNlZ6uwqnDQONgN8u44WdyKEaIwbv5IGjxIftLRw==",
+      "devOptional": true,
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-web": {
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-web/-/dsh-web-0.1.5-rc.1.tgz",
+      "integrity": "sha512-kf57xP4cIsKK3DNRQ7jJaLQCA7u30xLRerd98epHDThcCLP8Ab8z7p2C0Xh1J4GdorDnU+jxQ1lae9svwGNmZA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-web-app": {
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-web-app/-/dsh-web-app-0.1.5-rc.1.tgz",
+      "integrity": "sha512-9V2GPqEs0A+LFJVVPt7FQK//U8oM9S0TDhl6MqO7zQftimfnH8ruQZkEZXg9zXXEWULCW0vY1DtsPjvMepA8Mw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-agent-presets": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-api-remotes": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-api-session-controller": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-api-settings-controller": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-api-workspace-controller": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-api-workspace-files": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-app-boot": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-client-connection": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-client-file-upload": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-client-hmr": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-client-locale": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-client-modules": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-client-resources": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-client-ui-agent-preset": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-client-ui-approval": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-client-ui-attachment": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-client-ui-brand-official": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-client-ui-chat": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-client-ui-commands": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-client-ui-cordis": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-client-ui-deliverables": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-client-ui-directory-picker-browse": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-client-ui-directory-picker-native": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-client-ui-goal": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-client-ui-input-trigger": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-client-ui-jobs": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-client-ui-layout": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-client-ui-message-feedback": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-client-ui-model-selection": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-client-ui-open-in-app": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-client-ui-permission-presets": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-client-ui-plan": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-client-ui-reference": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-client-ui-renderer": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-client-ui-schedule": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-client-ui-session": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-client-ui-settings": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-client-ui-settings-general": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-client-ui-settings-models": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-client-ui-settings-plugin-inventory": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-client-ui-settings-plugins": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-client-ui-sidebar": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-client-ui-sidebar-documentpreview": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-client-ui-sidebar-files": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-client-ui-sidebar-right": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-client-ui-skill": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-client-ui-subagent": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-client-ui-theme": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-client-ui-tool": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-client-ui-trajectory": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-client-ui-user-questions": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-client-ui-workflow-run": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-client-ui-workspace": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-cmdline": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-code-runtime-worker-thread": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-cordis-client-runner": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-cordis-host-runner": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-file-reference": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-file-reference-local": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-host-directory-picker-auto": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-host-directory-picker-browse": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-host-directory-picker-native": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-host-frontend-static": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-host-open-in-app": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-host-plugin-inventory": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-host-webserver": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-launch-environment": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-message-feedback": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session-log-export": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session-reference": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session-stats": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session-turn-outline": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-subprocess": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-tool-subagent": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-web-frontend": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-workspace": "^0.1.5-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "commander": "^15.0.0",
+        "open": "^11.0.0"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/cordis-plugin-loader": "^1.0.3",
+        "@deepseek-ai/dsh-shell-env": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.5-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-web-fetch-http": {
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-web-fetch-http/-/dsh-web-fetch-http-0.1.5-rc.1.tgz",
+      "integrity": "sha512-n3cdS8saCgRoTyoV/Jx1gnQV5/hZ0n1ejIMuFUieSMwWfS+8KQNHHB1M8DhCtZ+XpQx5tict0D07hwLdjmb15A==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "ipaddr.js": "^2.5.0",
+        "undici": "^8.10.0"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-http-proxy": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-timeout": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-web": "^0.1.5-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-web-frontend": {
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-web-frontend/-/dsh-web-frontend-0.1.5-rc.1.tgz",
+      "integrity": "sha512-N6WnubGkuOt62OSFVs3XFybh9/VnDy2yMqaAivr1pIp3YtLsMv9QEyYrgqUhsYsuqu1Tfr5GAVmmcNI5OA7i/Q==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/@deepseek-ai/dsh-web-search-deepseek": {
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-web-search-deepseek/-/dsh-web-search-deepseek-0.1.5-rc.1.tgz",
+      "integrity": "sha512-/eu47plhOZLQcm+PeTh3hxSyaXpSJ+oEfVfWwfZ/TxEwbMKZm/mL/FTNnWtzvAhVB8e6nt0ERGVuQATco0k5lg==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-credentials": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-launch-environment": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-settings": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-web": "^0.1.5-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-webhook": {
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-webhook/-/dsh-webhook-0.1.5-rc.1.tgz",
+      "integrity": "sha512-Zj5cxTYweaC5sLnSHc26TZWY0PPJ+yCPSnuP2vrpn18FErMC539XfHN5+ann0iqK2fN7NKnxCqJmHHSI+Q43lw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-brand": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-util-values": "^0.1.5-rc.1"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-agent-default-model": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-agent-presets": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-permission-presets": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session-title": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-workspace": "^0.1.5-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-webhook-github": {
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-webhook-github/-/dsh-webhook-github-0.1.5-rc.1.tgz",
+      "integrity": "sha512-sroVKHjfsHAHnioMEmkSb7CJyJgFr44yISWv+d19SC2opcuo/1gcMqpbLMsbpxK1bODm2D9JR7W73TYJvF8ymA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-util-values": "^0.1.5-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "@octokit/webhooks": "^14.2.0"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-credentials": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-host-webserver": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-webhook": "^0.1.5-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-win32-process": {
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-win32-process/-/dsh-win32-process-0.1.5-rc.1.tgz",
+      "integrity": "sha512-bGRRprQhbSLqG4LjCJjAUyeVLCJibriNyR123xW50MhzX7Dvw6j8xG2saJ0HvQt8ak98RJYXeURVgD8HpDsgbA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "koffi": "^3.1.0"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-workflow": {
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-workflow/-/dsh-workflow-0.1.5-rc.1.tgz",
+      "integrity": "sha512-cIVts/XHHrrte0YRGixezFlLv0pVEsCzpqLvco24MCCFJrlpcJFkW44YTUJffUAYfpVq6O7MV6S4Y5f07sdsZA==",
+      "devOptional": true,
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-brand": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-workflow-worker-thread": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-workflow-worker-thread/-/dsh-workflow-worker-thread-0.1.1-rc.2.tgz",
-      "integrity": "sha512-DdMO6gn56wakPTetkLKwuuj7cI3y3ji6c0oR3ksFQLhkYwaYV1hZSxVU6HEiW3hl2so8C163ms8QBgDyIWZsXg==",
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-workflow-worker-thread/-/dsh-workflow-worker-thread-0.1.5-rc.1.tgz",
+      "integrity": "sha512-tXbav9wwZugtu1e09I4Y5gt8VyfmRlQPZkXYtOq+ltxwgZA0hJcaRV4UWpWCc0TSlSH155eAFS+yJnHQjBiuUQ==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
+        "@deepseek-ai/dsh-brand": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-util-values": "^0.1.5-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-brand": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-subagent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-workflow": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-subagent": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-workflow": "^0.1.5-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-workspace": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-workspace/-/dsh-workspace-0.1.1-rc.2.tgz",
-      "integrity": "sha512-jBUob4H5TZAiExq9YNVCglKAFmAKMtd1UbyqFfnZZ1Owm+3c3NbAXY947MHiD6NwCwFEW1y7FjrFj66UQvG90A==",
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-workspace/-/dsh-workspace-0.1.5-rc.1.tgz",
+      "integrity": "sha512-RR/PLSnpW9OrWJ0np1DlvIfi9nTA2a1rLqeOsko6tI2yW3p8F82ZkdE3wZ8DWMTBru12VMkY8SiDhXOxPyihfA==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
+        "@deepseek-ai/dsh-brand": "^0.1.5-rc.1",
         "zod": "^4.4.3"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-brand": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-persistence": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-storage": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-storage-domain": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session-persistence": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-storage": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-storage-domain": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.5-rc.1"
       }
     },
-    "node_modules/@deepseek-ai/node-addon-landlock-run": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/node-addon-landlock-run/-/node-addon-landlock-run-0.1.1.tgz",
-      "integrity": "sha512-aHGhlQJEutfobKM/4K59SERbT7RmQdD2oMKzD8Bne/Ps7TeT8AweCN+dpdfuxQhMNbFcJMymrgPnID0WYQ30Tw==",
+    "node_modules/@deepseek-ai/node-addon-system": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/node-addon-system/-/node-addon-system-0.1.2.tgz",
+      "integrity": "sha512-EFn8K+mXIXiw6s3rxX+cgp2hZTEAQdVIsURhrXnBxycSXvtQ1EQpsSVzoNKtKAQI0I0VqkEcVEjHzS/PeaGsvw==",
       "devOptional": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=20"
       },
       "optionalDependencies": {
-        "@deepseek-ai/node-addon-landlock-run-linux-arm64": "0.1.1",
-        "@deepseek-ai/node-addon-landlock-run-linux-x64": "0.1.1"
+        "@deepseek-ai/node-addon-system-darwin-arm64": "0.1.2",
+        "@deepseek-ai/node-addon-system-darwin-x64": "0.1.2",
+        "@deepseek-ai/node-addon-system-linux-arm64": "0.1.2",
+        "@deepseek-ai/node-addon-system-linux-x64": "0.1.2"
       }
     },
-    "node_modules/@deepseek-ai/node-addon-landlock-run-linux-arm64": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/node-addon-landlock-run-linux-arm64/-/node-addon-landlock-run-linux-arm64-0.1.1.tgz",
-      "integrity": "sha512-lYY2RbcPW4rGRM5hVJbrXlvLqyBxeJBjBqvt+QTHTU+GtfUVVjTODKa4e3CRwMQoCEpOjoARdQBHbN7HvE72WQ==",
+    "node_modules/@deepseek-ai/node-addon-system-darwin-arm64": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/node-addon-system-darwin-arm64/-/node-addon-system-darwin-arm64-0.1.2.tgz",
+      "integrity": "sha512-IR0cx8um19mLCZaJ+H5PLblKr6Eg3PWvVo8eTQBr/SwH2nh5tM9CD9/5fHweNS9Pjt15UdFlGqnvLSd/w+O6Rw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@deepseek-ai/node-addon-system-darwin-x64": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/node-addon-system-darwin-x64/-/node-addon-system-darwin-x64-0.1.2.tgz",
+      "integrity": "sha512-XDbmquNapk9aT28y4EKn9lbONVr9YNs1NM/GKH1Gi5gUhjOT9wgRaTv72FJdNaVIInbPAYbPoyn7/y+MzQMNNg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@deepseek-ai/node-addon-system-linux-arm64": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/node-addon-system-linux-arm64/-/node-addon-system-linux-arm64-0.1.2.tgz",
+      "integrity": "sha512-Z/DQtqgEYzjBzb2ocHGjMzx51W7xDILkJKKj89nyErr8gZMNiLs+JNL1uKzJqc3VLZB+vYCPaHGyQ3oX6EzEmA==",
       "cpu": [
         "arm64"
       ],
@@ -4283,10 +4700,10 @@
         "node": ">=20"
       }
     },
-    "node_modules/@deepseek-ai/node-addon-landlock-run-linux-x64": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/node-addon-landlock-run-linux-x64/-/node-addon-landlock-run-linux-x64-0.1.1.tgz",
-      "integrity": "sha512-OHAzPW2Coe/iYobAJAAA8CeVrBoKV4BnNHsgwvXwOfishxkUVSWSvdyxrZPiwYRXutpIGVrSo9zV3WOQy2euBA==",
+    "node_modules/@deepseek-ai/node-addon-system-linux-x64": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/node-addon-system-linux-x64/-/node-addon-system-linux-x64-0.1.2.tgz",
+      "integrity": "sha512-S2aPVHvYCpNCppCFyNlooMYuTB7ucK5lvD9oXQQ42v5Z2s5AoaiCdjz9r2l+ED2rI5oS1x0cUZmKjJH2dxV0pg==",
       "cpu": [
         "x64"
       ],
@@ -4300,34 +4717,33 @@
       }
     },
     "node_modules/@deepseek-ai/schemastery": {
-      "version": "3.18.1",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/schemastery/-/schemastery-3.18.1.tgz",
-      "integrity": "sha512-Qn0FCSwCQnpnj6SB31I6i2sIKgKWnkbJM8O0EU91Gv2UsYVvtZTl6IA0sCwk2e2MZf5S8w5hpq9QkeVvK9qwxg==",
+      "version": "3.18.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/schemastery/-/schemastery-3.18.2.tgz",
+      "integrity": "sha512-njDtZsznjYxok7KLLlHOPyuv2efdWVbSflAHgztSfbMsg+CVraEoRe2DjOCgClYv3ZCSm7WXoaUkbB/+RY7tWQ==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/cosmokit": "^1.8.2",
+        "@deepseek-ai/cosmokit": "^1.8.3",
         "@standard-schema/spec": "^1.1.0"
       }
     },
     "node_modules/@earendil-works/pi-ai": {
-      "version": "0.82.1",
-      "resolved": "https://registry.npmmirror.com/@earendil-works/pi-ai/-/pi-ai-0.82.1.tgz",
-      "integrity": "sha512-3WFYRhEp3lQB3444EhPMBcM7zSaEUE3eJgHOR7s4081NLqbw/FsWilIKWXSua0Gv3sRr7m9xMidR3pPDE7jI/A==",
+      "version": "0.85.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.85.1.tgz",
+      "integrity": "sha512-+VgVIJDkDO2efYJKEEqvPTH4zmnIaXdAppGbO+vKFA9qy5PdhFiAenuFAkU+oiCSfOC4dMHDyrjdQeL4ZoC5CQ==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "@anthropic-ai/sdk": "0.91.1",
+        "@anthropic-ai/sdk": "0.123.0",
         "@aws-sdk/client-bedrock-runtime": "3.1048.0",
+        "@earendil-works/pi-telemetry": "^0.85.1",
         "@google/genai": "1.52.0",
-        "@mistralai/mistralai": "2.2.6",
-        "@opentelemetry/api": "1.9.0",
         "@smithy/node-http-handler": "4.7.3",
         "http-proxy-agent": "7.0.2",
         "https-proxy-agent": "7.0.6",
-        "openai": "6.26.0",
+        "openai": "6.40.0",
         "partial-json": "0.1.7",
-        "typebox": "1.1.38"
+        "typebox": "1.3.7"
       },
       "bin": {
         "pi-ai": "dist/cli.js"
@@ -4336,19 +4752,19 @@
         "node": ">=22.19.0"
       }
     },
-    "node_modules/@earendil-works/pi-ai/node_modules/@opentelemetry/api": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmmirror.com/@opentelemetry/api/-/api-1.9.0.tgz",
-      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+    "node_modules/@earendil-works/pi-telemetry": {
+      "version": "0.85.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-telemetry/-/pi-telemetry-0.85.1.tgz",
+      "integrity": "sha512-Bg/YN6kA7Swja/NQxka8xFdecb4E/auIEGF2G5A25EaQXhRnPj300/7/KpgsDDMYUzHTDAv4RyUxaQPJKW81Rw==",
       "devOptional": true,
-      "license": "Apache-2.0",
+      "license": "MIT",
       "engines": {
-        "node": ">=8.0.0"
+        "node": ">=22.19.0"
       }
     },
     "node_modules/@emnapi/runtime": {
       "version": "1.11.3",
-      "resolved": "https://registry.npmmirror.com/@emnapi/runtime/-/runtime-1.11.3.tgz",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
       "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
       "license": "MIT",
       "optional": true,
@@ -4358,7 +4774,7 @@
     },
     "node_modules/@google/genai": {
       "version": "1.52.0",
-      "resolved": "https://registry.npmmirror.com/@google/genai/-/genai-1.52.0.tgz",
+      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.52.0.tgz",
       "integrity": "sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q==",
       "devOptional": true,
       "hasInstallScript": true,
@@ -4383,7 +4799,7 @@
     },
     "node_modules/@hono/node-server": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmmirror.com/@hono/node-server/-/node-server-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.1.1.tgz",
       "integrity": "sha512-ELuehkj5VCBdgEw9zs+ivkKwyzzUCSQuE96YmiPvn1ECBoZCczbFXJLeEGMTYjphP6gydh4pHMqEYPVMYUVgQg==",
       "devOptional": true,
       "license": "MIT",
@@ -4396,7 +4812,7 @@
     },
     "node_modules/@img/colour": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmmirror.com/@img/colour/-/colour-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
       "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
       "devOptional": true,
       "license": "MIT",
@@ -4405,9 +4821,9 @@
       }
     },
     "node_modules/@img/sharp-darwin-arm64": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmmirror.com/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.3.tgz",
-      "integrity": "sha512-RMnFX7YQsMoh7lWfcM4NEHHymBX/rLuKNPVM84XE9ONPcaSCDgE7CHIHpSgPcO2xcRthgBy1HfNO319mwhIAkg==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.4.tgz",
+      "integrity": "sha512-Uhfl4V4lhP2nbUVF9+hyH1+luj86f1gUFeo8ALYxFoULoU+G87D43BfeMP8XHsk9boxAnCY/bf2EHwhA7MuGsA==",
       "cpu": [
         "arm64"
       ],
@@ -4423,13 +4839,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-arm64": "1.3.2"
+        "@img/sharp-libvips-darwin-arm64": "1.3.3"
       }
     },
     "node_modules/@img/sharp-darwin-x64": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmmirror.com/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.3.tgz",
-      "integrity": "sha512-Xo+5uFBtLN0BKqieTxiFzFPQAUlBbbH5iBKyRX/z1JrbnYsHTfKJnUfL8+p2TPXr1pXqao4eeL4Rl144uDpK9w==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.4.tgz",
+      "integrity": "sha512-hWniXY3bG5qKpkKrAwPe4y+VTPmf086YQAnkxWh7uA1YrlRouWGa0M0Mxj3ZjnXFkv7/TD1bTy9lGUK26vRvWw==",
       "cpu": [
         "x64"
       ],
@@ -4445,20 +4861,20 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-x64": "1.3.2"
+        "@img/sharp-libvips-darwin-x64": "1.3.3"
       }
     },
     "node_modules/@img/sharp-freebsd-wasm32": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmmirror.com/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.3.tgz",
-      "integrity": "sha512-lUxcqWIj2wMQ9BrwNjngcr1gWUr5xgaGThBRqPPalIC2n67Cqj1uPh8NnA/ZhAg8hUbKl+kVHKwgUIwe6ZYPrg==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.4.tgz",
+      "integrity": "sha512-lIsKw/BU+kjB4eZjxrYrZmwOJYi3Ajrv66iAlBmUPyKc3HpnloevB1g3wxGD9P/5BbQ1brBGl65VRRrCvQDEqA==",
       "license": "Apache-2.0",
       "optional": true,
       "os": [
         "freebsd"
       ],
       "dependencies": {
-        "@img/sharp-wasm32": "0.35.3"
+        "@img/sharp-wasm32": "0.35.4"
       },
       "engines": {
         "node": ">=20.9.0"
@@ -4468,9 +4884,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-darwin-arm64": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmmirror.com/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.2.tgz",
-      "integrity": "sha512-9J6ypZFpQBj4YnePGoq/S38w6nz+vqg5WZLrLGY4YuSemdMq47GMLBPO42MzwdGwpg/agZ7xzZcFHa48xlywfg==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.3.tgz",
+      "integrity": "sha512-suTBPTDGrI9WodccaDdwZItTSaBYASlBk1NSfElSHrUfzu3szG6lvIF58+WiFvnfzuK8ZBFS5zE00PxqxnRiPg==",
       "cpu": [
         "arm64"
       ],
@@ -4484,9 +4900,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-darwin-x64": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmmirror.com/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.2.tgz",
-      "integrity": "sha512-m2pW1n6cns9VaubNwsZ+c3CRYjxNQWgJ5gPlnL1nbBcpkBvFm6SCFN5o0psFHI8w9n11NKhFkeEDns98tiqbEw==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.3.tgz",
+      "integrity": "sha512-FVJZ5mITMobmXIz/hPDTw0EintTW5H3WfrxwLqEqjiIihlu+hVRyGrFQ60xl0Lxn7Bt3zdpevPaQi0HEzqz9fw==",
       "cpu": [
         "x64"
       ],
@@ -4500,9 +4916,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmmirror.com/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.2.tgz",
-      "integrity": "sha512-1eMLzy92I4J6rmi4mAT8yC3HxOtniyGELlzGbNMLLeqe052ahFQ0h6LFq+lh5DsDIdYViIDst08abvSbcEdLXQ==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.3.tgz",
+      "integrity": "sha512-3rbU4vqXXc3hY/OiXdl52xZvT0F1yEngWfvqudtPJg/KkyiaQw2DRsFrNzpmLvfavbwOq3qXn36GP8obHRULQA==",
       "cpu": [
         "arm"
       ],
@@ -4519,9 +4935,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm64": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmmirror.com/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.2.tgz",
-      "integrity": "sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.3.tgz",
+      "integrity": "sha512-0DaL0A6Xu6sQSQFwe4iVCrKWU2cCTItnRsYsCdxAMm9NF6twAA9BKnoqy4hqz4+azQ0JHuA26qiUKsf1XJ/v5A==",
       "cpu": [
         "arm64"
       ],
@@ -4538,9 +4954,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-ppc64": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmmirror.com/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.2.tgz",
-      "integrity": "sha512-3z0NHDxD6n5I9gc05U1eW1AyRm+Gznzq3naMrthPNqE6oYykcogW0l/jfpJdjYnuNl8R7yI9pNbE1XiUeyq0Aw==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.3.tgz",
+      "integrity": "sha512-cdn1OvUBwsXhbC0zSzJnNzf5MZ/mTrobawDvNXBTxe8VtqKAm0sRuEY2Evzovb/w9JMk4TvRxqt1mekSuJz64w==",
       "cpu": [
         "ppc64"
       ],
@@ -4557,9 +4973,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-riscv64": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmmirror.com/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.2.tgz",
-      "integrity": "sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.3.tgz",
+      "integrity": "sha512-HjPVx7yKz+0lqdhDlTw1tt90wamBoxhiXpvl1XZpJLiHH4RCJ5yDTqH+VlYPv2fwFs89JFw4c1IexYOcQUi4IQ==",
       "cpu": [
         "riscv64"
       ],
@@ -4576,9 +4992,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-s390x": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmmirror.com/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.2.tgz",
-      "integrity": "sha512-/ABshyj8gCpyIrNXnHn4LorDJ0HHm1VhXPBlxZ8zAtfVPAaSafXPGn+sUSIRiwaSBy0mmFjSjiXI5mkcwdChKQ==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.3.tgz",
+      "integrity": "sha512-neWLh+3yCNThxnfy3c4BbVBeGgt9aftno+XbT56iK28RgeDs3UOFWviLWlUu0bArYVYJaFDK+RRohbicUNCm8Q==",
       "cpu": [
         "s390x"
       ],
@@ -4595,9 +5011,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-x64": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmmirror.com/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.2.tgz",
-      "integrity": "sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.3.tgz",
+      "integrity": "sha512-4vKmvAst9nrowcqquKFAyZJUDolUaIp8uRiN0mWFguJ1IplC9/pitXtlnnlU4aa/eJw3J7i67V+pwUL+wZGdsA==",
       "cpu": [
         "x64"
       ],
@@ -4614,9 +5030,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmmirror.com/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.2.tgz",
-      "integrity": "sha512-zE9EdiUzUmg5mDT5a1rk5fYJ6GWPloTwWBYDS14naqHsL+EaMpDj1AWnpLgh3u0YCORv2Tt50wrcrpYqkP97Kw==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.3.tgz",
+      "integrity": "sha512-Y9kQaLMuNoB0bPYOOdcZMaseNrFpPodIWWMrx+CZyydf2xn68j9WYc6sWWRrDwNkzCQjKYfc68L7jKjGlHMibw==",
       "cpu": [
         "arm64"
       ],
@@ -4633,9 +5049,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-x64": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmmirror.com/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.2.tgz",
-      "integrity": "sha512-m0lrLiUt+lBYnCFr8qV/65yMR4E/c7/wf78I5eKTdkEakFAlZ9QlzEM3QIhhAwVeUhLAHLcCq7a7Vszq/oFNZQ==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.3.tgz",
+      "integrity": "sha512-fj8Mv0HHfD1Rr+4I68+3agJynxDWtBFgicTbSOb9Bke6pIwzGcJ+RX/yHjmiEGFMCavY/dxvem7MyNaJF+wDiw==",
       "cpu": [
         "x64"
       ],
@@ -4652,9 +5068,9 @@
       }
     },
     "node_modules/@img/sharp-linux-arm": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmmirror.com/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.3.tgz",
-      "integrity": "sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.4.tgz",
+      "integrity": "sha512-7OAS8gI0EReKGVN2HssHlM6umJgxF5VI3xN0p9FA91p/YO+ou5hiNghLdZ5BEHztwaaK5+bLKRf8x/o2L2nk9A==",
       "cpu": [
         "arm"
       ],
@@ -4673,13 +5089,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm": "1.3.2"
+        "@img/sharp-libvips-linux-arm": "1.3.3"
       }
     },
     "node_modules/@img/sharp-linux-arm64": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmmirror.com/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.3.tgz",
-      "integrity": "sha512-QgKDspHPnrU+GQ55XPhGwyhC8acLVOOSyAvo1oVfFmrIXLkDNmGWzAfDZ4xK8oSA1qBQrALcHX0G5UZni/SuFQ==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.4.tgz",
+      "integrity": "sha512-De4jpEnAU8Hd5oT0j1G3uL4ZvTuipVMn7YC6vPaJhy6/7EwEae0SVAoBrUMYQbkLGDm85taVWwuPc1a44LTzCQ==",
       "cpu": [
         "arm64"
       ],
@@ -4698,13 +5114,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm64": "1.3.2"
+        "@img/sharp-libvips-linux-arm64": "1.3.3"
       }
     },
     "node_modules/@img/sharp-linux-ppc64": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmmirror.com/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.3.tgz",
-      "integrity": "sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.4.tgz",
+      "integrity": "sha512-2oYZJeIl4kCcMGk4ouZVjnkCtFrpQFlNEtJ6GbxzhHQchwH0NH/qEb9ykmOl29dqwMq+JhFdZn+1ak2FKhI9fQ==",
       "cpu": [
         "ppc64"
       ],
@@ -4723,13 +5139,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-ppc64": "1.3.2"
+        "@img/sharp-libvips-linux-ppc64": "1.3.3"
       }
     },
     "node_modules/@img/sharp-linux-riscv64": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmmirror.com/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.3.tgz",
-      "integrity": "sha512-0Eob78yjlYPfL5vMNWAW55l3R9Y6BQS/gOfe0ZcP9mEz9ohhKSt4im1hayiknXgf8AWrFqMvJcKIdmLmEe7yeQ==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.4.tgz",
+      "integrity": "sha512-cPbNChoRURAWdebDIHSenxRpgEdy7JkPydSnUxRm9VvKD7m0/xVaR/8Fzlu81pk5nHEvHH87UZUA7cTtwnbJSA==",
       "cpu": [
         "riscv64"
       ],
@@ -4748,13 +5164,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-riscv64": "1.3.2"
+        "@img/sharp-libvips-linux-riscv64": "1.3.3"
       }
     },
     "node_modules/@img/sharp-linux-s390x": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmmirror.com/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.3.tgz",
-      "integrity": "sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.4.tgz",
+      "integrity": "sha512-RY0JFY8Fd6RonCBtHz+DvadaPkXDSI1AUn6yWL9TipqkZ1vY8w8evqdgyDFnkm4/K1ve1TvZiaePP5oSd4+WVQ==",
       "cpu": [
         "s390x"
       ],
@@ -4773,13 +5189,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-s390x": "1.3.2"
+        "@img/sharp-libvips-linux-s390x": "1.3.3"
       }
     },
     "node_modules/@img/sharp-linux-x64": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmmirror.com/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.3.tgz",
-      "integrity": "sha512-8pqvxubL2PGdhlPy6GLqzDYMUjyRmKAwKHYKixpdJYBUK7PJ0C029XdsnpFIdgRZG68fZiGdHVWcKPvtiPB4cA==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.4.tgz",
+      "integrity": "sha512-9qvvEAuk8k89TfWUoX2htWjbAMX8p+NxCppjpcg5k6xMsjhBQPTsoIh36h9Qde4WRuGpJeYnOjdosDn/cnv+OA==",
       "cpu": [
         "x64"
       ],
@@ -4798,13 +5214,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-x64": "1.3.2"
+        "@img/sharp-libvips-linux-x64": "1.3.3"
       }
     },
     "node_modules/@img/sharp-linuxmusl-arm64": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmmirror.com/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.3.tgz",
-      "integrity": "sha512-Vz0iQjzzcSX3HCbfwFfCSG/9SCIqyO0mH2sXyiHaAYfBk0cRsCWXRyQYX0ovCK/PAQBbTzQ0dsPQHh5MAFL59w==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.4.tgz",
+      "integrity": "sha512-KB5jxpfWQTr0nc3xdHtWChdbifHrBGsd2SM62Eyxrl8afikm+f5qGBU75SJIZBT/S1MC8XyacdlXBMSWq6OURA==",
       "cpu": [
         "arm64"
       ],
@@ -4823,13 +5239,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-arm64": "1.3.2"
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.3"
       }
     },
     "node_modules/@img/sharp-linuxmusl-x64": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmmirror.com/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.3.tgz",
-      "integrity": "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.4.tgz",
+      "integrity": "sha512-f+eZJZIQNEEd26RPSW+76chwOf1XtA2Y/O+5ocVyLliHkeih3e+jhLVBdNTd2rS3IbNXK8+ug93Vf5ZXtF5Lxg==",
       "cpu": [
         "x64"
       ],
@@ -4848,17 +5264,17 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-x64": "1.3.2"
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.3"
       }
     },
     "node_modules/@img/sharp-wasm32": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmmirror.com/@img/sharp-wasm32/-/sharp-wasm32-0.35.3.tgz",
-      "integrity": "sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.4.tgz",
+      "integrity": "sha512-zQnl4Kwp7Q6NHsENtU2T/00Zi+w3AQNwz3+UaTyVBy2FpXrzXzGjndpK61onhZjRtRpQXxCTeqw19bVyXOh7jA==",
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/runtime": "^1.11.1"
+        "@emnapi/runtime": "^1.11.3"
       },
       "engines": {
         "node": ">=20.9.0"
@@ -4868,16 +5284,16 @@
       }
     },
     "node_modules/@img/sharp-webcontainers-wasm32": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmmirror.com/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.3.tgz",
-      "integrity": "sha512-2rnq7bX3NzeR2T4YWgz8qiG4h3TSdMe+vN1iQXpJleSJ3SM5zQ8Fy2SyyXAWlbxpEZ2Y+Z4u1BePgJEYbSy80Q==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.4.tgz",
+      "integrity": "sha512-ESfNkywmCfPNyaZjxooddJQiQ+l/nTpGEOGthxiLnIHXC/CmcBixnfwUleX9mCz9ovrUUvKMap/pm8RYbzfwaA==",
       "cpu": [
         "wasm32"
       ],
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
-        "@img/sharp-wasm32": "0.35.3"
+        "@img/sharp-wasm32": "0.35.4"
       },
       "engines": {
         "node": ">=20.9.0"
@@ -4887,9 +5303,9 @@
       }
     },
     "node_modules/@img/sharp-win32-arm64": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmmirror.com/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.3.tgz",
-      "integrity": "sha512-4bPwFdMbeC4JQ8L8LOyWp6nsHcboP5fxkp6iPOXz2Vg49R42TuMs2whkJ5OAP4/Ul035qOzy0AecOF9VOscn4w==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.4.tgz",
+      "integrity": "sha512-iNdlBX9gLVvqe2I3uIJSIKTq6wckP/DYxZtcqxm09x5Gi24DnFBmPAWZmr60ZyYMG0xlzo6goG3670ar+RXvRw==",
       "cpu": [
         "arm64"
       ],
@@ -4906,9 +5322,9 @@
       }
     },
     "node_modules/@img/sharp-win32-ia32": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmmirror.com/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.3.tgz",
-      "integrity": "sha512-r53mXsBN6lFUDiST764SvgwUdHAqM4rPAiDzAmf4fLoB6X/rkfyTrLCg6+g17wJJiCmB3JYgHuUldCWUIRFSXw==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.4.tgz",
+      "integrity": "sha512-kqRsbaa5CS6KHlpxnN7WhE6vAAugXyZButpRdvDWetlv6Qv4N9WTcrWzF7tXfB9T7MsoadqdI8hmwLq6UlLvtw==",
       "cpu": [
         "ia32"
       ],
@@ -4925,9 +5341,9 @@
       }
     },
     "node_modules/@img/sharp-win32-x64": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmmirror.com/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.3.tgz",
-      "integrity": "sha512-D4y1vNeZrIIJCN+uHaWVtH86B+aCrdMYYjicy9pXHvbGZeGYLLSd3wdVuC37FxVXlU1ARsk84eKWfWMXGYEqvA==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.4.tgz",
+      "integrity": "sha512-XtmnYhBcrORsJ4XJngyzr/EWP0hRZLAZRFaApdKuviyqF78+ylxh2y06ZmtULAMOnObJ3ucpN0AcwSWnMowTRg==",
       "cpu": [
         "x64"
       ],
@@ -4956,16 +5372,48 @@
       }
     },
     "node_modules/@joplin/turndown-plugin-gfm": {
-      "version": "1.0.67",
-      "resolved": "https://registry.npmmirror.com/@joplin/turndown-plugin-gfm/-/turndown-plugin-gfm-1.0.67.tgz",
-      "integrity": "sha512-FZfW5EZfidhzd1IaY1uxHnIZPTVOxAdleMZ4/1U6Nt5b7+Qj5JThDnaIomuJtetnUBzuRNbe9FWMuqD4B3dlWA==",
+      "version": "1.0.68",
+      "resolved": "https://registry.npmjs.org/@joplin/turndown-plugin-gfm/-/turndown-plugin-gfm-1.0.68.tgz",
+      "integrity": "sha512-m8DfAQNC/V7g0j5H6Jv60WhekBBjodD+zTPGrU+g2m+ux/z8ZX07KQIl6kaAmbKwfvsQhC04op52g63I78sVgg==",
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/@koromix/koffi-android-arm64": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-android-arm64/-/koffi-android-arm64-3.2.1.tgz",
+      "integrity": "sha512-1pJQ4jnZlUJduK9u9DC5CGy3aOgDUPvIXpNb6syV3+Dh5Q/ugezAIGCqvY+w+1mgXsve0pd0NVvJRjdZNHQ6MA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-android-x64": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-android-x64/-/koffi-android-x64-3.2.1.tgz",
+      "integrity": "sha512-HH40xGh3gVQifjOBnhwT2tECC0lL1lYe+nxHvWNSzxDIyQNcVPXg38ta7vuONRFpD+uIrw7fqGYLzbZIagkVcg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
     "node_modules/@koromix/koffi-darwin-arm64": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmmirror.com/@koromix/koffi-darwin-arm64/-/koffi-darwin-arm64-3.1.6.tgz",
-      "integrity": "sha512-8FHyXGCZN7/iQf4f7W5BRysmtdlAFvSx6FpmX4u6wmkZiX/2e9hIRdGLiZYlHGudlcA18UmXB/cMiyhJ7fJkzA==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-darwin-arm64/-/koffi-darwin-arm64-3.2.1.tgz",
+      "integrity": "sha512-Vj4h+xcjc5+Cn0DhPHjgRX4omKAv96Kehtcd+1YgYuY2W7FvQn9vS+3SmzVwhC5Qmg9bIwUZObYQ8T/4hBqQqA==",
       "cpu": [
         "arm64"
       ],
@@ -4979,9 +5427,9 @@
       }
     },
     "node_modules/@koromix/koffi-darwin-x64": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmmirror.com/@koromix/koffi-darwin-x64/-/koffi-darwin-x64-3.1.6.tgz",
-      "integrity": "sha512-uzx/jqFQuSHqgg1zaRidTBTCfj8Y9M0SDTO8HeoI9s9fJhiJ1mbB9TTwJO5c2hiMnuWg2m1byczC8BaIH6cG/w==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-darwin-x64/-/koffi-darwin-x64-3.2.1.tgz",
+      "integrity": "sha512-gFCWxNBTZIvxo1p+PURWfsy2Ctj5FGnVVs1f03lTLhBvmxEto70pdIiFztdFLDFkAJ1pmtQmruRKapeK+E8YPA==",
       "cpu": [
         "x64"
       ],
@@ -4995,9 +5443,9 @@
       }
     },
     "node_modules/@koromix/koffi-freebsd-arm64": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmmirror.com/@koromix/koffi-freebsd-arm64/-/koffi-freebsd-arm64-3.1.6.tgz",
-      "integrity": "sha512-PjpTVrsCK5YTtixOw7VsseYXJOyoY6k0qBt+bf0T9h3wyV06y73rALsorFDDEoYpLUBZO7R6EIMs6CpUrEkNTQ==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-freebsd-arm64/-/koffi-freebsd-arm64-3.2.1.tgz",
+      "integrity": "sha512-qj+f1s2e6vULaUG1cdlTcCXmunCq2t+rjxku1+esaMIqVnHpOwj0QzPuInG0AFdXjwBNQhyVR/HpDj8daEwwsQ==",
       "cpu": [
         "arm64"
       ],
@@ -5011,9 +5459,9 @@
       }
     },
     "node_modules/@koromix/koffi-freebsd-ia32": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmmirror.com/@koromix/koffi-freebsd-ia32/-/koffi-freebsd-ia32-3.1.6.tgz",
-      "integrity": "sha512-ETYwL820HtFwYoOVzgyvmFmzTHRo9DJtGYTxa5Nb7ajaa5ldCum0jbmUJ3PMECxFTLxD5Q6PYZ8Xbp101bGeSg==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-freebsd-ia32/-/koffi-freebsd-ia32-3.2.1.tgz",
+      "integrity": "sha512-6olHb1Qfgai0jjs6ddlDDD0ZfsCxy7SPi8rMRpuYQWH0qhgtyQu82hw5b1p7z+TJ0zZP3ZeQQ6l+U/MlM1ICHQ==",
       "cpu": [
         "ia32"
       ],
@@ -5027,9 +5475,9 @@
       }
     },
     "node_modules/@koromix/koffi-freebsd-x64": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmmirror.com/@koromix/koffi-freebsd-x64/-/koffi-freebsd-x64-3.1.6.tgz",
-      "integrity": "sha512-BkqxkNXhAAT9toU2stvLwx1iKHPDx7h08NCICyBbjYEXkCAEr84igTkpE5V3XJ9xZZ2gKll7VvdhxorHtHUqZw==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-freebsd-x64/-/koffi-freebsd-x64-3.2.1.tgz",
+      "integrity": "sha512-Dikhw1ySYNVMkmeFvFVjnU5Wdk6mffNoOjJxm9bTG96vg7OlemylxqdEven47R1YJ3yzNVJn/MlQ207ORWfi2w==",
       "cpu": [
         "x64"
       ],
@@ -5042,10 +5490,26 @@
         "url": "https://liberapay.com/Koromix"
       }
     },
+    "node_modules/@koromix/koffi-linux-arm": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-linux-arm/-/koffi-linux-arm-3.2.1.tgz",
+      "integrity": "sha512-OfwUwZylidq95wQKp6ClInULrfB2giu7dqM6Rhe0zAe6lES5I2SXNw15T9+GnRHk3/9hKT2XZ37OZLaKSyWNLA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
     "node_modules/@koromix/koffi-linux-arm64": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmmirror.com/@koromix/koffi-linux-arm64/-/koffi-linux-arm64-3.1.6.tgz",
-      "integrity": "sha512-cM4XPm9ljbCrcPgXjzFYjDNxDUvvuR7TCYaEoo1AKjwZT/vmWhu2xN3pomfbsHh6aVn80SFA3enufQnaETW1rQ==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-linux-arm64/-/koffi-linux-arm64-3.2.1.tgz",
+      "integrity": "sha512-K+cGUL5iBcDqxmsocrjmlASqDf24gc7artbVW3PewG2c9AqwC63lezgwvB85Nx4lZAQjB6zIFHh9A7t1yGbwhw==",
       "cpu": [
         "arm64"
       ],
@@ -5059,9 +5523,9 @@
       }
     },
     "node_modules/@koromix/koffi-linux-ia32": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmmirror.com/@koromix/koffi-linux-ia32/-/koffi-linux-ia32-3.1.6.tgz",
-      "integrity": "sha512-l1SVTpO10iaQt8slbowJpzK4fbwQZ7ufj9tmCyAcIwWUpyAbPS83mJMctU72If6N9/gCS2wuRqwnYB2uPLLhLg==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-linux-ia32/-/koffi-linux-ia32-3.2.1.tgz",
+      "integrity": "sha512-rxj6UYjU1qd98gxNQOSCdLpc5cPRi5Giq9rNd3jnGuSNIyMkwa6Dxw4cUjmhIBCYESMJtmNt5NWnJp5u9wTfYQ==",
       "cpu": [
         "ia32"
       ],
@@ -5075,9 +5539,9 @@
       }
     },
     "node_modules/@koromix/koffi-linux-loong64": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmmirror.com/@koromix/koffi-linux-loong64/-/koffi-linux-loong64-3.1.6.tgz",
-      "integrity": "sha512-KpTJpMSbIdCVFU26ynt0xy4x15h+y6AwPJxj2+iVxJhCzJf4oisCPc0YH2VnutuLV2nVzSrFm7sL/WSOqPgkXw==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-linux-loong64/-/koffi-linux-loong64-3.2.1.tgz",
+      "integrity": "sha512-aHhnHzkPRmT/IHDlGvESJ/Bs32m8N6UE6Ab6kMeJzgk74IN8af2m/81/wZJtybR1M2UxCV4NmlVNUYQQvSAO3Q==",
       "cpu": [
         "loong64"
       ],
@@ -5091,9 +5555,9 @@
       }
     },
     "node_modules/@koromix/koffi-linux-riscv64": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmmirror.com/@koromix/koffi-linux-riscv64/-/koffi-linux-riscv64-3.1.6.tgz",
-      "integrity": "sha512-YdFNpsywnXiYOYQlDAatf7TJLnspbGXdmfwIZhf82kbKSflYUsq4tI6NmoUOzM89oIWDGpYqd4Hz3xL7tsyXsw==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-linux-riscv64/-/koffi-linux-riscv64-3.2.1.tgz",
+      "integrity": "sha512-qtQBsjbm3LiirLJvajWmKkNb7ARk7fvJVXdftJ7NtAnF3Xw8EbDvrtvmvtNI1yLPlYcBmlzCCD71hwhWYk0SIA==",
       "cpu": [
         "riscv64"
       ],
@@ -5107,9 +5571,9 @@
       }
     },
     "node_modules/@koromix/koffi-linux-x64": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmmirror.com/@koromix/koffi-linux-x64/-/koffi-linux-x64-3.1.6.tgz",
-      "integrity": "sha512-Xx5mpr9VcaMCXfvbqIiLIWIL9Iuu6F4r3iMXg7+zZCqYUFZPFwJgiDQBLxctHv2OYgIfAoaaHMW0GC1cJkHfbA==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-linux-x64/-/koffi-linux-x64-3.2.1.tgz",
+      "integrity": "sha512-c7hw7Qs/r5gnFRTQLcbifBwRU7wiocj+2pVuDQ5Ahb3r36SZmupmgYbTWcLvTW+hul1jd7SKRV0d14ZJq/tvSw==",
       "cpu": [
         "x64"
       ],
@@ -5123,9 +5587,9 @@
       }
     },
     "node_modules/@koromix/koffi-openbsd-ia32": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmmirror.com/@koromix/koffi-openbsd-ia32/-/koffi-openbsd-ia32-3.1.6.tgz",
-      "integrity": "sha512-39Np4QTxhTlTT6RRveIeP+TnbzrwuDJ0UMyHxEZ+oGtzmb9GqWhl9T1oyehG6v/O+c4BffafG2NwLkCZ7tDKWw==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-openbsd-ia32/-/koffi-openbsd-ia32-3.2.1.tgz",
+      "integrity": "sha512-mmY8fY8LQ/CB52+h3yrMYmVyoxzW3x08S0yI6VNfHWdfU6yJtZkKCbhjmQCYMrWbYKC4gMvwZwCywIGPAkLyeA==",
       "cpu": [
         "ia32"
       ],
@@ -5139,9 +5603,9 @@
       }
     },
     "node_modules/@koromix/koffi-openbsd-x64": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmmirror.com/@koromix/koffi-openbsd-x64/-/koffi-openbsd-x64-3.1.6.tgz",
-      "integrity": "sha512-3EynGn3ycQRqaMWGmUJ0tdtuQdStByqSy/tJ0ZGKWizbMGdFAE73YpgLsyd8BDvwnKWytVG/OLNb5nDHpfd9Dg==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-openbsd-x64/-/koffi-openbsd-x64-3.2.1.tgz",
+      "integrity": "sha512-k4ig6aAPbFSRATOIIOfdf/KtlOGH4SVls6L9fy0QnTxRJYvY2oSltTsQtBDANgEQldlq8Kl5WnpRa1VSibP4Lw==",
       "cpu": [
         "x64"
       ],
@@ -5155,9 +5619,9 @@
       }
     },
     "node_modules/@koromix/koffi-win32-arm64": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmmirror.com/@koromix/koffi-win32-arm64/-/koffi-win32-arm64-3.1.6.tgz",
-      "integrity": "sha512-27FdPPRtT4xbO9bsd2OZa95M5YQ7bcJ8QjCRO57UUMI21REfkDegjqKwqo/CFlugxXlJf5IYtG2rq4BEYIrvxg==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-win32-arm64/-/koffi-win32-arm64-3.2.1.tgz",
+      "integrity": "sha512-cTWBJGK//pDMeKQJE/79Aq9MiOAF4H8QyLZHSQ9IWm8czOfwjG4J1AhsQ9DjI9KFOykH77hhnpmQTGVMIubGig==",
       "cpu": [
         "arm64"
       ],
@@ -5171,9 +5635,9 @@
       }
     },
     "node_modules/@koromix/koffi-win32-ia32": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmmirror.com/@koromix/koffi-win32-ia32/-/koffi-win32-ia32-3.1.6.tgz",
-      "integrity": "sha512-5mVelLKVDup4eoxZOpCzCyMPxoctsg+Qe4J9O5BP4KbBEdqoOEqaNEBBRgNzXcdr2g+GGfmIUo+oVR1NvIdiJw==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-win32-ia32/-/koffi-win32-ia32-3.2.1.tgz",
+      "integrity": "sha512-Z50EM6TAZ7CFyMmyX6thv8eNpJchqe9eenhibSIy2Eq/FQYF76gU2VK/LEoaF46L8hfC7TpTp9b10MvReHEyFA==",
       "cpu": [
         "ia32"
       ],
@@ -5187,9 +5651,9 @@
       }
     },
     "node_modules/@koromix/koffi-win32-x64": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmmirror.com/@koromix/koffi-win32-x64/-/koffi-win32-x64-3.1.6.tgz",
-      "integrity": "sha512-lPKjAaHz0aoiZXT/wDVqH+joR5y3lCZj1s9Bk5qx/DGRq+0MK8Ib8VoqiBOrJ69NG5AsJSvn0tQDcSqfRgLmBQ==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-win32-x64/-/koffi-win32-x64-3.2.1.tgz",
+      "integrity": "sha512-ZmZNiBO6bkOSh3QNzgfvb1cMY0yMobn6ZQrSMqbAce21qyYL8niIbyipz9N/PIRDciGhsV0wUxnZsxIO+yWsHQ==",
       "cpu": [
         "x64"
       ],
@@ -5202,37 +5666,16 @@
         "url": "https://liberapay.com/Koromix"
       }
     },
-    "node_modules/@mistralai/mistralai": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmmirror.com/@mistralai/mistralai/-/mistralai-2.2.6.tgz",
-      "integrity": "sha512-W8pX7zHxjJvMIpw8JMxeJEleapXX0Q9NPszdNzqkM3MIEoIGPObdodujj+WHteXEvGfaP/AMwlNyRfEzSY6dQQ==",
-      "devOptional": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "^1.40.0",
-        "ws": "^8.18.0",
-        "zod": "^3.25.0 || ^4.0.0",
-        "zod-to-json-schema": "^3.25.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.9.0"
-      },
-      "peerDependenciesMeta": {
-        "@opentelemetry/api": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@mixmark-io/domino": {
       "version": "2.2.0",
-      "resolved": "https://registry.npmmirror.com/@mixmark-io/domino/-/domino-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@mixmark-io/domino/-/domino-2.2.0.tgz",
       "integrity": "sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw==",
       "devOptional": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.30.0",
-      "resolved": "https://registry.npmmirror.com/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
       "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
       "devOptional": true,
       "license": "MIT",
@@ -5271,10 +5714,72 @@
         }
       }
     },
+    "node_modules/@octokit/openapi-types": {
+      "version": "29.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-29.0.1.tgz",
+      "integrity": "sha512-9qWOMFNxxLokERcms42rU0PTLqQmVs7g5E41TI4mCOxmpFayD1rfC7XxOL55cG9MBZLFlC31BrR37myMKardwg==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/@octokit/openapi-webhooks-types": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-webhooks-types/-/openapi-webhooks-types-12.1.0.tgz",
+      "integrity": "sha512-WiuzhOsiOvb7W3Pvmhf8d2C6qaLHXrWiLBP4nJ/4kydu+wpagV5Fkz9RfQwV2afYzv3PB+3xYgp4mAdNGjDprA==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/@octokit/request-error": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-7.1.2.tgz",
+      "integrity": "sha512-XZRuT3xZ84D3gYErI1DZvhJ33dCWVV6uzBtWkaBB4TvA/L6eOeTZodxLFVB44bBEEo3vEx7y00UfX1tBLrtLRg==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^18.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/types": {
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-18.0.0.tgz",
+      "integrity": "sha512-l6bAF43PNxkJp6g+W4PjoUSSkxHomXw2nOum5CTftJz1NlV3vu93NImgOYtLf6CbBUb5j+fiuzW0PPQ5JTSvZA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^29.0.1"
+      }
+    },
+    "node_modules/@octokit/webhooks": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/webhooks/-/webhooks-14.2.0.tgz",
+      "integrity": "sha512-da6KbdNCV5sr1/txD896V+6W0iamFWrvVl8cHkBSPT+YlvmT3DwXa4jxZnQc+gnuTEqSWbBeoSZYTayXH9wXcw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-webhooks-types": "12.1.0",
+        "@octokit/request-error": "^7.0.0",
+        "@octokit/webhooks-methods": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/webhooks-methods": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/webhooks-methods/-/webhooks-methods-6.0.0.tgz",
+      "integrity": "sha512-MFlzzoDJVw/GcbfzVC1RLR36QqkTLUf79vLVO3D+xn7r0QgxnFoLZgtrzxiQErAjFUOdH6fas2KeQJ1yr/qaXQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
     "node_modules/@openma/deepseek-harness-acp": {
-      "version": "0.4.29",
-      "resolved": "https://registry.npmjs.org/@openma/deepseek-harness-acp/-/deepseek-harness-acp-0.4.29.tgz",
-      "integrity": "sha512-6FbEqyv5a/u9m0H0sV0keljI7PYUFsFmtBUaBmRXWbgzJc5K6VI/xhgyj/WBLUho1dsESM9ImPTAPTFLCdVi/w==",
+      "version": "0.4.31",
+      "resolved": "https://registry.npmjs.org/@openma/deepseek-harness-acp/-/deepseek-harness-acp-0.4.31.tgz",
+      "integrity": "sha512-6cebBQF5qztQMAqZtJtzM2WZTyUjzX029gz/AGuw0uVD7giCpiv/NBWxy3DOrqW8zBAC++bvZm5phXycVm/jsQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@agentclientprotocol/sdk": "1.4.0",
@@ -5298,7 +5803,7 @@
     },
     "node_modules/@opentelemetry/api": {
       "version": "1.9.1",
-      "resolved": "https://registry.npmmirror.com/@opentelemetry/api/-/api-1.9.1.tgz",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "devOptional": true,
       "license": "Apache-2.0",
@@ -5308,7 +5813,7 @@
     },
     "node_modules/@opentelemetry/api-logs": {
       "version": "0.220.0",
-      "resolved": "https://registry.npmmirror.com/@opentelemetry/api-logs/-/api-logs-0.220.0.tgz",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.220.0.tgz",
       "integrity": "sha512-CmVa4ImJ+ynfrPMNaAXHET6Bhb44SwzmfyVJFq9ni2jgXJR/l7C6gfVFddNmHP+ZOkP9cf4f9DBe68qVLTHc9w==",
       "devOptional": true,
       "license": "Apache-2.0",
@@ -5321,7 +5826,7 @@
     },
     "node_modules/@opentelemetry/core": {
       "version": "2.9.0",
-      "resolved": "https://registry.npmmirror.com/@opentelemetry/core/-/core-2.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.9.0.tgz",
       "integrity": "sha512-m2nckMT80NnmjTYSPjJQObBJ+8dgkoajEOUbznL8AHZ3T3yHRk2P7gI1PhEBc1+lOnrYE9UWrWHqJDsmqjmNbw==",
       "devOptional": true,
       "license": "Apache-2.0",
@@ -5337,7 +5842,7 @@
     },
     "node_modules/@opentelemetry/exporter-logs-otlp-http": {
       "version": "0.220.0",
-      "resolved": "https://registry.npmmirror.com/@opentelemetry/exporter-logs-otlp-http/-/exporter-logs-otlp-http-0.220.0.tgz",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-http/-/exporter-logs-otlp-http-0.220.0.tgz",
       "integrity": "sha512-8186thl+pTw64iz/qEEen5oJZoZ/gO73XruChdaGlYdWOdBIQ42r+vHLf6a7vIDqTD4b8ZOoMlyxptanECaI9A==",
       "devOptional": true,
       "license": "Apache-2.0",
@@ -5357,7 +5862,7 @@
     },
     "node_modules/@opentelemetry/otlp-exporter-base": {
       "version": "0.220.0",
-      "resolved": "https://registry.npmmirror.com/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.220.0.tgz",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.220.0.tgz",
       "integrity": "sha512-CXYo8UD5Mn9YbgebO2EL4wejtA+gxLmLiu6HCk2KH2BR7XhFN6/6p1UlCb23DYCjeYkndevLHuejCCN1yx4+OQ==",
       "devOptional": true,
       "license": "Apache-2.0",
@@ -5374,7 +5879,7 @@
     },
     "node_modules/@opentelemetry/otlp-transformer": {
       "version": "0.220.0",
-      "resolved": "https://registry.npmmirror.com/@opentelemetry/otlp-transformer/-/otlp-transformer-0.220.0.tgz",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.220.0.tgz",
       "integrity": "sha512-lXGrv7KXZ0gNH9SVNUaa6vv6phVYGvJxfXAlMbzbakiXru75f5MZl8Z7oqiMMQD77riVHJCFlQvbZs/VVN2/4A==",
       "devOptional": true,
       "license": "Apache-2.0",
@@ -5395,7 +5900,7 @@
     },
     "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/resources": {
       "version": "2.9.0",
-      "resolved": "https://registry.npmmirror.com/@opentelemetry/resources/-/resources-2.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.9.0.tgz",
       "integrity": "sha512-jyA5MBLQ+Dkl3+JsZkUoUvL7yHvU64kLsvpXKarWm6347Sl1t1bXFTFykUePNpT5WH5pm9a2Qtt03iIYQhZ1Fg==",
       "devOptional": true,
       "license": "Apache-2.0",
@@ -5411,13 +5916,13 @@
       }
     },
     "node_modules/@opentelemetry/resources": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmmirror.com/@opentelemetry/resources/-/resources-2.10.0.tgz",
-      "integrity": "sha512-q6MMm2zhggzsHVNbabYwut+a6nbuQQe3URUoxaojM/8K1IBfwwPzvxIjNi2/lI1TFe+fMHMW9MWhrtDLEXEnkA==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.11.0.tgz",
+      "integrity": "sha512-Ie7+8q8MDF4FAEQCKVMTx3ReUvxiIAgIiiW3c9JdmP8+HMcDy20puT+AHjexnExgnbvBxjQ9fjkFDWrikJ2jQA==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/core": "2.11.0",
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
       "engines": {
@@ -5428,9 +5933,9 @@
       }
     },
     "node_modules/@opentelemetry/resources/node_modules/@opentelemetry/core": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmmirror.com/@opentelemetry/core/-/core-2.10.0.tgz",
-      "integrity": "sha512-/wNZ8twnEQQA4HoHu22+vcsdru6pWPWxW+7w+FlxT6Id7PE/WIbZmVKkte+PF72e0F2dnImFeHD2syyE1Mw6MQ==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.11.0.tgz",
+      "integrity": "sha512-7YP44XH0tV6+Mb54x2YGf84i7yi+31MBZlE8JwvozkxyTvXbSp10X7cI7YE49ChJ3shMJoBmCJF3+1QFBJctGA==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -5445,7 +5950,7 @@
     },
     "node_modules/@opentelemetry/sdk-logs": {
       "version": "0.220.0",
-      "resolved": "https://registry.npmmirror.com/@opentelemetry/sdk-logs/-/sdk-logs-0.220.0.tgz",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.220.0.tgz",
       "integrity": "sha512-WywcTkQtv2iNmt+6y5Kcd4rzvx9bLVsBa2Nwcmg01IUaBTkTow3W4d9KE5vNBpEDtb9tp21WcRBY/lANRrApYA==",
       "devOptional": true,
       "license": "Apache-2.0",
@@ -5464,7 +5969,7 @@
     },
     "node_modules/@opentelemetry/sdk-logs/node_modules/@opentelemetry/resources": {
       "version": "2.9.0",
-      "resolved": "https://registry.npmmirror.com/@opentelemetry/resources/-/resources-2.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.9.0.tgz",
       "integrity": "sha512-jyA5MBLQ+Dkl3+JsZkUoUvL7yHvU64kLsvpXKarWm6347Sl1t1bXFTFykUePNpT5WH5pm9a2Qtt03iIYQhZ1Fg==",
       "devOptional": true,
       "license": "Apache-2.0",
@@ -5481,7 +5986,7 @@
     },
     "node_modules/@opentelemetry/sdk-metrics": {
       "version": "2.9.0",
-      "resolved": "https://registry.npmmirror.com/@opentelemetry/sdk-metrics/-/sdk-metrics-2.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.9.0.tgz",
       "integrity": "sha512-Xx8RGS4H5XEBl01WuCreMIpiah9cCXMbSkeuIePPdD2cUpq/vUzYmj8E/MK1OsbOc93FuAD4jfn2WOacKwLn7Q==",
       "devOptional": true,
       "license": "Apache-2.0",
@@ -5498,7 +6003,7 @@
     },
     "node_modules/@opentelemetry/sdk-metrics/node_modules/@opentelemetry/resources": {
       "version": "2.9.0",
-      "resolved": "https://registry.npmmirror.com/@opentelemetry/resources/-/resources-2.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.9.0.tgz",
       "integrity": "sha512-jyA5MBLQ+Dkl3+JsZkUoUvL7yHvU64kLsvpXKarWm6347Sl1t1bXFTFykUePNpT5WH5pm9a2Qtt03iIYQhZ1Fg==",
       "devOptional": true,
       "license": "Apache-2.0",
@@ -5515,7 +6020,7 @@
     },
     "node_modules/@opentelemetry/sdk-trace": {
       "version": "2.9.0",
-      "resolved": "https://registry.npmmirror.com/@opentelemetry/sdk-trace/-/sdk-trace-2.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace/-/sdk-trace-2.9.0.tgz",
       "integrity": "sha512-sGA19HvtrrSKYsseHphluH6j3p6Xa3fqc7c7y8f/7mYWejc1lyDFcpSdD1kYa50HCLUeEo4zA5bW0pniaPszuw==",
       "devOptional": true,
       "license": "Apache-2.0",
@@ -5533,7 +6038,7 @@
     },
     "node_modules/@opentelemetry/sdk-trace/node_modules/@opentelemetry/resources": {
       "version": "2.9.0",
-      "resolved": "https://registry.npmmirror.com/@opentelemetry/resources/-/resources-2.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.9.0.tgz",
       "integrity": "sha512-jyA5MBLQ+Dkl3+JsZkUoUvL7yHvU64kLsvpXKarWm6347Sl1t1bXFTFykUePNpT5WH5pm9a2Qtt03iIYQhZ1Fg==",
       "devOptional": true,
       "license": "Apache-2.0",
@@ -5550,7 +6055,7 @@
     },
     "node_modules/@opentelemetry/semantic-conventions": {
       "version": "1.43.0",
-      "resolved": "https://registry.npmmirror.com/@opentelemetry/semantic-conventions/-/semantic-conventions-1.43.0.tgz",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.43.0.tgz",
       "integrity": "sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==",
       "devOptional": true,
       "license": "Apache-2.0",
@@ -5560,35 +6065,35 @@
     },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmmirror.com/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
       "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
       "devOptional": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/base64": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmmirror.com/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
       "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
       "devOptional": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/codegen": {
       "version": "2.0.5",
-      "resolved": "https://registry.npmmirror.com/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
       "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
       "devOptional": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/eventemitter": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmmirror.com/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
       "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
       "devOptional": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/fetch": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmmirror.com/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
       "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
       "devOptional": true,
       "license": "BSD-3-Clause",
@@ -5598,35 +6103,35 @@
     },
     "node_modules/@protobufjs/float": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmmirror.com/@protobufjs/float/-/float-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
       "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
       "devOptional": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/path": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmmirror.com/@protobufjs/path/-/path-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
       "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
       "devOptional": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/pool": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmmirror.com/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
       "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
       "devOptional": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/utf8": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmmirror.com/@protobufjs/utf8/-/utf8-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.2.tgz",
       "integrity": "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==",
       "devOptional": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@smithy/core": {
       "version": "3.33.3",
-      "resolved": "https://registry.npmmirror.com/@smithy/core/-/core-3.33.3.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.33.3.tgz",
       "integrity": "sha512-CsOeKq/9kA3y6VJHt+/+VTCtBaxJ4OTFpgrjIUhPpDIKxBci1k2bJaQASF2h/ELWrulGp+t97DZ0mevfAD8idg==",
       "devOptional": true,
       "license": "Apache-2.0",
@@ -5640,7 +6145,7 @@
     },
     "node_modules/@smithy/credential-provider-imds": {
       "version": "4.5.2",
-      "resolved": "https://registry.npmmirror.com/@smithy/credential-provider-imds/-/credential-provider-imds-4.5.2.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.5.2.tgz",
       "integrity": "sha512-A9uSdn72ozbRUSit0eib0TW7nXuNPlaeM0zcGkJ+nE6tFcSDbnmtwoxbTCFBukVQcszDAyvsd7+rTduPTXpygg==",
       "devOptional": true,
       "license": "Apache-2.0",
@@ -5654,14 +6159,14 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmmirror.com/@smithy/fetch-http-handler/-/fetch-http-handler-5.7.2.tgz",
-      "integrity": "sha512-nZyWTmSpJEXl6VtWVMBJve/7x12DZu6sIX1z1a+ZMaHlQQRs9Zpu6NbTe/gmxYXVRpkjxyDYpZ5gx2IM6f/Wkw==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.8.0.tgz",
+      "integrity": "sha512-ycSJu3tFAQ4v04CBB0agqFMVsSQ1iG3yw+SpgxRqKfaURpQD4CZ8Wn0zPMmSnOuTpTh65Vz+EA0rMrw089wvkA==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.33.2",
-        "@smithy/types": "^4.17.2",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.18.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5670,7 +6175,7 @@
     },
     "node_modules/@smithy/is-array-buffer": {
       "version": "2.2.0",
-      "resolved": "https://registry.npmmirror.com/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
       "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
       "devOptional": true,
       "license": "Apache-2.0",
@@ -5683,7 +6188,7 @@
     },
     "node_modules/@smithy/node-http-handler": {
       "version": "4.7.3",
-      "resolved": "https://registry.npmmirror.com/@smithy/node-http-handler/-/node-http-handler-4.7.3.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.3.tgz",
       "integrity": "sha512-/jPhevcTFPMVl6KNjbaI47iOg1zxC7IsnX4PQDGVZKMFceOXtB8IEYaB7a9VvkP/3oC60WzTeKocvSI7vLT0vA==",
       "devOptional": true,
       "license": "Apache-2.0",
@@ -5698,7 +6203,7 @@
     },
     "node_modules/@smithy/signature-v4": {
       "version": "5.7.3",
-      "resolved": "https://registry.npmmirror.com/@smithy/signature-v4/-/signature-v4-5.7.3.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.7.3.tgz",
       "integrity": "sha512-7ImGm+FkHRLcBaRttIAMZ6bzJZWb2cJGoYjq46F2UjycujWzrL9GEN9h4w7eQyXJYnltrUhxbbieBAIRrdqpow==",
       "devOptional": true,
       "license": "Apache-2.0",
@@ -5712,9 +6217,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "4.17.2",
-      "resolved": "https://registry.npmmirror.com/@smithy/types/-/types-4.17.2.tgz",
-      "integrity": "sha512-FOKpVZob9MPTn2znRzGrnsMHv7BOsKVw3XiP/cOyYLDVZ9qKp4nifIiSCuUU/fIj5Vu0UOAxCFr+qRAtG0NUkA==",
+      "version": "4.18.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.18.0.tgz",
+      "integrity": "sha512-CgB6HHWer/vrKps24ulRIbpcpb7K4xAU7SkZ7YHzBPlwHsvsrCJFEXK421s+cJzX+ZrqtA/TuU5w1HzI7k9N8A==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -5726,7 +6231,7 @@
     },
     "node_modules/@smithy/util-buffer-from": {
       "version": "2.2.0",
-      "resolved": "https://registry.npmmirror.com/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
       "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
       "devOptional": true,
       "license": "Apache-2.0",
@@ -5740,7 +6245,7 @@
     },
     "node_modules/@smithy/util-utf8": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmmirror.com/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
       "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
       "devOptional": true,
       "license": "Apache-2.0",
@@ -5752,43 +6257,39 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "devOptional": true,
+      "license": "MIT"
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "license": "MIT"
     },
-    "node_modules/@tanstack/virtual-core": {
-      "version": "3.17.8",
-      "resolved": "https://registry.npmmirror.com/@tanstack/virtual-core/-/virtual-core-3.17.8.tgz",
-      "integrity": "sha512-BfEvehNpOT75r5Ksc5xW6NZuXujTfb7nlSEyVu4XHG3gdxNg1KqXruWbDewXOUaUYIo4oRbSfkjIajz4MAT8tA==",
-      "devOptional": true,
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/tannerlinsley"
-      }
-    },
     "node_modules/@types/node": {
-      "version": "26.2.0",
-      "resolved": "https://registry.npmmirror.com/@types/node/-/node-26.2.0.tgz",
-      "integrity": "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==",
+      "version": "22.20.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.2.tgz",
+      "integrity": "sha512-xlvWf4Vs9n1PEVYwP1n4vvG07M6y8WgvJ2t0vbrWTmijsIHp1cS+uJ2kMIRdY3nHZK0nCYKrPeD171+SzF4/zw==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~8.3.0"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@types/retry": {
       "version": "0.12.0",
-      "resolved": "https://registry.npmmirror.com/@types/retry/-/retry-0.12.0.tgz",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
       "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
       "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@vscode/ripgrep": {
       "version": "1.18.0",
-      "resolved": "https://registry.npmmirror.com/@vscode/ripgrep/-/ripgrep-1.18.0.tgz",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep/-/ripgrep-1.18.0.tgz",
       "integrity": "sha512-ns5lWe44tSfbTMbVUsyB+I1819PVSw4AdpgK0RNkzfWfwy6+3IUNSxwSrfTno1/oWaS/hERNz+XLWVyga2aJBQ==",
       "devOptional": true,
       "license": "MIT",
@@ -5809,7 +6310,7 @@
     },
     "node_modules/@vscode/ripgrep-darwin-arm64": {
       "version": "1.18.0",
-      "resolved": "https://registry.npmmirror.com/@vscode/ripgrep-darwin-arm64/-/ripgrep-darwin-arm64-1.18.0.tgz",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-darwin-arm64/-/ripgrep-darwin-arm64-1.18.0.tgz",
       "integrity": "sha512-r3ktHSvbFycQNF6sl7sNDPocpsI7J+mEzh1IaZFkY0spm3k2Z9t8hPAeOK7+p0l6p6/swkQC14XWX01low+94Q==",
       "cpu": [
         "arm64"
@@ -5822,7 +6323,7 @@
     },
     "node_modules/@vscode/ripgrep-darwin-x64": {
       "version": "1.18.0",
-      "resolved": "https://registry.npmmirror.com/@vscode/ripgrep-darwin-x64/-/ripgrep-darwin-x64-1.18.0.tgz",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-darwin-x64/-/ripgrep-darwin-x64-1.18.0.tgz",
       "integrity": "sha512-25b4gWbL138dGuQU244ebCKKc0q05ULBMoFSz9oAEUHNeqK/lOJViDS7DRvbDazzAzSEdan391Znks/R5mkaTQ==",
       "cpu": [
         "x64"
@@ -5835,7 +6336,7 @@
     },
     "node_modules/@vscode/ripgrep-linux-arm": {
       "version": "1.18.0",
-      "resolved": "https://registry.npmmirror.com/@vscode/ripgrep-linux-arm/-/ripgrep-linux-arm-1.18.0.tgz",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-linux-arm/-/ripgrep-linux-arm-1.18.0.tgz",
       "integrity": "sha512-GDAvufNDHu8zqLEmXstalQF0Wh6wQvdsBi/Vg3Yi3CK4a8XoFXqqXVEHEZ9xQz3t0NfoSEc9JbvK9DDS6FxyxQ==",
       "cpu": [
         "arm"
@@ -5848,7 +6349,7 @@
     },
     "node_modules/@vscode/ripgrep-linux-arm64": {
       "version": "1.18.0",
-      "resolved": "https://registry.npmmirror.com/@vscode/ripgrep-linux-arm64/-/ripgrep-linux-arm64-1.18.0.tgz",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-linux-arm64/-/ripgrep-linux-arm64-1.18.0.tgz",
       "integrity": "sha512-lQ/5zTG++U0E3IhVgS4EPTTn/U4okncaRMM5GOFfOYZywS4nuD31GhkHbNYlDk5CuDC68+hYJ0/eQeyCKJDA+g==",
       "cpu": [
         "arm64"
@@ -5861,7 +6362,7 @@
     },
     "node_modules/@vscode/ripgrep-linux-ia32": {
       "version": "1.18.0",
-      "resolved": "https://registry.npmmirror.com/@vscode/ripgrep-linux-ia32/-/ripgrep-linux-ia32-1.18.0.tgz",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-linux-ia32/-/ripgrep-linux-ia32-1.18.0.tgz",
       "integrity": "sha512-YWLkSUtFd4Jh5EepIhA9RJSfv3uMAVMo+2rBIGHPBnvgLrZciIs2cDKei1/p6Wc/aCzUoHyMAg2R6tw4ZCBKGg==",
       "cpu": [
         "ia32"
@@ -5874,7 +6375,7 @@
     },
     "node_modules/@vscode/ripgrep-linux-ppc64": {
       "version": "1.18.0",
-      "resolved": "https://registry.npmmirror.com/@vscode/ripgrep-linux-ppc64/-/ripgrep-linux-ppc64-1.18.0.tgz",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-linux-ppc64/-/ripgrep-linux-ppc64-1.18.0.tgz",
       "integrity": "sha512-quXVY8fwQ8O/lvU1yrSqSl3jlUzysRSb+AfUfCL/tRtphxsKlFvPAejryZ6vg4Bgvn8XL74xb4qMCDmWgYrT5w==",
       "cpu": [
         "ppc64"
@@ -5887,7 +6388,7 @@
     },
     "node_modules/@vscode/ripgrep-linux-riscv64": {
       "version": "1.18.0",
-      "resolved": "https://registry.npmmirror.com/@vscode/ripgrep-linux-riscv64/-/ripgrep-linux-riscv64-1.18.0.tgz",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-linux-riscv64/-/ripgrep-linux-riscv64-1.18.0.tgz",
       "integrity": "sha512-f5kBQBrWfQt8Q7OhSORuNDei5dkYagBj3y4jImSUXGMy8B/Ke7SltSRcUtjPv166FAFfHCAmWuZp3+cWnX2/Vw==",
       "cpu": [
         "riscv64"
@@ -5900,7 +6401,7 @@
     },
     "node_modules/@vscode/ripgrep-linux-s390x": {
       "version": "1.18.0",
-      "resolved": "https://registry.npmmirror.com/@vscode/ripgrep-linux-s390x/-/ripgrep-linux-s390x-1.18.0.tgz",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-linux-s390x/-/ripgrep-linux-s390x-1.18.0.tgz",
       "integrity": "sha512-rTOcJFGGcl2c07RUOWUo4U1ndnemKhY6A9hnMB18uk7jSgJc0d/QLBGWMWpumdtoJtpizn/wIv5mXIisJukusQ==",
       "cpu": [
         "s390x"
@@ -5913,7 +6414,7 @@
     },
     "node_modules/@vscode/ripgrep-linux-x64": {
       "version": "1.18.0",
-      "resolved": "https://registry.npmmirror.com/@vscode/ripgrep-linux-x64/-/ripgrep-linux-x64-1.18.0.tgz",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-linux-x64/-/ripgrep-linux-x64-1.18.0.tgz",
       "integrity": "sha512-mQ3bVrUpnD2vs7QT0vX90Lt0cnUq467uFtEktIdsJJmW296RoSULRGqWgzG1AKxyBpNDD6l4ZO4qKf6SgyC23Q==",
       "cpu": [
         "x64"
@@ -5926,7 +6427,7 @@
     },
     "node_modules/@vscode/ripgrep-win32-arm64": {
       "version": "1.18.0",
-      "resolved": "https://registry.npmmirror.com/@vscode/ripgrep-win32-arm64/-/ripgrep-win32-arm64-1.18.0.tgz",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-win32-arm64/-/ripgrep-win32-arm64-1.18.0.tgz",
       "integrity": "sha512-vfTIjq1OHnzUjxZcHVQAMbnggp8dpGf+0QKFOZHwWPqFwXxQC8eCWM+5NUdoJ6yrElCeMzoUTXoK/LdZaniB+Q==",
       "cpu": [
         "arm64"
@@ -5939,7 +6440,7 @@
     },
     "node_modules/@vscode/ripgrep-win32-ia32": {
       "version": "1.18.0",
-      "resolved": "https://registry.npmmirror.com/@vscode/ripgrep-win32-ia32/-/ripgrep-win32-ia32-1.18.0.tgz",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-win32-ia32/-/ripgrep-win32-ia32-1.18.0.tgz",
       "integrity": "sha512-//rfAE+BOw5AC2EMmepmiE36jUuevtQYNQqqlw1s3m9FlRxjxEut97RkRPHAu9BG4mSojatZx+kXZXNdyI9caQ==",
       "cpu": [
         "ia32"
@@ -5952,7 +6453,7 @@
     },
     "node_modules/@vscode/ripgrep-win32-x64": {
       "version": "1.18.0",
-      "resolved": "https://registry.npmmirror.com/@vscode/ripgrep-win32-x64/-/ripgrep-win32-x64-1.18.0.tgz",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-win32-x64/-/ripgrep-win32-x64-1.18.0.tgz",
       "integrity": "sha512-KNPvtElldqILHdnAetujPaowkNbpqJy3ssIGGN6F6Kve9Qi+nNLI2DN01O83JjCEVQbCzl8Ov3QZ9Eov3BR8Dg==",
       "cpu": [
         "x64"
@@ -5963,9 +6464,19 @@
         "win32"
       ]
     },
+    "node_modules/@xterm/headless": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@xterm/headless/-/headless-6.0.0.tgz",
+      "integrity": "sha512-5Yj1QINYCyzrZtf8OFIHi47iQtI+0qYFPHmouEfG8dHNxbZ9Tb9YGSuLcsEwj9Z+OL75GJqPyJbyoFer80a2Hw==",
+      "devOptional": true,
+      "license": "MIT",
+      "workspaces": [
+        "addons/*"
+      ]
+    },
     "node_modules/accepts": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmmirror.com/accepts/-/accepts-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
       "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
       "devOptional": true,
       "license": "MIT",
@@ -5979,7 +6490,7 @@
     },
     "node_modules/agent-base": {
       "version": "7.1.4",
-      "resolved": "https://registry.npmmirror.com/agent-base/-/agent-base-7.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
       "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
       "devOptional": true,
       "license": "MIT",
@@ -5989,7 +6500,7 @@
     },
     "node_modules/ajv": {
       "version": "8.20.0",
-      "resolved": "https://registry.npmmirror.com/ajv/-/ajv-8.20.0.tgz",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "devOptional": true,
       "license": "MIT",
@@ -6006,7 +6517,7 @@
     },
     "node_modules/ajv-formats": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmmirror.com/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
       "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
       "devOptional": true,
       "license": "MIT",
@@ -6031,7 +6542,7 @@
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
-      "resolved": "https://registry.npmmirror.com/base64-js/-/base64-js-1.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
       "devOptional": true,
       "funding": [
@@ -6052,7 +6563,7 @@
     },
     "node_modules/bignumber.js": {
       "version": "9.3.1",
-      "resolved": "https://registry.npmmirror.com/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
       "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
       "devOptional": true,
       "license": "MIT",
@@ -6062,7 +6573,7 @@
     },
     "node_modules/body-parser": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmmirror.com/body-parser/-/body-parser-2.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
       "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
       "devOptional": true,
       "license": "MIT",
@@ -6087,7 +6598,7 @@
     },
     "node_modules/body-parser/node_modules/content-type": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmmirror.com/content-type/-/content-type-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
       "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
       "devOptional": true,
       "license": "MIT",
@@ -6099,23 +6610,48 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/body-parser/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/body-parser/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "devOptional": true,
+      "license": "MIT"
+    },
     "node_modules/bowser": {
       "version": "2.14.1",
-      "resolved": "https://registry.npmmirror.com/bowser/-/bowser-2.14.1.tgz",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
       "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
       "devOptional": true,
       "license": "MIT"
     },
     "node_modules/buffer-equal-constant-time": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmmirror.com/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
       "devOptional": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/bundle-name": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmmirror.com/bundle-name/-/bundle-name-4.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
       "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
       "devOptional": true,
       "license": "MIT",
@@ -6131,7 +6667,7 @@
     },
     "node_modules/bytes": {
       "version": "3.1.2",
-      "resolved": "https://registry.npmmirror.com/bytes/-/bytes-3.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
       "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
       "devOptional": true,
       "license": "MIT",
@@ -6141,7 +6677,7 @@
     },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmmirror.com/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
       "devOptional": true,
       "license": "MIT",
@@ -6155,7 +6691,7 @@
     },
     "node_modules/call-bound": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmmirror.com/call-bound/-/call-bound-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
       "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
       "devOptional": true,
       "license": "MIT",
@@ -6172,7 +6708,7 @@
     },
     "node_modules/chokidar": {
       "version": "4.0.3",
-      "resolved": "https://registry.npmmirror.com/chokidar/-/chokidar-4.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
       "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
       "devOptional": true,
       "license": "MIT",
@@ -6195,19 +6731,9 @@
         "node": ">=18"
       }
     },
-    "node_modules/clsx": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmmirror.com/clsx/-/clsx-2.1.1.tgz",
-      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
-      "devOptional": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/commander": {
       "version": "15.0.0",
-      "resolved": "https://registry.npmmirror.com/commander/-/commander-15.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
       "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
       "devOptional": true,
       "license": "MIT",
@@ -6215,9 +6741,51 @@
         "node": ">=22.12.0"
       }
     },
+    "node_modules/compressible": {
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
+      "integrity": "sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": ">= 1.43.0 < 2"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/compression": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/compression/-/compression-1.8.1.tgz",
+      "integrity": "sha512-9mAqGPHLakhCLeNyxPkK4xVo746zQ/czLH1Ky+vkitMnWfWZps8r0qXuwhwizagCRttsL4lfG4pIOvaWLpAP0w==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "compressible": "~2.0.18",
+        "debug": "2.6.9",
+        "negotiator": "~0.6.4",
+        "on-headers": "~1.1.0",
+        "safe-buffer": "5.2.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/compression/node_modules/negotiator": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
+      "integrity": "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/content-disposition": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmmirror.com/content-disposition/-/content-disposition-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
       "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
       "devOptional": true,
       "license": "MIT",
@@ -6231,7 +6799,7 @@
     },
     "node_modules/content-type": {
       "version": "1.0.5",
-      "resolved": "https://registry.npmmirror.com/content-type/-/content-type-1.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
       "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
       "devOptional": true,
       "license": "MIT",
@@ -6241,7 +6809,7 @@
     },
     "node_modules/cookie": {
       "version": "0.7.2",
-      "resolved": "https://registry.npmmirror.com/cookie/-/cookie-0.7.2.tgz",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
       "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
       "devOptional": true,
       "license": "MIT",
@@ -6251,7 +6819,7 @@
     },
     "node_modules/cookie-signature": {
       "version": "1.2.2",
-      "resolved": "https://registry.npmmirror.com/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
       "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
       "devOptional": true,
       "license": "MIT",
@@ -6261,7 +6829,7 @@
     },
     "node_modules/cors": {
       "version": "2.8.6",
-      "resolved": "https://registry.npmmirror.com/cors/-/cors-2.8.6.tgz",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
       "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
       "devOptional": true,
       "license": "MIT",
@@ -6293,7 +6861,7 @@
     },
     "node_modules/data-uri-to-buffer": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmmirror.com/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
       "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
       "devOptional": true,
       "license": "MIT",
@@ -6302,26 +6870,18 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmmirror.com/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
+        "ms": "2.0.0"
       }
     },
     "node_modules/default-browser": {
       "version": "5.5.1",
-      "resolved": "https://registry.npmmirror.com/default-browser/-/default-browser-5.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.1.tgz",
       "integrity": "sha512-m1pAzaJgZ/gssEqlOhJkPJp8Xly7QyW6xcrkUa2KKcDeDSEMP7X8xipU3snUcfisTQx0w1AGae+9UtJSfVnXGw==",
       "devOptional": true,
       "license": "MIT",
@@ -6338,7 +6898,7 @@
     },
     "node_modules/default-browser-id": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmmirror.com/default-browser-id/-/default-browser-id-5.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
       "integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
       "devOptional": true,
       "license": "MIT",
@@ -6351,7 +6911,7 @@
     },
     "node_modules/define-lazy-prop": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmmirror.com/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
       "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
       "devOptional": true,
       "license": "MIT",
@@ -6364,7 +6924,7 @@
     },
     "node_modules/depd": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmmirror.com/depd/-/depd-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
       "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
       "devOptional": true,
       "license": "MIT",
@@ -6374,7 +6934,7 @@
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
-      "resolved": "https://registry.npmmirror.com/detect-libc/-/detect-libc-2.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
       "devOptional": true,
       "license": "Apache-2.0",
@@ -6384,7 +6944,7 @@
     },
     "node_modules/diff": {
       "version": "9.0.0",
-      "resolved": "https://registry.npmmirror.com/diff/-/diff-9.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-9.0.0.tgz",
       "integrity": "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==",
       "devOptional": true,
       "license": "BSD-3-Clause",
@@ -6394,7 +6954,7 @@
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmmirror.com/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
       "devOptional": true,
       "license": "MIT",
@@ -6409,7 +6969,7 @@
     },
     "node_modules/ecdsa-sig-formatter": {
       "version": "1.0.11",
-      "resolved": "https://registry.npmmirror.com/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
       "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
       "devOptional": true,
       "license": "Apache-2.0",
@@ -6419,14 +6979,14 @@
     },
     "node_modules/ee-first": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmmirror.com/ee-first/-/ee-first-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
       "devOptional": true,
       "license": "MIT"
     },
     "node_modules/encodeurl": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmmirror.com/encodeurl/-/encodeurl-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
       "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
       "devOptional": true,
       "license": "MIT",
@@ -6436,7 +6996,7 @@
     },
     "node_modules/es-define-property": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmmirror.com/es-define-property/-/es-define-property-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
       "devOptional": true,
       "license": "MIT",
@@ -6446,7 +7006,7 @@
     },
     "node_modules/es-errors": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmmirror.com/es-errors/-/es-errors-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
       "devOptional": true,
       "license": "MIT",
@@ -6456,7 +7016,7 @@
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmmirror.com/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
       "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
       "devOptional": true,
       "license": "MIT",
@@ -6469,14 +7029,14 @@
     },
     "node_modules/escape-html": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmmirror.com/escape-html/-/escape-html-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
       "devOptional": true,
       "license": "MIT"
     },
     "node_modules/etag": {
       "version": "1.8.1",
-      "resolved": "https://registry.npmmirror.com/etag/-/etag-1.8.1.tgz",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
       "devOptional": true,
       "license": "MIT",
@@ -6486,7 +7046,7 @@
     },
     "node_modules/eventsource": {
       "version": "3.0.7",
-      "resolved": "https://registry.npmmirror.com/eventsource/-/eventsource-3.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
       "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
       "devOptional": true,
       "license": "MIT",
@@ -6499,7 +7059,7 @@
     },
     "node_modules/eventsource-parser": {
       "version": "3.1.1",
-      "resolved": "https://registry.npmmirror.com/eventsource-parser/-/eventsource-parser-3.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.1.tgz",
       "integrity": "sha512-EKN1vKAMcZ8MlYMpaNuxN6R9yakzH6uajHcHVTqWJzvu5pWw9DyhbP35HH8MVBQ+dZjAfDxk+A8NiR9KWaXiyQ==",
       "devOptional": true,
       "license": "MIT",
@@ -6509,7 +7069,7 @@
     },
     "node_modules/express": {
       "version": "5.2.1",
-      "resolved": "https://registry.npmmirror.com/express/-/express-5.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "devOptional": true,
       "license": "MIT",
@@ -6552,9 +7112,9 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.6.2",
-      "resolved": "https://registry.npmmirror.com/express-rate-limit/-/express-rate-limit-8.6.2.tgz",
-      "integrity": "sha512-YH4ru+eOJxQABscKFfRCy9R7x9QFGdezclVMwwgFFndzS2Xnm0uo6B0ABZsLhcpeptGv2qvuJVWlQr9gQZoC3A==",
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.7.0.tgz",
+      "integrity": "sha512-hOwV7WOxXfjRpAM1DSJWZDXx3GhplwD8IfwuwvogD8i1Qnkgosw/H45s4ZnFAUHDAhPjlY9hLBvJhKmGMyY26g==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -6571,24 +7131,81 @@
         "express": ">= 4.11"
       }
     },
+    "node_modules/express-rate-limit/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/express-rate-limit/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/express/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/express/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "devOptional": true,
+      "license": "MIT"
+    },
     "node_modules/extend": {
       "version": "3.0.2",
-      "resolved": "https://registry.npmmirror.com/extend/-/extend-3.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "devOptional": true,
       "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
-      "resolved": "https://registry.npmmirror.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "devOptional": true,
+      "license": "Unlicense"
+    },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmmirror.com/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "devOptional": true,
       "funding": [
         {
@@ -6604,7 +7221,7 @@
     },
     "node_modules/fetch-blob": {
       "version": "3.2.0",
-      "resolved": "https://registry.npmmirror.com/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
       "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
       "devOptional": true,
       "funding": [
@@ -6628,14 +7245,14 @@
     },
     "node_modules/fflate": {
       "version": "0.8.3",
-      "resolved": "https://registry.npmmirror.com/fflate/-/fflate-0.8.3.tgz",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
       "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
       "devOptional": true,
       "license": "MIT"
     },
     "node_modules/finalhandler": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmmirror.com/finalhandler/-/finalhandler-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
       "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
       "devOptional": true,
       "license": "MIT",
@@ -6655,9 +7272,34 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/finalhandler/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/finalhandler/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "devOptional": true,
+      "license": "MIT"
+    },
     "node_modules/formdata-polyfill": {
       "version": "4.0.10",
-      "resolved": "https://registry.npmmirror.com/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
       "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
       "devOptional": true,
       "license": "MIT",
@@ -6670,7 +7312,7 @@
     },
     "node_modules/forwarded": {
       "version": "0.2.0",
-      "resolved": "https://registry.npmmirror.com/forwarded/-/forwarded-0.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
       "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
       "devOptional": true,
       "license": "MIT",
@@ -6680,7 +7322,7 @@
     },
     "node_modules/fresh": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmmirror.com/fresh/-/fresh-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
       "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
       "devOptional": true,
       "license": "MIT",
@@ -6690,7 +7332,7 @@
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmmirror.com/function-bind/-/function-bind-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
       "devOptional": true,
       "license": "MIT",
@@ -6700,7 +7342,7 @@
     },
     "node_modules/gaxios": {
       "version": "7.3.1",
-      "resolved": "https://registry.npmmirror.com/gaxios/-/gaxios-7.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.3.1.tgz",
       "integrity": "sha512-kB3rzJV7d9juLZh8/56QTXCwQfxyhdOMdyYk1HdQKFtF8TJTDTZQJtixWIwXdE9Jji91mC41DUNpjleo4L4eAQ==",
       "devOptional": true,
       "license": "Apache-2.0",
@@ -6715,7 +7357,7 @@
     },
     "node_modules/gcp-metadata": {
       "version": "8.1.2",
-      "resolved": "https://registry.npmmirror.com/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
       "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
       "devOptional": true,
       "license": "Apache-2.0",
@@ -6730,7 +7372,7 @@
     },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmmirror.com/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
       "devOptional": true,
       "license": "MIT",
@@ -6755,7 +7397,7 @@
     },
     "node_modules/get-proto": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmmirror.com/get-proto/-/get-proto-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
       "devOptional": true,
       "license": "MIT",
@@ -6769,7 +7411,7 @@
     },
     "node_modules/google-auth-library": {
       "version": "10.9.1",
-      "resolved": "https://registry.npmmirror.com/google-auth-library/-/google-auth-library-10.9.1.tgz",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.9.1.tgz",
       "integrity": "sha512-i1ydyHrqcIxXkWh/uBmVkzCvIuq5yiK2ATndIe5XxKholrG/MTYP9xGYka4sQhrbIAgGjL2B6NOE7rFaiF3fXw==",
       "devOptional": true,
       "license": "Apache-2.0",
@@ -6787,7 +7429,7 @@
     },
     "node_modules/google-logging-utils": {
       "version": "1.1.3",
-      "resolved": "https://registry.npmmirror.com/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
       "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
       "devOptional": true,
       "license": "Apache-2.0",
@@ -6797,7 +7439,7 @@
     },
     "node_modules/gopd": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmmirror.com/gopd/-/gopd-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
       "devOptional": true,
       "license": "MIT",
@@ -6810,7 +7452,7 @@
     },
     "node_modules/has-symbols": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmmirror.com/has-symbols/-/has-symbols-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "devOptional": true,
       "license": "MIT",
@@ -6823,7 +7465,7 @@
     },
     "node_modules/hasown": {
       "version": "2.0.4",
-      "resolved": "https://registry.npmmirror.com/hasown/-/hasown-2.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
       "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "devOptional": true,
       "license": "MIT",
@@ -6835,9 +7477,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.13.3",
-      "resolved": "https://registry.npmmirror.com/hono/-/hono-4.13.3.tgz",
-      "integrity": "sha512-r8AO2mYHoLxSHkgafNeC/BXyb2vWRxD3jem4Ts+ptav8oTG5FIRifAjuJEmZI4bSvvc2ns0GxmIYiZnHqN3mMw==",
+      "version": "4.13.7",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.7.tgz",
+      "integrity": "sha512-c8/gF9ac8Y78/agExVocyLevgR+JlpNB444Py0FSX8pJoPdYUfUzRcXtYEYGwt6l19qIlVZPN5Mfsw9jFShmQQ==",
       "devOptional": true,
       "license": "MIT",
       "engines": {
@@ -6846,7 +7488,7 @@
     },
     "node_modules/http-errors": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmmirror.com/http-errors/-/http-errors-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
       "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
       "devOptional": true,
       "license": "MIT",
@@ -6867,7 +7509,7 @@
     },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
-      "resolved": "https://registry.npmmirror.com/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
       "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
       "devOptional": true,
       "license": "MIT",
@@ -6879,9 +7521,34 @@
         "node": ">= 14"
       }
     },
+    "node_modules/http-proxy-agent/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/http-proxy-agent/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "devOptional": true,
+      "license": "MIT"
+    },
     "node_modules/https-proxy-agent": {
       "version": "7.0.6",
-      "resolved": "https://registry.npmmirror.com/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
       "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
       "devOptional": true,
       "license": "MIT",
@@ -6893,9 +7560,34 @@
         "node": ">= 14"
       }
     },
+    "node_modules/https-proxy-agent/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/https-proxy-agent/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "devOptional": true,
+      "license": "MIT"
+    },
     "node_modules/iconv-lite": {
       "version": "0.7.3",
-      "resolved": "https://registry.npmmirror.com/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
       "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
       "devOptional": true,
       "license": "MIT",
@@ -6910,28 +7602,17 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/immer": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmmirror.com/immer/-/immer-10.2.0.tgz",
-      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
-      "devOptional": true,
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/immer"
-      }
-    },
     "node_modules/inherits": {
       "version": "2.0.4",
-      "resolved": "https://registry.npmmirror.com/inherits/-/inherits-2.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "devOptional": true,
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmmirror.com/ip-address/-/ip-address-10.5.0.tgz",
-      "integrity": "sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==",
+      "version": "10.7.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.7.0.tgz",
+      "integrity": "sha512-BGFsyJd5mpXp3rK6jIdADLNgpJUK1jnjzvYF8lK+VyDab9JAmqN0YOKDdP17HlgKb2+ehPgDc8EtnRLbGCAMhA==",
       "devOptional": true,
       "license": "MIT",
       "engines": {
@@ -6939,18 +7620,18 @@
       }
     },
     "node_modules/ipaddr.js": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmmirror.com/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
-      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.5.0.tgz",
+      "integrity": "sha512-aq+t5NAc+cS6rZQQVWC2x98CPqGtKKTMDd4Gaodv0wShnItdKg/51djkGJ1hqH+Oy0ivDftCbSLCQob8zso01w==",
       "devOptional": true,
       "license": "MIT",
       "engines": {
-        "node": ">= 0.10"
+        "node": ">= 10"
       }
     },
     "node_modules/is-docker": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmmirror.com/is-docker/-/is-docker-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
       "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
       "devOptional": true,
       "license": "MIT",
@@ -6966,7 +7647,7 @@
     },
     "node_modules/is-in-ssh": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmmirror.com/is-in-ssh/-/is-in-ssh-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-in-ssh/-/is-in-ssh-1.0.0.tgz",
       "integrity": "sha512-jYa6Q9rH90kR1vKB6NM7qqd1mge3Fx4Dhw5TVlK1MUBqhEOuCagrEHMevNuCcbECmXZ0ThXkRm+Ymr51HwEPAw==",
       "devOptional": true,
       "license": "MIT",
@@ -6979,7 +7660,7 @@
     },
     "node_modules/is-inside-container": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmmirror.com/is-inside-container/-/is-inside-container-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
       "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
       "devOptional": true,
       "license": "MIT",
@@ -6998,14 +7679,14 @@
     },
     "node_modules/is-promise": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmmirror.com/is-promise/-/is-promise-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
       "devOptional": true,
       "license": "MIT"
     },
     "node_modules/is-wsl": {
       "version": "3.1.1",
-      "resolved": "https://registry.npmmirror.com/is-wsl/-/is-wsl-3.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
       "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
       "devOptional": true,
       "license": "MIT",
@@ -7026,9 +7707,9 @@
       "license": "ISC"
     },
     "node_modules/jose": {
-      "version": "6.2.10",
-      "resolved": "https://registry.npmmirror.com/jose/-/jose-6.2.10.tgz",
-      "integrity": "sha512-iiW7J9qRFlGxvCOIBDBDxFePQSn7ZMAnrYGhrrOo6siO/MIqwfyilLR27pkfDgUk+raLuzADS8A3S/KLBisc0g==",
+      "version": "6.2.12",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.12.tgz",
+      "integrity": "sha512-9NiFmJEex0sy2Dk58j2UGBSHgUs2ypF9eZSu4L6vjOX3Dp96Sw1F3uL+H+D1sx02jZZdzUT0HgvCy59CuvXcWw==",
       "devOptional": true,
       "license": "MIT",
       "funding": {
@@ -7067,7 +7748,7 @@
     },
     "node_modules/json-bigint": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmmirror.com/json-bigint/-/json-bigint-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
       "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
       "devOptional": true,
       "license": "MIT",
@@ -7077,7 +7758,7 @@
     },
     "node_modules/json-schema-to-ts": {
       "version": "3.1.1",
-      "resolved": "https://registry.npmmirror.com/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
       "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
       "devOptional": true,
       "license": "MIT",
@@ -7091,21 +7772,21 @@
     },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmmirror.com/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "devOptional": true,
       "license": "MIT"
     },
     "node_modules/json-schema-typed": {
       "version": "8.0.2",
-      "resolved": "https://registry.npmmirror.com/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
       "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
       "devOptional": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/jwa": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmmirror.com/jwa/-/jwa-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
       "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
       "devOptional": true,
       "license": "MIT",
@@ -7117,7 +7798,7 @@
     },
     "node_modules/jws": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmmirror.com/jws/-/jws-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
       "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
       "devOptional": true,
       "license": "MIT",
@@ -7127,9 +7808,9 @@
       }
     },
     "node_modules/koffi": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmmirror.com/koffi/-/koffi-3.1.6.tgz",
-      "integrity": "sha512-ln60chEb3o7Du1ayjwl6BFiNN1wZK+3cTM2wWGiHLEzCY/FdTIN1ER5VWDwHq7J/j4tSnnrHaH5ABS1EO6+6ag==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/koffi/-/koffi-3.2.1.tgz",
+      "integrity": "sha512-0qE3lZ8jllRqPN4Ob6Ajl7c2bJSJDhQWuKLGP5hIEpHLllJWv1ydHFMhHmHc5p/W9GticKVDbYzZd7TBoQ4CZg==",
       "devOptional": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -7137,47 +7818,36 @@
         "url": "https://liberapay.com/Koromix"
       },
       "optionalDependencies": {
-        "@koromix/koffi-darwin-arm64": "3.1.6",
-        "@koromix/koffi-darwin-x64": "3.1.6",
-        "@koromix/koffi-freebsd-arm64": "3.1.6",
-        "@koromix/koffi-freebsd-ia32": "3.1.6",
-        "@koromix/koffi-freebsd-x64": "3.1.6",
-        "@koromix/koffi-linux-arm64": "3.1.6",
-        "@koromix/koffi-linux-ia32": "3.1.6",
-        "@koromix/koffi-linux-loong64": "3.1.6",
-        "@koromix/koffi-linux-riscv64": "3.1.6",
-        "@koromix/koffi-linux-x64": "3.1.6",
-        "@koromix/koffi-openbsd-ia32": "3.1.6",
-        "@koromix/koffi-openbsd-x64": "3.1.6",
-        "@koromix/koffi-win32-arm64": "3.1.6",
-        "@koromix/koffi-win32-ia32": "3.1.6",
-        "@koromix/koffi-win32-x64": "3.1.6"
+        "@koromix/koffi-android-arm64": "3.2.1",
+        "@koromix/koffi-android-x64": "3.2.1",
+        "@koromix/koffi-darwin-arm64": "3.2.1",
+        "@koromix/koffi-darwin-x64": "3.2.1",
+        "@koromix/koffi-freebsd-arm64": "3.2.1",
+        "@koromix/koffi-freebsd-ia32": "3.2.1",
+        "@koromix/koffi-freebsd-x64": "3.2.1",
+        "@koromix/koffi-linux-arm": "3.2.1",
+        "@koromix/koffi-linux-arm64": "3.2.1",
+        "@koromix/koffi-linux-ia32": "3.2.1",
+        "@koromix/koffi-linux-loong64": "3.2.1",
+        "@koromix/koffi-linux-riscv64": "3.2.1",
+        "@koromix/koffi-linux-x64": "3.2.1",
+        "@koromix/koffi-openbsd-ia32": "3.2.1",
+        "@koromix/koffi-openbsd-x64": "3.2.1",
+        "@koromix/koffi-win32-arm64": "3.2.1",
+        "@koromix/koffi-win32-ia32": "3.2.1",
+        "@koromix/koffi-win32-x64": "3.2.1"
       }
     },
     "node_modules/long": {
       "version": "5.3.2",
-      "resolved": "https://registry.npmmirror.com/long/-/long-5.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
       "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
       "devOptional": true,
       "license": "Apache-2.0"
     },
-    "node_modules/loose-envify": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmmirror.com/loose-envify/-/loose-envify-1.4.0.tgz",
-      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "devOptional": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
-      },
-      "bin": {
-        "loose-envify": "cli.js"
-      }
-    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmmirror.com/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
       "devOptional": true,
       "license": "MIT",
@@ -7187,7 +7857,7 @@
     },
     "node_modules/media-typer": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmmirror.com/media-typer/-/media-typer-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.1.tgz",
       "integrity": "sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==",
       "devOptional": true,
       "license": "MIT",
@@ -7201,7 +7871,7 @@
     },
     "node_modules/merge-descriptors": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmmirror.com/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
       "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
       "devOptional": true,
       "license": "MIT",
@@ -7214,7 +7884,7 @@
     },
     "node_modules/mime-db": {
       "version": "1.54.0",
-      "resolved": "https://registry.npmmirror.com/mime-db/-/mime-db-1.54.0.tgz",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
       "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
       "devOptional": true,
       "license": "MIT",
@@ -7224,7 +7894,7 @@
     },
     "node_modules/mime-types": {
       "version": "3.0.2",
-      "resolved": "https://registry.npmmirror.com/mime-types/-/mime-types-3.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
       "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
       "devOptional": true,
       "license": "MIT",
@@ -7261,15 +7931,15 @@
       }
     },
     "node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmmirror.com/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "devOptional": true,
       "license": "MIT"
     },
     "node_modules/negotiator": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmmirror.com/negotiator/-/negotiator-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.1.0.tgz",
       "integrity": "sha512-NMPBRMJgiQHjbd8phG3Vebdx4kZ1H121rbl5IkMqeOsahptB9BKo/d7oJ3zTXqTgagn2bWlNSXkh0QUGM31RYg==",
       "devOptional": true,
       "license": "MIT",
@@ -7286,7 +7956,7 @@
     },
     "node_modules/negotiator/node_modules/content-type": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmmirror.com/content-type/-/content-type-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
       "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
       "devOptional": true,
       "license": "MIT",
@@ -7300,7 +7970,7 @@
     },
     "node_modules/node-addon-api": {
       "version": "7.1.1",
-      "resolved": "https://registry.npmmirror.com/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
       "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
       "devOptional": true,
       "license": "MIT"
@@ -7478,7 +8148,7 @@
     },
     "node_modules/node-domexception": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmmirror.com/node-domexception/-/node-domexception-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
       "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
       "deprecated": "Use your platform's native DOMException instead",
       "devOptional": true,
@@ -7511,7 +8181,7 @@
     },
     "node_modules/node-fetch": {
       "version": "3.3.2",
-      "resolved": "https://registry.npmmirror.com/node-fetch/-/node-fetch-3.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
       "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
       "devOptional": true,
       "license": "MIT",
@@ -7530,7 +8200,7 @@
     },
     "node_modules/node-pty": {
       "version": "1.2.0-beta.15",
-      "resolved": "https://registry.npmmirror.com/node-pty/-/node-pty-1.2.0-beta.15.tgz",
+      "resolved": "https://registry.npmjs.org/node-pty/-/node-pty-1.2.0-beta.15.tgz",
       "integrity": "sha512-vORSzHXi4Ofl7HemVWpuudLqCPdaQb4LfpRCUpE5HPxhp4JYscl8zZwxh11p26v2wvW24WMwnMfLjhRLixrfxA==",
       "devOptional": true,
       "hasInstallScript": true,
@@ -7541,7 +8211,7 @@
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
-      "resolved": "https://registry.npmmirror.com/object-assign/-/object-assign-4.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
       "devOptional": true,
       "license": "MIT",
@@ -7551,7 +8221,7 @@
     },
     "node_modules/object-inspect": {
       "version": "1.13.4",
-      "resolved": "https://registry.npmmirror.com/object-inspect/-/object-inspect-1.13.4.tgz",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
       "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
       "devOptional": true,
       "license": "MIT",
@@ -7564,7 +8234,7 @@
     },
     "node_modules/on-finished": {
       "version": "2.4.1",
-      "resolved": "https://registry.npmmirror.com/on-finished/-/on-finished-2.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
       "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
       "devOptional": true,
       "license": "MIT",
@@ -7575,9 +8245,19 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/on-headers": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.1.0.tgz",
+      "integrity": "sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmmirror.com/once/-/once-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "devOptional": true,
       "license": "ISC",
@@ -7586,17 +8266,17 @@
       }
     },
     "node_modules/open": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmmirror.com/open/-/open-11.0.1.tgz",
-      "integrity": "sha512-NzwMUB6C1D0+Kd+9iMS/H4k+Ck3cTX6Ckyfr/gAGlmvSE1LUQZnEZvWBi4PYmMwH/S5SMeTXnE+9uAz8uF+pWw==",
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-11.0.2.tgz",
+      "integrity": "sha512-RWqF+pBSkqecEvCKOn8QYhaNdRMJDZRIrlS/7rTDdLHaPcfXGCZ/h8zb413NfvdeAV0MR7T1yJcA34/q+CSm1Q==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "default-browser": "^5.4.0",
+        "default-browser": "^5.5.1",
         "define-lazy-prop": "^3.0.0",
         "is-in-ssh": "^1.0.0",
         "is-inside-container": "^1.0.0",
-        "powershell-utils": "^0.2.0",
+        "powershell-utils": "^0.2.1",
         "wsl-utils": "^1.0.0"
       },
       "engines": {
@@ -7607,14 +8287,11 @@
       }
     },
     "node_modules/openai": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmmirror.com/openai/-/openai-6.26.0.tgz",
-      "integrity": "sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA==",
+      "version": "6.40.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.40.0.tgz",
+      "integrity": "sha512-MWtTjd/gQt4jpbji61NTgFWJLoY/PdRJ6wG9/ZDRMYNMlBKrCrSlkLI+KgHP1vR1qT6LKSAyAqIxno6lcK9JiA==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "bin": {
-        "openai": "bin/cli"
-      },
       "peerDependencies": {
         "ws": "^8.18.0",
         "zod": "^3.25 || ^4.0"
@@ -7630,7 +8307,7 @@
     },
     "node_modules/p-retry": {
       "version": "4.6.2",
-      "resolved": "https://registry.npmmirror.com/p-retry/-/p-retry-4.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
       "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
       "devOptional": true,
       "license": "MIT",
@@ -7644,7 +8321,7 @@
     },
     "node_modules/parseurl": {
       "version": "1.3.3",
-      "resolved": "https://registry.npmmirror.com/parseurl/-/parseurl-1.3.3.tgz",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
       "devOptional": true,
       "license": "MIT",
@@ -7654,7 +8331,7 @@
     },
     "node_modules/partial-json": {
       "version": "0.1.7",
-      "resolved": "https://registry.npmmirror.com/partial-json/-/partial-json-0.1.7.tgz",
+      "resolved": "https://registry.npmjs.org/partial-json/-/partial-json-0.1.7.tgz",
       "integrity": "sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==",
       "devOptional": true,
       "license": "MIT"
@@ -7670,7 +8347,7 @@
     },
     "node_modules/path-to-regexp": {
       "version": "8.4.2",
-      "resolved": "https://registry.npmmirror.com/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
       "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
       "devOptional": true,
       "license": "MIT",
@@ -7681,15 +8358,15 @@
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmmirror.com/picocolors/-/picocolors-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "devOptional": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmmirror.com/picomatch/-/picomatch-4.0.5.tgz",
-      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+      "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
       "devOptional": true,
       "license": "MIT",
       "engines": {
@@ -7701,7 +8378,7 @@
     },
     "node_modules/pkce-challenge": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmmirror.com/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
       "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
       "devOptional": true,
       "license": "MIT",
@@ -7710,9 +8387,9 @@
       }
     },
     "node_modules/powershell-utils": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmmirror.com/powershell-utils/-/powershell-utils-0.2.0.tgz",
-      "integrity": "sha512-ZlsFlG7MtSFCoc5xreOvBAozCJ6Pf06opgJjh9ONEv418xpZSAzNjstD36C6+JwOnfSqOW/9uDkqKjezTdxZhw==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.2.1.tgz",
+      "integrity": "sha512-C+y9x90UElAddDZmV4qOx9W53B61PO7cIqWz2dQsWlwswuq4mr8NEwytdGKboYbQlGZ3awrkTeNvcZiZNHnQ8A==",
       "devOptional": true,
       "license": "MIT",
       "engines": {
@@ -7723,9 +8400,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.6.5",
-      "resolved": "https://registry.npmmirror.com/protobufjs/-/protobufjs-7.6.5.tgz",
-      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
+      "version": "7.6.6",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.6.tgz",
+      "integrity": "sha512-dYDWdjSl5RNb7SgPxGQcRU+GtvP7s2fpkrY0r432PcOIaZ0/rBcxEZnQN67iJhFuQiVw754JDoPruPCNdGsbjg==",
       "devOptional": true,
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
@@ -7748,7 +8425,7 @@
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
-      "resolved": "https://registry.npmmirror.com/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
       "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
       "devOptional": true,
       "license": "MIT",
@@ -7760,10 +8437,20 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/proxy-addr/node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/qs": {
-      "version": "6.15.3",
-      "resolved": "https://registry.npmmirror.com/qs/-/qs-6.15.3.tgz",
-      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
       "devOptional": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -7779,7 +8466,7 @@
     },
     "node_modules/range-parser": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmmirror.com/range-parser/-/range-parser-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
       "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
       "devOptional": true,
       "license": "MIT",
@@ -7793,7 +8480,7 @@
     },
     "node_modules/raw-body": {
       "version": "3.0.2",
-      "resolved": "https://registry.npmmirror.com/raw-body/-/raw-body-3.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
       "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
       "devOptional": true,
       "license": "MIT",
@@ -7807,23 +8494,9 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/react": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmmirror.com/react/-/react-18.3.1.tgz",
-      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
-      "devOptional": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/readdirp": {
       "version": "4.1.2",
-      "resolved": "https://registry.npmmirror.com/readdirp/-/readdirp-4.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
       "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
       "devOptional": true,
       "license": "MIT",
@@ -7837,7 +8510,7 @@
     },
     "node_modules/require-from-string": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmmirror.com/require-from-string/-/require-from-string-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "devOptional": true,
       "license": "MIT",
@@ -7845,9 +8518,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/resolve.exports": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.3.tgz",
+      "integrity": "sha512-OcXjMsGdhL4XnbShKpAcSqPMzQoYkYyhbEaeSko47MjRP9NfEQMhZkXL1DoFlt9LWQn4YttrdnV6X2OiyzBi+A==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/retry": {
       "version": "0.13.1",
-      "resolved": "https://registry.npmmirror.com/retry/-/retry-0.13.1.tgz",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
       "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
       "devOptional": true,
       "license": "MIT",
@@ -7857,7 +8540,7 @@
     },
     "node_modules/router": {
       "version": "2.2.0",
-      "resolved": "https://registry.npmmirror.com/router/-/router-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
       "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
       "devOptional": true,
       "license": "MIT",
@@ -7872,9 +8555,34 @@
         "node": ">= 18"
       }
     },
+    "node_modules/router/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/router/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "devOptional": true,
+      "license": "MIT"
+    },
     "node_modules/run-applescript": {
       "version": "7.1.0",
-      "resolved": "https://registry.npmmirror.com/run-applescript/-/run-applescript-7.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
       "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
       "devOptional": true,
       "license": "MIT",
@@ -7887,7 +8595,7 @@
     },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
-      "resolved": "https://registry.npmmirror.com/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
       "devOptional": true,
       "funding": [
@@ -7908,22 +8616,14 @@
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
-      "resolved": "https://registry.npmmirror.com/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "devOptional": true,
       "license": "MIT"
     },
-    "node_modules/scheduler": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmmirror.com/scheduler/-/scheduler-0.27.0.tgz",
-      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
-      "devOptional": true,
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/semver": {
       "version": "7.8.5",
-      "resolved": "https://registry.npmmirror.com/semver/-/semver-7.8.5.tgz",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
       "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "devOptional": true,
       "license": "ISC",
@@ -7936,7 +8636,7 @@
     },
     "node_modules/send": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmmirror.com/send/-/send-1.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
       "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
       "devOptional": true,
       "license": "MIT",
@@ -7961,9 +8661,34 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/send/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/send/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "devOptional": true,
+      "license": "MIT"
+    },
     "node_modules/serve-static": {
       "version": "2.2.1",
-      "resolved": "https://registry.npmmirror.com/serve-static/-/serve-static-2.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
       "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
       "devOptional": true,
       "license": "MIT",
@@ -7983,15 +8708,15 @@
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmmirror.com/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "devOptional": true,
       "license": "ISC"
     },
     "node_modules/sharp": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmmirror.com/sharp/-/sharp-0.35.3.tgz",
-      "integrity": "sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.4.tgz",
+      "integrity": "sha512-n++8XWcj+jCOr2IOl7h8LbKnGBDY4aPbmprMONBNFdn0ImXqpGVv5zliDs0V9HbmbCQLpbuo2ej9rAoOQTvMDA==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -8006,31 +8731,31 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-darwin-arm64": "0.35.3",
-        "@img/sharp-darwin-x64": "0.35.3",
-        "@img/sharp-freebsd-wasm32": "0.35.3",
-        "@img/sharp-libvips-darwin-arm64": "1.3.2",
-        "@img/sharp-libvips-darwin-x64": "1.3.2",
-        "@img/sharp-libvips-linux-arm": "1.3.2",
-        "@img/sharp-libvips-linux-arm64": "1.3.2",
-        "@img/sharp-libvips-linux-ppc64": "1.3.2",
-        "@img/sharp-libvips-linux-riscv64": "1.3.2",
-        "@img/sharp-libvips-linux-s390x": "1.3.2",
-        "@img/sharp-libvips-linux-x64": "1.3.2",
-        "@img/sharp-libvips-linuxmusl-arm64": "1.3.2",
-        "@img/sharp-libvips-linuxmusl-x64": "1.3.2",
-        "@img/sharp-linux-arm": "0.35.3",
-        "@img/sharp-linux-arm64": "0.35.3",
-        "@img/sharp-linux-ppc64": "0.35.3",
-        "@img/sharp-linux-riscv64": "0.35.3",
-        "@img/sharp-linux-s390x": "0.35.3",
-        "@img/sharp-linux-x64": "0.35.3",
-        "@img/sharp-linuxmusl-arm64": "0.35.3",
-        "@img/sharp-linuxmusl-x64": "0.35.3",
-        "@img/sharp-webcontainers-wasm32": "0.35.3",
-        "@img/sharp-win32-arm64": "0.35.3",
-        "@img/sharp-win32-ia32": "0.35.3",
-        "@img/sharp-win32-x64": "0.35.3"
+        "@img/sharp-darwin-arm64": "0.35.4",
+        "@img/sharp-darwin-x64": "0.35.4",
+        "@img/sharp-freebsd-wasm32": "0.35.4",
+        "@img/sharp-libvips-darwin-arm64": "1.3.3",
+        "@img/sharp-libvips-darwin-x64": "1.3.3",
+        "@img/sharp-libvips-linux-arm": "1.3.3",
+        "@img/sharp-libvips-linux-arm64": "1.3.3",
+        "@img/sharp-libvips-linux-ppc64": "1.3.3",
+        "@img/sharp-libvips-linux-riscv64": "1.3.3",
+        "@img/sharp-libvips-linux-s390x": "1.3.3",
+        "@img/sharp-libvips-linux-x64": "1.3.3",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.3",
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.3",
+        "@img/sharp-linux-arm": "0.35.4",
+        "@img/sharp-linux-arm64": "0.35.4",
+        "@img/sharp-linux-ppc64": "0.35.4",
+        "@img/sharp-linux-riscv64": "0.35.4",
+        "@img/sharp-linux-s390x": "0.35.4",
+        "@img/sharp-linux-x64": "0.35.4",
+        "@img/sharp-linuxmusl-arm64": "0.35.4",
+        "@img/sharp-linuxmusl-x64": "0.35.4",
+        "@img/sharp-webcontainers-wasm32": "0.35.4",
+        "@img/sharp-win32-arm64": "0.35.4",
+        "@img/sharp-win32-ia32": "0.35.4",
+        "@img/sharp-win32-x64": "0.35.4"
       },
       "peerDependenciesMeta": {
         "@types/node": {
@@ -8061,7 +8786,7 @@
     },
     "node_modules/side-channel": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmmirror.com/side-channel/-/side-channel-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
       "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "devOptional": true,
       "license": "MIT",
@@ -8081,7 +8806,7 @@
     },
     "node_modules/side-channel-list": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmmirror.com/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
       "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "devOptional": true,
       "license": "MIT",
@@ -8098,7 +8823,7 @@
     },
     "node_modules/side-channel-map": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmmirror.com/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
       "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
       "devOptional": true,
       "license": "MIT",
@@ -8117,7 +8842,7 @@
     },
     "node_modules/side-channel-weakmap": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmmirror.com/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
       "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
       "devOptional": true,
       "license": "MIT",
@@ -8135,9 +8860,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/standardwebhooks": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.1.1.tgz",
+      "integrity": "sha512-bCbX9ZEyFkWPsRz7Bl3NuQUJohmwGSev/yhr7vhaGPlc4AfIrspIRa6cPTBuI1ItmrTDJ4d/S2hCsfe4+vQGnQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmmirror.com/statuses/-/statuses-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
       "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
       "devOptional": true,
       "license": "MIT",
@@ -8163,7 +8899,7 @@
     },
     "node_modules/toidentifier": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmmirror.com/toidentifier/-/toidentifier-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
       "devOptional": true,
       "license": "MIT",
@@ -8173,21 +8909,21 @@
     },
     "node_modules/ts-algebra": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmmirror.com/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
       "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
       "devOptional": true,
       "license": "MIT"
     },
     "node_modules/tslib": {
       "version": "2.8.1",
-      "resolved": "https://registry.npmmirror.com/tslib/-/tslib-2.8.1.tgz",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "devOptional": true,
       "license": "0BSD"
     },
     "node_modules/turndown": {
       "version": "7.2.4",
-      "resolved": "https://registry.npmmirror.com/turndown/-/turndown-7.2.4.tgz",
+      "resolved": "https://registry.npmjs.org/turndown/-/turndown-7.2.4.tgz",
       "integrity": "sha512-I8yFsfRzmzK0WV1pNNOA4A7y4RDfFxPRxb3t+e3ui14qSGOxGtiSP6GjeX+Y6CHb7HYaFj7ECUD7VE5kQMZWGQ==",
       "devOptional": true,
       "license": "MIT",
@@ -8201,7 +8937,7 @@
     },
     "node_modules/type-is": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmmirror.com/type-is/-/type-is-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
       "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
       "devOptional": true,
       "license": "MIT",
@@ -8220,7 +8956,7 @@
     },
     "node_modules/type-is/node_modules/content-type": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmmirror.com/content-type/-/content-type-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
       "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
       "devOptional": true,
       "license": "MIT",
@@ -8233,22 +8969,32 @@
       }
     },
     "node_modules/typebox": {
-      "version": "1.1.38",
-      "resolved": "https://registry.npmmirror.com/typebox/-/typebox-1.1.38.tgz",
-      "integrity": "sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA==",
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.3.7.tgz",
+      "integrity": "sha512-meKuifc33Pccx0O6PdIzYMq3Og8zvP4TIi/a+Bw3AEMZMxOD0+RHGQvpglEe6Zdy3wZ8nqn/j95h8LUZLk/6Hg==",
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/undici": {
+      "version": "8.10.2",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.2.tgz",
+      "integrity": "sha512-/y4/bH9YNU5hi9NIrpOuvGXFcxrj3CMrV+/AYpowAYTpHn8gX/XPFjNy766FPoYY0miQhdW977JFWKGNhBdwyQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
     "node_modules/undici-types": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmmirror.com/undici-types/-/undici-types-8.3.0.tgz",
-      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unpipe": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmmirror.com/unpipe/-/unpipe-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
       "devOptional": true,
       "license": "MIT",
@@ -8256,19 +9002,9 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/use-sync-external-store": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmmirror.com/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
-      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
-      "devOptional": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
-      }
-    },
     "node_modules/vary": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmmirror.com/vary/-/vary-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
       "devOptional": true,
       "license": "MIT",
@@ -8278,7 +9014,7 @@
     },
     "node_modules/web-streams-polyfill": {
       "version": "3.3.3",
-      "resolved": "https://registry.npmmirror.com/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
       "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
       "devOptional": true,
       "license": "MIT",
@@ -8303,14 +9039,14 @@
     },
     "node_modules/wrappy": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmmirror.com/wrappy/-/wrappy-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "devOptional": true,
       "license": "ISC"
     },
     "node_modules/ws": {
       "version": "8.21.3",
-      "resolved": "https://registry.npmmirror.com/ws/-/ws-8.21.3.tgz",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
       "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
       "devOptional": true,
       "license": "MIT",
@@ -8332,7 +9068,7 @@
     },
     "node_modules/wsl-utils": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmmirror.com/wsl-utils/-/wsl-utils-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-1.0.0.tgz",
       "integrity": "sha512-Hl0ZOAs672vg+06kfujwRhoS6/jehvULrlFkuF2dRu6pHgA8U06h3xqNIqNNU1LTXPcedxByAR4GS6pwQK0mgA==",
       "devOptional": true,
       "license": "MIT",
@@ -8349,7 +9085,7 @@
     },
     "node_modules/wsl-utils/node_modules/powershell-utils": {
       "version": "0.1.0",
-      "resolved": "https://registry.npmmirror.com/powershell-utils/-/powershell-utils-0.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.1.0.tgz",
       "integrity": "sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==",
       "devOptional": true,
       "license": "MIT",
@@ -8371,7 +9107,7 @@
     },
     "node_modules/yaml": {
       "version": "2.9.0",
-      "resolved": "https://registry.npmmirror.com/yaml/-/yaml-2.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
       "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
       "devOptional": true,
       "license": "ISC",
@@ -8396,41 +9132,12 @@
     },
     "node_modules/zod-to-json-schema": {
       "version": "3.25.2",
-      "resolved": "https://registry.npmmirror.com/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
       "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
       "devOptional": true,
       "license": "ISC",
       "peerDependencies": {
         "zod": "^3.25.28 || ^4"
-      }
-    },
-    "node_modules/zustand": {
-      "version": "4.4.7",
-      "resolved": "https://registry.npmmirror.com/zustand/-/zustand-4.4.7.tgz",
-      "integrity": "sha512-QFJWJMdlETcI69paJwhSMJz7PPWjVP8Sjhclxmxmxv/RYI7ZOvR5BHX+ktH0we9gTWQMxcne8q1OY8xxz604gw==",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "use-sync-external-store": "1.2.0"
-      },
-      "engines": {
-        "node": ">=12.7.0"
-      },
-      "peerDependencies": {
-        "@types/react": ">=16.8",
-        "immer": ">=9.0",
-        "react": ">=16.8"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "immer": {
-          "optional": true
-        },
-        "react": {
-          "optional": true
-        }
       }
     }
   }

--- a/npm/package-lock.json
+++ b/npm/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@openma/deepseek-harness-tui",
-  "version": "0.2.37",
+  "version": "0.2.38",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openma/deepseek-harness-tui",
-      "version": "0.2.37",
+      "version": "0.2.38",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/cordis": "^4.0.1",

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openma/deepseek-harness-tui",
-  "version": "0.2.37",
+  "version": "0.2.38",
   "description": "Terminal-native ACP client UI; Cordis client tree, any ACP agent",
   "license": "MIT",
   "repository": {

--- a/npm/package.json
+++ b/npm/package.json
@@ -76,12 +76,12 @@
   },
   "dependencies": {
     "@deepseek-ai/cordis": "^4.0.1",
-    "@openma/deepseek-harness-acp": "0.4.29",
+    "@openma/deepseek-harness-acp": "0.4.31",
     "cross-spawn": "^7.0.6",
     "node-downloader-helper": "2.1.11"
   },
   "devDependencies": {
-    "@deepseek-ai/dsh": "0.1.1-rc.2"
+    "@deepseek-ai/dsh": "0.1.5-rc.1"
   },
   "engines": {
     "node": ">=18"


### PR DESCRIPTION
Align the TUI's runtime ACP adapter and development baseline with the DSH 0.1.5 generation.

## Commits

- `c25bab1` chore(deps): align ACP adapter and dsh baseline with DSH 0.1.5-rc.1
  - runtime `@openma/deepseek-harness-acp`: `0.4.29` → `0.4.31` (bundles DSH 0.1.5-rc.1 with session write ownership; keeps ACP events and question routing in Web hosts)
  - dev/CI `@deepseek-ai/dsh`: `0.1.1-rc.2` → `0.1.5-rc.1`; because 0.1.5-rc.1 depends on `^0.1.5-rc.1` subpackages, all 231 `@deepseek-ai/dsh-*` lock entries move to the same generation
  - `CHANGELOG.md` entry under `[Unreleased]`
- `b0e4e76` release: v0.2.38 (prepared with `scripts/release.mjs`; `Cargo.toml`, `Cargo.lock`, `npm/package.json`, `npm/package-lock.json`)

## Verification

- `npm ci --dry-run` — lockfile consistent
- `npm test --prefix npm` — 439 pass, 0 fail (3 skipped)
- `npm run test:profile-install-matrix --prefix npm` — 6/6 pass against acp 0.4.31
- host specifiers used by the TUI still resolve against dsh 0.1.5-rc.1 (`dsh-session`, `dsh-tool-subagent/model-selection-settings`, `dsh-scope`, `dsh-tools`, `dsh-agent-presets`)
- `node scripts/check-release-tag.mjs v0.2.38 npm/package.json Cargo.toml` — OK
- `cargo metadata --locked` — OK

## Release note

Tag `v0.2.38` already exists on the fork pointing at `b0e4e76`. Merge this with a **merge commit** (not squash) so the tag stays reachable on `main`, then push the tag to this repository — that tag push is what runs the `publish` job and publishes `martty@0.2.38` to npm.
